### PR TITLE
feat(messenger): add email template for received contact

### DIFF
--- a/api/config/messenger/mailer/dev.yaml
+++ b/api/config/messenger/mailer/dev.yaml
@@ -1,1 +1,2 @@
-register-admin: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
+admin-register: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
+user-received-contact: 'd-b91d425a9c3b4172b27d32d4873e47b5'

--- a/api/config/messenger/mailer/stg.yaml
+++ b/api/config/messenger/mailer/stg.yaml
@@ -1,1 +1,2 @@
-register-admin: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
+admin-register: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
+user-received-contact: 'd-b91d425a9c3b4172b27d32d4873e47b5'

--- a/api/internal/messenger/entity/mail.go
+++ b/api/internal/messenger/entity/mail.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	EmailIDRegisterAdmin = "register-admin"
+	EmailIDAdminRegister       = "admin-register"        // 管理者登録
+	EmailIDUserReceivedContact = "user-received-contact" // お問い合わせ受領
 )
 
 // MailConfig - メール送信設定
@@ -47,6 +48,11 @@ func (b *TemplateDataBuilder) Name(name string) *TemplateDataBuilder {
 	return b
 }
 
+func (b *TemplateDataBuilder) Email(email string) *TemplateDataBuilder {
+	b.data["メールアドレス"] = email
+	return b
+}
+
 func (b *TemplateDataBuilder) Password(password string) *TemplateDataBuilder {
 	b.data["パスワード"] = password
 	return b
@@ -54,5 +60,11 @@ func (b *TemplateDataBuilder) Password(password string) *TemplateDataBuilder {
 
 func (b *TemplateDataBuilder) WebURL(url string) *TemplateDataBuilder {
 	b.data["サイトURL"] = url
+	return b
+}
+
+func (b *TemplateDataBuilder) Contact(title, body string) *TemplateDataBuilder {
+	b.data["件名"] = title
+	b.data["本文"] = body
 	return b
 }

--- a/api/internal/messenger/entity/mail_test.go
+++ b/api/internal/messenger/entity/mail_test.go
@@ -12,10 +12,17 @@ func TestTemplateBuilder(t *testing.T) {
 		Data(map[string]string{"key": "value"}).
 		YearMonth(jst.Date(2022, 1, 2, 18, 30, 0, 0)).
 		Name("中村 広大").
-		WebURL("http://example.com")
+		Email("test-user@and-period.jp").
+		Password("!Qaz2wsx").
+		WebURL("http://example.com").
+		Contact("件名", "本文")
 	data := builder.Build()
 	assert.Equal(t, "value", data["key"])
 	assert.Equal(t, "2022年01月", data["年月"])
 	assert.Equal(t, "中村 広大", data["氏名"])
+	assert.Equal(t, "test-user@and-period.jp", data["メールアドレス"])
+	assert.Equal(t, "!Qaz2wsx", data["パスワード"])
 	assert.Equal(t, "http://example.com", data["サイトURL"])
+	assert.Equal(t, "件名", data["件名"])
+	assert.Equal(t, "本文", data["本文"])
 }

--- a/api/internal/messenger/entity/payload.go
+++ b/api/internal/messenger/entity/payload.go
@@ -18,6 +18,7 @@ const (
 	UserTypeAdministrator UserType = 3 // システム管理者
 	UserTypeCoordinator   UserType = 4 // 仲介者
 	UserTypeProducer      UserType = 5 // 生産者
+	UserTypeGuest         UserType = 6 // 未登録ユーザー
 )
 
 type WorkerPayload struct {
@@ -25,5 +26,11 @@ type WorkerPayload struct {
 	EventType EventType   `json:"eventType"`       // Worker実行種別
 	UserType  UserType    `json:"userType"`        // 送信先ユーザー種別
 	UserIDs   []string    `json:"userIds"`         // 送信先ユーザー一覧
+	Guest     *Guest      `json:"guest,omitempty"` // 未登録ユーザー情報
 	Email     *MailConfig `json:"email,omitempty"` // メール送信設定
+}
+
+type Guest struct {
+	Name  string `json:"name"`  // 氏名
+	Email string `json:"email"` // メールアドレス
 }

--- a/api/internal/messenger/entity/received_queue_test.go
+++ b/api/internal/messenger/entity/received_queue_test.go
@@ -23,7 +23,7 @@ func TestReceivedQueue(t *testing.T) {
 				UserType:  UserTypeAdmin,
 				UserIDs:   []string{"admin-id"},
 				Email: &MailConfig{
-					EmailID:       EmailIDRegisterAdmin,
+					EmailID:       EmailIDAdminRegister,
 					Substitutions: map[string]string{"パスワード": "!Qaz2wsx"},
 				},
 			},

--- a/api/internal/messenger/service/notify.go
+++ b/api/internal/messenger/service/notify.go
@@ -19,7 +19,7 @@ func (s *service) NotifyRegisterAdmin(ctx context.Context, in *messenger.NotifyR
 		WebURL(maker.SignIn()).
 		Password(in.Password)
 	mail := &entity.MailConfig{
-		EmailID:       entity.EmailIDRegisterAdmin,
+		EmailID:       entity.EmailIDAdminRegister,
 		Substitutions: builder.Build(),
 	}
 	payload := &entity.WorkerPayload{

--- a/api/internal/messenger/service/notify_test.go
+++ b/api/internal/messenger/service/notify_test.go
@@ -50,7 +50,7 @@ func TestNotifyRegisterAdmin(t *testing.T) {
 							UserType:  entity.UserTypeAdmin,
 							UserIDs:   []string{"admin-id"},
 							Email: &entity.MailConfig{
-								EmailID: entity.EmailIDRegisterAdmin,
+								EmailID: entity.EmailIDAdminRegister,
 								Substitutions: map[string]string{
 									"サイトURL": "htts://admin.and-period.jp/signin",
 									"パスワード":  "!Qaz2wsx",

--- a/api/internal/messenger/worker/mailer.go
+++ b/api/internal/messenger/worker/mailer.go
@@ -67,6 +67,8 @@ func (w *worker) newPersonalizations(
 		err = w.fetchProducers(ctx, payload.UserIDs, execute)
 	case entity.UserTypeUser:
 		err = w.fetchUsers(ctx, payload.UserIDs, execute)
+	case entity.UserTypeGuest:
+		err = w.fetchGuest(ctx, payload.Guest, execute)
 	default:
 		err = fmt.Errorf("worker: failed to multi send mail: %w", errUnknownUserType)
 	}
@@ -147,5 +149,13 @@ func (w *worker) fetchUsers(ctx context.Context, userIDs []string, execute func(
 	for i := range users {
 		execute(users[i].Name(), users[i].Email)
 	}
+	return nil
+}
+
+func (w *worker) fetchGuest(ctx context.Context, guest *entity.Guest, execute func(name, email string)) error {
+	if guest == nil {
+		return errGuestRequired
+	}
+	execute(guest.Name, guest.Email)
 	return nil
 }

--- a/api/internal/messenger/worker/worker.go
+++ b/api/internal/messenger/worker/worker.go
@@ -19,7 +19,10 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-var errUnknownUserType = errors.New("worker: unknown user type")
+var (
+	errUnknownUserType = errors.New("worker: unknown user type")
+	errGuestRequired   = errors.New("worker: guest is required")
+)
 
 type Worker interface {
 	Lambda(ctx context.Context, event events.SQSEvent) error

--- a/api/internal/messenger/worker/worker_test.go
+++ b/api/internal/messenger/worker/worker_test.go
@@ -154,7 +154,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				mocks.db.ReceivedQueue.EXPECT().Get(ctx, "queue-id").Return(queue, nil)
 				mocks.db.ReceivedQueue.EXPECT().UpdateDone(ctx, "queue-id", true).Return(nil)
 				mocks.user.EXPECT().MultiGetUsers(gomock.Any(), in).Return(users, nil)
-				mocks.mailer.EXPECT().MultiSendFromInfo(gomock.Any(), entity.EmailIDRegisterAdmin, personalizations).Return(nil)
+				mocks.mailer.EXPECT().MultiSendFromInfo(gomock.Any(), entity.EmailIDAdminRegister, personalizations).Return(nil)
 			},
 			payload: &entity.WorkerPayload{
 				QueueID:   "queue-id",
@@ -162,7 +162,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				UserType:  entity.UserTypeUser,
 				UserIDs:   []string{"user-id"},
 				Email: &entity.MailConfig{
-					EmailID:       entity.EmailIDRegisterAdmin,
+					EmailID:       entity.EmailIDAdminRegister,
 					Substitutions: map[string]string{"key": "value"},
 				},
 			},
@@ -180,7 +180,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				UserType:  entity.UserTypeUser,
 				UserIDs:   []string{"user-id"},
 				Email: &entity.MailConfig{
-					EmailID:       entity.EmailIDRegisterAdmin,
+					EmailID:       entity.EmailIDAdminRegister,
 					Substitutions: map[string]string{"key": "value"},
 				},
 			},
@@ -212,7 +212,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				UserType:  entity.UserTypeUser,
 				UserIDs:   []string{"user-id"},
 				Email: &entity.MailConfig{
-					EmailID:       entity.EmailIDRegisterAdmin,
+					EmailID:       entity.EmailIDAdminRegister,
 					Substitutions: map[string]string{"key": "value"},
 				},
 			},
@@ -230,7 +230,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				UserType:  entity.UserTypeUser,
 				UserIDs:   []string{"user-id"},
 				Email: &entity.MailConfig{
-					EmailID:       entity.EmailIDRegisterAdmin,
+					EmailID:       entity.EmailIDAdminRegister,
 					Substitutions: map[string]string{"key": "value"},
 				},
 			},
@@ -242,7 +242,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				mocks.db.ReceivedQueue.EXPECT().Get(ctx, "queue-id").Return(queue, nil)
 				mocks.db.ReceivedQueue.EXPECT().UpdateDone(ctx, "queue-id", true).Return(errmock)
 				mocks.user.EXPECT().MultiGetUsers(gomock.Any(), in).Return(users, nil)
-				mocks.mailer.EXPECT().MultiSendFromInfo(gomock.Any(), entity.EmailIDRegisterAdmin, personalizations).Return(nil)
+				mocks.mailer.EXPECT().MultiSendFromInfo(gomock.Any(), entity.EmailIDAdminRegister, personalizations).Return(nil)
 			},
 			payload: &entity.WorkerPayload{
 				QueueID:   "queue-id",
@@ -250,7 +250,7 @@ func TestWorker_Dispatch(t *testing.T) {
 				UserType:  entity.UserTypeUser,
 				UserIDs:   []string{"user-id"},
 				Email: &entity.MailConfig{
-					EmailID:       entity.EmailIDRegisterAdmin,
+					EmailID:       entity.EmailIDAdminRegister,
 					Substitutions: map[string]string{"key": "value"},
 				},
 			},


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
お問い合わせ受領通知用のメールテンプレート設定を追加しました。

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
