### PR TITLE
fix(user): add error handling for update admin email

### DIFF
--- a/api/internal/user/service/admin_auth.go
+++ b/api/internal/user/service/admin_auth.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/and-period/furumaru/api/internal/exception"
 	"github.com/and-period/furumaru/api/internal/user"
@@ -67,6 +68,9 @@ func (s *service) UpdateAdminEmail(ctx context.Context, in *user.UpdateAdminEmai
 	admin, err := s.getAdmin(ctx, auth.AdminID, auth.Role)
 	if err != nil {
 		return exception.InternalError(err)
+	}
+	if admin.Email == in.Email {
+		return fmt.Errorf("this admin does not need to be changed email: %w", exception.ErrFailedPrecondition)
 	}
 	params := &cognito.ChangeEmailParams{
 		AccessToken: in.AccessToken,

--- a/api/internal/user/service/admin_auth_test.go
+++ b/api/internal/user/service/admin_auth_test.go
@@ -495,6 +495,19 @@ func TestUpdateAdminEmail(t *testing.T) {
 			expectErr: exception.ErrInvalidArgument,
 		},
 		{
+			name: "does not need to be changed",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.adminAuth.EXPECT().GetUsername(ctx, "access-token").Return("username", nil)
+				mocks.db.AdminAuth.EXPECT().GetByCognitoID(ctx, "username", "admin_id", "role").Return(auth, nil)
+				mocks.db.Administrator.EXPECT().Get(ctx, "admin-id").Return(administrator, nil)
+			},
+			input: &user.UpdateAdminEmailInput{
+				AccessToken: "access-token",
+				Email:       "test-admin@and-period.jp",
+			},
+			expectErr: exception.ErrFailedPrecondition,
+		},
+		{
 			name: "failed to change email",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.adminAuth.EXPECT().GetUsername(ctx, "access-token").Return("username", nil)

--- a/docs/swagger/admin/paths/v1/auth/email/index.yaml
+++ b/docs/swagger/admin/paths/v1/auth/email/index.yaml
@@ -29,3 +29,9 @@ patch:
         application/json:
           schema:
             $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'
+    412:
+      description: percondition failed error
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
管理者が自分のメールアドレスを変更するためのAPIについて、以下フロントエンドからの要望を満たすような修正を行いました。

* 変更後のメールアドレスが現在と同じ場合、4xx系エラーを返す -> 412(Precondition Failed)を割り当てています

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
