### PR TITLE
ApiClientのfactoryを作って環境変数で柔軟にAPIの向き先を変える

### DIFF
--- a/web/admin/src/store/administrator.ts
+++ b/web/admin/src/store/administrator.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
 
+import { useAuthStore } from './auth'
+
+import { ApiClientFactory } from '.'
+
 import { AdministratorApi, AdministratorsResponse } from '~/types/api'
 
 export const useAdministratorStore = defineStore('administrator', {
@@ -9,7 +13,15 @@ export const useAdministratorStore = defineStore('administrator', {
   actions: {
     async fetchAdministrators(): Promise<void> {
       try {
-        const administratorApiClient = new AdministratorApi()
+        const authStore = useAuthStore()
+        const accessToken = authStore.accessToken
+        if (!accessToken) throw new Error('認証エラー')
+
+        const factory = new ApiClientFactory()
+        const administratorApiClient = factory.create(
+          AdministratorApi,
+          accessToken
+        )
         const res = await administratorApiClient.v1ListAdministrators()
         this.administrators = res.data.administrators
       } catch (error) {

--- a/web/admin/src/store/auth.ts
+++ b/web/admin/src/store/auth.ts
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 
+import { ApiClientFactory } from '.'
+
 import { AuthApi, AuthResponse, SignInRequest } from '~/types/api'
 
 export const useAuthStore = defineStore('auth', {
@@ -15,7 +17,8 @@ export const useAuthStore = defineStore('auth', {
   actions: {
     async signIn(payload: SignInRequest): Promise<void> {
       try {
-        const authApiClient = new AuthApi()
+        const factory = new ApiClientFactory()
+        const authApiClient = factory.create(AuthApi)
         const res = await authApiClient.v1SignIn(payload)
         this.isAuthenticated = true
         this.user = res.data

--- a/web/admin/src/store/index.ts
+++ b/web/admin/src/store/index.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '~/types/api'
+import { BaseAPI } from '~/types/api/base'
+
+const BASE_API = process.env.API_BASE_URL || 'http://localhost:18010'
+
+export class ApiClientFactory {
+  create<T extends BaseAPI>(
+    Client: new (config: Configuration) => T,
+    token?: string
+  ): T {
+    const config = new Configuration({ accessToken: token, basePath: BASE_API })
+    return new Client(config)
+  }
+}

--- a/web/admin/src/store/producer.ts
+++ b/web/admin/src/store/producer.ts
@@ -2,7 +2,9 @@ import { defineStore } from 'pinia'
 
 import { useAuthStore } from './auth'
 
-import { Configuration, ProducerApi, ProducersResponse } from '~/types/api'
+import { ApiClientFactory } from '.'
+
+import { ProducerApi, ProducersResponse } from '~/types/api'
 
 export const useProducerStore = defineStore('Producer', {
   state: () => ({
@@ -15,8 +17,8 @@ export const useProducerStore = defineStore('Producer', {
         const accessToken = authStore.accessToken
         if (!accessToken) throw new Error('認証エラー')
 
-        const config = new Configuration({ accessToken })
-        const producersApiClient = new ProducerApi(config)
+        const factory = new ApiClientFactory()
+        const producersApiClient = factory.create(ProducerApi, accessToken)
         const res = await producersApiClient.v1ListProducers()
         this.producers = res.data.producers
       } catch (error) {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- 自動生成されるAPIクライアントコードのAPIのベースパスの変更が難しい問題への対応
  - 自動生成されるAPIクライアントのコードを使い回せるようにAPIClientのfactoryクラスを作った。


## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
