### PR TITLE
fix: refreshTokenで認証情報を取ったあとはcookieを再セットしない

### DIFF
--- a/web/admin/src/store/auth.ts
+++ b/web/admin/src/store/auth.ts
@@ -58,9 +58,7 @@ export const useAuthStore = defineStore('auth', {
         })
         this.isAuthenticated = true
         this.user = res.data
-
-        const cookies = new Cookies()
-        cookies.set('refreshToken', this.user.refreshToken)
+        this.user.refreshToken = refreshToken
       } catch (error) {
         const cookies = new Cookies()
         cookies.remove('refreshToken')


### PR DESCRIPTION
## やったこと

- リフレッシュトークンで取得した認証情報にはリフレッシュトークンが含まれておらず、ミドルウェアのCookieの部分で空文字がセットされていたので修正した。

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
