### PR TITLE
feat: 生産者登録機能の改善

### DIFF
--- a/web/admin/nuxt.config.ts
+++ b/web/admin/nuxt.config.ts
@@ -29,7 +29,7 @@ const config: NuxtConfig = {
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
-  css: [],
+  css: ['~/assets/main.scss'],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [],

--- a/web/admin/src/assets/main.scss
+++ b/web/admin/src/assets/main.scss
@@ -1,3 +1,3 @@
 .v-data-table {
-	white-space: nowrap;
+  white-space: nowrap;
 }

--- a/web/admin/src/assets/main.scss
+++ b/web/admin/src/assets/main.scss
@@ -1,0 +1,3 @@
+.v-data-table {
+	white-space: nowrap;
+}

--- a/web/admin/src/components/molecules/TheHeaderSelectForm.vue
+++ b/web/admin/src/components/molecules/TheHeaderSelectForm.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <p>ヘッダー画像の設定</p>
+    <v-card
+      class="d-flex flex-column text-center align-center"
+      role="button"
+      min-width="180"
+      flat
+      :img="imgUrl"
+      @click="handleClick"
+    >
+      <v-card-text>
+        <v-icon>mdi-plus</v-icon>
+        <input
+          ref="inputRef"
+          type="file"
+          class="d-none"
+          accept="image/*"
+          @change="handleInputFileChange"
+        />
+        <p class="ma-0">ヘッダー画像を選択</p>
+      </v-card-text>
+    </v-card>
+    <p v-show="error" class="red--text ma-0">{{ message }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api'
+
+export default defineComponent({
+  props: {
+    imgUrl: {
+      type: String,
+      default: '',
+    },
+    error: {
+      type: Boolean,
+      default: false,
+    },
+    message: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(_, { emit }) {
+    const inputRef = ref<HTMLInputElement | null>(null)
+    const handleClick = () => {
+      if (inputRef.value !== null) {
+        inputRef.value.click()
+      }
+    }
+
+    const handleInputFileChange = () => {
+      if (inputRef.value && inputRef.value.files) {
+        emit('update:file', inputRef.value.files)
+      }
+    }
+
+    return {
+      inputRef,
+      handleClick,
+      handleInputFileChange,
+    }
+  },
+})
+</script>

--- a/web/admin/src/components/molecules/TheHeaderSelectForm.vue
+++ b/web/admin/src/components/molecules/TheHeaderSelectForm.vue
@@ -10,7 +10,9 @@
       @click="handleClick"
     >
       <v-card-text>
-        <v-icon>mdi-plus</v-icon>
+        <v-avatar size="96">
+          <v-icon x-large>mdi-plus</v-icon>
+        </v-avatar>
         <input
           ref="inputRef"
           type="file"

--- a/web/admin/src/components/molecules/TheProfileSelectForm.vue
+++ b/web/admin/src/components/molecules/TheProfileSelectForm.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <p>アイコン画像の設定</p>
+    <div class="text-center" role="button" @click="handleClick">
+      <v-icon v-if="imgUrl === ''" x-large>mdi-account</v-icon>
+      <v-img v-else :src="imgUrl" aspect-ratio="1" max-height="150" contain />
+      <input
+        ref="inputRef"
+        type="file"
+        class="d-none"
+        accept="image/*"
+        @change="handleInputFileChange"
+      />
+      <p>アイコン画像を選択</p>
+    </div>
+    <p v-show="error" class="red--text ma-0">{{ message }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api'
+
+export default defineComponent({
+  props: {
+    imgUrl: {
+      type: String,
+      default: '',
+    },
+    error: {
+      type: Boolean,
+      default: false,
+    },
+    message: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(_, { emit }) {
+    const inputRef = ref<HTMLInputElement | null>(null)
+    const handleClick = () => {
+      if (inputRef.value !== null) {
+        inputRef.value.click()
+      }
+    }
+
+    const handleInputFileChange = () => {
+      if (inputRef.value && inputRef.value.files) {
+        emit('update:file', inputRef.value.files)
+      }
+    }
+
+    return {
+      inputRef,
+      handleClick,
+      handleInputFileChange,
+    }
+  },
+})
+</script>

--- a/web/admin/src/components/molecules/TheProfileSelectForm.vue
+++ b/web/admin/src/components/molecules/TheProfileSelectForm.vue
@@ -1,18 +1,28 @@
 <template>
   <div>
     <p>アイコン画像の設定</p>
-    <div class="text-center" role="button" @click="handleClick">
-      <v-icon v-if="imgUrl === ''" x-large>mdi-account</v-icon>
-      <v-img v-else :src="imgUrl" aspect-ratio="1" max-height="150" contain />
-      <input
-        ref="inputRef"
-        type="file"
-        class="d-none"
-        accept="image/*"
-        @change="handleInputFileChange"
-      />
-      <p>アイコン画像を選択</p>
-    </div>
+    <v-card class="text-center" role="button" flat @click="handleClick">
+      <v-card-text>
+        <v-avatar size="96">
+          <v-icon v-if="imgUrl === ''" x-large>mdi-account</v-icon>
+          <v-img
+            v-else
+            :src="imgUrl"
+            aspect-ratio="1"
+            max-height="150"
+            contain
+          />
+        </v-avatar>
+        <input
+          ref="inputRef"
+          type="file"
+          class="d-none"
+          accept="image/*"
+          @change="handleInputFileChange"
+        />
+        <p class="ma-0">アイコン画像を選択</p>
+      </v-card-text>
+    </v-card>
     <p v-show="error" class="red--text ma-0">{{ message }}</p>
   </div>
 </template>

--- a/web/admin/src/store/producer.ts
+++ b/web/admin/src/store/producer.ts
@@ -8,6 +8,7 @@ import {
   CreateProducerRequest,
   ProducerApi,
   ProducersResponse,
+  UploadImageResponse,
 } from '~/types/api'
 
 export const useProducerStore = defineStore('Producer', {
@@ -46,6 +47,57 @@ export const useProducerStore = defineStore('Producer', {
       } catch (error) {
         // TODO: エラーハンドリング
         console.log(error)
+        throw new Error('Internal Server Error')
+      }
+    },
+
+    /**
+     * 生産者のサムネイル画像をアップロードする関数
+     * @param payload サムネイル画像のファイルオブジェクト
+     * @returns アップロード後のサムネイル画像のパスを含んだオブジェクト
+     */
+    async uploadProducerThumbnail(payload: File): Promise<UploadImageResponse> {
+      try {
+        const authStore = useAuthStore()
+        const accessToken = authStore.accessToken
+        if (!accessToken) throw new Error('認証エラー')
+
+        const factory = new ApiClientFactory()
+        const producersApiClient = factory.create(ProducerApi, accessToken)
+        const res = await producersApiClient.v1UploadProducerThumbnail(
+          payload,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          }
+        )
+        return res.data
+      } catch (error) {
+        throw new Error('Internal Server Error')
+      }
+    },
+
+    /**
+     * 生産者のヘッダー画像をアップロードする関数
+     * @param payload ヘッダー画像のファイルオブジェクト
+     * @returns アップロード後のヘッダー画像のパスを含んだオブジェクト
+     */
+    async uploadProducerHeader(payload: File): Promise<UploadImageResponse> {
+      try {
+        const authStore = useAuthStore()
+        const accessToken = authStore.accessToken
+        if (!accessToken) throw new Error('認証エラー')
+
+        const factory = new ApiClientFactory()
+        const producersApiClient = factory.create(ProducerApi, accessToken)
+        const res = await producersApiClient.v1UploadProducerHeader(payload, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        })
+        return res.data
+      } catch (error) {
         throw new Error('Internal Server Error')
       }
     },


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

- 生産者登録でアイコン画像とヘッダー画像がアップロードできるようにした



## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

![localhost_3010_](https://user-images.githubusercontent.com/27722351/178278705-950c6a52-65c8-4433-a19c-aca1de7b2e20.png)


## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

- 住所をAPIを使って入力補完する
- 生産者登録後のユーザーフィードバックの実装

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
