### PR TITLE
fix: docker-composeをdocker composeコマンドに変更

### DIFF
--- a/.github/workflows/ci-backend-for-all.yaml
+++ b/.github/workflows/ci-backend-for-all.yaml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Start MySQL container
       working-directory: .
-      run: docker compose -f docker-compose.ci.yaml up --build --detach mysql
+      run: docker compose --file=docker-compose.ci.yaml up --build --detach mysql
 
     - name: Wait start MySQL
       run: |

--- a/.github/workflows/ci-backend-for-all.yaml
+++ b/.github/workflows/ci-backend-for-all.yaml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Start MySQL container
       working-directory: .
-      run: docker compose --file=docker-compose.ci.yaml up --build --detach mysql
+      run: docker-compose --file=docker-compose.ci.yaml up --build --detach mysql
 
     - name: Wait start MySQL
       run: |

--- a/.github/workflows/ci-backend-for-all.yaml
+++ b/.github/workflows/ci-backend-for-all.yaml
@@ -130,21 +130,21 @@ jobs:
       working-directory: .
       run: docker compose --file=docker-compose.ci.yaml up --build --detach mysql
 
-    # - name: Wait start MySQL
-    #   run: |
-    #     #!/bin/bash
-    #     retry=60
-    #     count=1
-    #     until mysqladmin ping -h${DB_HOST} -P${DB_PORT} -u${DB_USERNAME} -p${DB_PASSWORD}; do
-    #       echo 'mysql is unavailable - sleeping'
-    #       sleep 3
-    #       if [ $(expr $retry - $count) -le 0 ]; then
-    #         echo 'mysql is unavailable - throw error for timeout'
-    #         exit 1
-    #       fi
-    #       count=$(expr $count + 1)
-    #     done
-    #     echo 'mysql is up - executing command'
+    - name: Wait start MySQL
+      run: |
+        #!/bin/bash
+        retry=60
+        count=1
+        until mysqladmin ping -h${DB_HOST} -P${DB_PORT} -u${DB_USERNAME} -p${DB_PASSWORD}; do
+          echo 'mysql is unavailable - sleeping'
+          sleep 3
+          if [ $(expr $retry - $count) -le 0 ]; then
+            echo 'mysql is unavailable - throw error for timeout'
+            exit 1
+          fi
+          count=$(expr $count + 1)
+        done
+        echo 'mysql is up - executing command'
 
     - uses: actions/cache@v3
       id: modules-cache

--- a/.github/workflows/ci-backend-for-all.yaml
+++ b/.github/workflows/ci-backend-for-all.yaml
@@ -128,23 +128,23 @@ jobs:
 
     - name: Start MySQL container
       working-directory: .
-      run: docker-compose --file=docker-compose.ci.yaml up --build --detach mysql
+      run: docker compose --file=docker-compose.ci.yaml up --build --detach mysql
 
-    - name: Wait start MySQL
-      run: |
-        #!/bin/bash
-        retry=60
-        count=1
-        until mysqladmin ping -h${DB_HOST} -P${DB_PORT} -u${DB_USERNAME} -p${DB_PASSWORD}; do
-          echo 'mysql is unavailable - sleeping'
-          sleep 3
-          if [ $(expr $retry - $count) -le 0 ]; then
-            echo 'mysql is unavailable - throw error for timeout'
-            exit 1
-          fi
-          count=$(expr $count + 1)
-        done
-        echo 'mysql is up - executing command'
+    # - name: Wait start MySQL
+    #   run: |
+    #     #!/bin/bash
+    #     retry=60
+    #     count=1
+    #     until mysqladmin ping -h${DB_HOST} -P${DB_PORT} -u${DB_USERNAME} -p${DB_PASSWORD}; do
+    #       echo 'mysql is unavailable - sleeping'
+    #       sleep 3
+    #       if [ $(expr $retry - $count) -le 0 ]; then
+    #         echo 'mysql is unavailable - throw error for timeout'
+    #         exit 1
+    #       fi
+    #       count=$(expr $count + 1)
+    #     done
+    #     echo 'mysql is up - executing command'
 
     - uses: actions/cache@v3
       id: modules-cache

