### PR TITLE
fix: migrationに失敗するので、作成前にDROP TABLE命令を入れるようにした

### DIFF
--- a/infra/mysql/schema/2022061801-messengers-create-notifications.sql
+++ b/infra/mysql/schema/2022061801-messengers-create-notifications.sql
@@ -1,5 +1,7 @@
 CREATE SCHEMA IF NOT EXISTS `messengers` DEFAULT CHARACTER SET utf8mb4;
 
+DROP TABLE IF EXISTS `messengers`.`notifications`;
+
 CREATE TABLE `messengers`.`notifications` (
   `id`           VARCHAR(22)  NOT NULL,          -- お知らせID (Primary Key用)
   `created_by`   VARCHAR(22)  NOT NULL,          -- 登録者ID

--- a/infra/mysql/schema/2022061801-messengers-create-notifications.sql
+++ b/infra/mysql/schema/2022061801-messengers-create-notifications.sql
@@ -1,8 +1,6 @@
 CREATE SCHEMA IF NOT EXISTS `messengers` DEFAULT CHARACTER SET utf8mb4;
 
-DROP TABLE IF EXISTS `messengers`.`notifications`;
-
-CREATE TABLE `messengers`.`notifications` (
+CREATE TABLE IF NOT EXIST `messengers`.`notifications` (
   `id`           VARCHAR(22)  NOT NULL,          -- お知らせID (Primary Key用)
   `created_by`   VARCHAR(22)  NOT NULL,          -- 登録者ID
   `creator_name` VARCHAR(32)  NOT NULL,          -- 登録者名


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

-  migrationに失敗するので、作成前にDROP TABLE命令を入れるようにした

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
