### PR TITLE
Feat/delete notification/database layer

### DIFF
--- a/api/internal/messenger/database/database.go
+++ b/api/internal/messenger/database/database.go
@@ -69,6 +69,7 @@ type Notification interface {
 	Count(ctx context.Context, params *ListNotificationsParams) (int64, error)
 	Get(ctx context.Context, notificationID string, fields ...string) (*entity.Notification, error)
 	Create(ctx context.Context, notification *entity.Notification) error
+	Delete(ctx context.Context, notificationID string) error
 }
 
 type PushTemplate interface {

--- a/api/internal/messenger/entity/notification.go
+++ b/api/internal/messenger/entity/notification.go
@@ -7,6 +7,7 @@ import (
 	set "github.com/and-period/furumaru/api/pkg/set/v2"
 	"github.com/and-period/furumaru/api/pkg/uuid"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 // 掲載対象
@@ -50,6 +51,7 @@ type Notification struct {
 	Public      bool           `gorm:""`                            // 公開フラグ
 	CreatedAt   time.Time      `gorm:"<-:create"`                   // 作成日時
 	UpdatedAt   time.Time      `gorm:""`                            // 更新日時
+	DeletedAt   gorm.DeletedAt `gorm:"default:null"`                // 削除日時
 }
 
 type Notifications []*Notification

--- a/api/mock/messenger/database/database.go
+++ b/api/mock/messenger/database/database.go
@@ -334,6 +334,20 @@ func (mr *MockNotificationMockRecorder) Create(ctx, notification interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockNotification)(nil).Create), ctx, notification)
 }
 
+// Delete mocks base method.
+func (m *MockNotification) Delete(ctx context.Context, notificationID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, notificationID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockNotificationMockRecorder) Delete(ctx, notificationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockNotification)(nil).Delete), ctx, notificationID)
+}
+
 // Get mocks base method.
 func (m *MockNotification) Get(ctx context.Context, notificationID string, fields ...string) (*entity.Notification, error) {
 	m.ctrl.T.Helper()

--- a/infra/mysql/schema/2022082501-messengers-add-column.sql
+++ b/infra/mysql/schema/2022082501-messengers-add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `messengers`.`notifications` ADD COLUMN `deleted_at` DATETIME NULL DEFAULT NULL AFTER `updated_at`;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- deleted_atカラムを追加するSQL作成
- notificationのentityにDeletedAtを追加
- DeleteNotificationのデータベース層の実装

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->
* [x] database
* [ ] service
* [ ] gateway

## 備考
SQL追加したので、`make migrate`は必要
<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