--- a/.github/workflows/ci-backend-for-all.yaml
+++ b/.github/workflows/ci-backend-for-all.yaml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Start MySQL container
       working-directory: .
-      run: docker-compose -f docker-compose.ci.yaml up --build --detach mysql
+      run: docker compose -f docker-compose.ci.yaml up --build --detach mysql
 
     - name: Wait start MySQL
       run: |

--- a/Makefile
+++ b/Makefile
@@ -9,28 +9,28 @@ setup: build install swagger
 	fi
 
 install: migrate
-	docker-compose run --rm swagger_generator yarn
-	docker-compose run --rm user_web yarn
-	docker-compose run --rm admin_web yarn
+	docker compose run --rm swagger_generator yarn
+	docker compose run --rm user_web yarn
+	docker compose run --rm admin_web yarn
 
 build:
-	docker-compose build --parallel
+	docker compose build --parallel
 
 start: migrate
-	docker-compose up --remove-orphans
+	docker compose up --remove-orphans
 
 stop:
-	docker-compose stop
+	docker compose stop
 
 down:
-	docker-compose down
+	docker compose down
 
 remove:
-	docker-compose down --rmi all --volumes --remove-orphans
+	docker compose down --rmi all --volumes --remove-orphans
 	rm -rf ./tmp/data ./tmp/logs
 
 logs:
-	docker-compose logs
+	docker compose logs
 
 ##################################################
 # Container Commands - Run Container Group
@@ -38,19 +38,19 @@ logs:
 .PHONY: start-user start-admin start-web start-api start-swagger
 
 start-user:
-	docker-compose up user_web user_gateway mysql
+	docker compose up user_web user_gateway mysql
 
 start-admin:
-	docker-compose up admin_web admin_gateway mysql
+	docker compose up admin_web admin_gateway mysql
 
 start-web:
-	docker-compose up user_web admin_web
+	docker compose up user_web admin_web
 
 start-api:
-	docker-compose up user_gateway admin_gateway mysql mysql_test
+	docker compose up user_gateway admin_gateway mysql mysql_test
 
 start-swagger:
-	docker-compose up swagger_generator swagger_user swagger_admin
+	docker compose up swagger_generator swagger_user swagger_admin
 
 ##################################################
 # Container Commands - Single
@@ -58,14 +58,14 @@ start-swagger:
 .PHONY: swagger migrate
 
 swagger:
-	docker-compose run --rm swagger_generator yarn generate
-	docker-compose run --rm user_web yarn lintfix
-	docker-compose run --rm admin_web yarn lintfix
+	docker compose run --rm swagger_generator yarn generate
+	docker compose run --rm user_web yarn lintfix
+	docker compose run --rm admin_web yarn lintfix
 
 migrate:
-	docker-compose up -d mysql mysql_test
-	docker-compose exec mysql bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql_test is ready!'"
-	docker-compose exec mysql_test bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql_test is ready!'"
-	docker-compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql -db-port=3306"
-	docker-compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql_test -db-port=3306"
-	docker-compose stop mysql mysql_test
+	docker compose up -d mysql mysql_test
+	docker compose exec mysql bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql_test is ready!'"
+	docker compose exec mysql_test bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql_test is ready!'"
+	docker compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql -db-port=3306"
+	docker compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql_test -db-port=3306"
+	docker compose stop mysql mysql_test


### PR DESCRIPTION
## やったこと

- Makefileのタスクの`docker-compose`を`docker compose`コマンドに変更

変更理由は`docker-compose`は非推奨となるため。
https://www.docker.com/blog/announcing-compose-v2-general-availability/

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
