### PR TITLE
管理者ページのフロントエンドバリデーションを追加

### DIFF
--- a/web/admin/src/lib/validations/index.ts
+++ b/web/admin/src/lib/validations/index.ts
@@ -1,0 +1,2 @@
+export * from './rule'
+export * from './message'

--- a/web/admin/src/lib/validations/message.ts
+++ b/web/admin/src/lib/validations/message.ts
@@ -1,0 +1,12 @@
+import { ErrorObject } from '@vuelidate/core'
+
+/**
+ * バリデーションオブジェクトから指定したキーのエラーメッセージを取得する関数
+ * @param errors ErrorObjectの配列
+ * @returns
+ */
+const getErrorMessage = (errors: ErrorObject[]): string => {
+  return errors.length > 0 ? errors[0].$message.toString() : ''
+}
+
+export { getErrorMessage }

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -6,6 +6,7 @@ import {
   email as _email,
   minLength as _minLength,
   maxLength as _maxLength,
+  minValue as _minValue,
 } from '@vuelidate/validators'
 
 /**
@@ -77,4 +78,24 @@ const maxLength = (max: number | Ref<number>) =>
     _maxLength(max)
   )
 
-export { kana, tel, required, email, postalCode, minLength, maxLength }
+/**
+ * 最小値のバリデーションルールをラップする関数
+ * @param min
+ * @returns
+ */
+const minValue = (min: string | number | Ref<number> | Ref<string>) =>
+  helpers.withMessage(
+    ({ $params }: MessageProps) => `${$params.min}以上で入力してください。`,
+    _minValue(min)
+  )
+
+export {
+  kana,
+  tel,
+  required,
+  email,
+  postalCode,
+  minLength,
+  maxLength,
+  minValue,
+}

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -1,4 +1,12 @@
-import { helpers } from '@vuelidate/validators'
+import { Ref } from '@vue/composition-api'
+import {
+  helpers,
+  MessageProps,
+  required as _required,
+  email as _email,
+  minLength as _minLength,
+  maxLength as _maxLength,
+} from '@vuelidate/validators'
 
 /**
  * ひらがなを判定する関数
@@ -15,4 +23,58 @@ const kanaValidator = (value: string): boolean => {
  */
 const kana = helpers.withMessage('ひらがなを入力してください。', kanaValidator)
 
-export { kana }
+/**
+ * 電話番号を判定するカスタムバリデーション
+ */
+const tel = helpers.withMessage(
+  '電話番号は0から始まる数字のみの9桁または10桁で入力してください。',
+  helpers.regex(/^0[0-9]{9,10}$/)
+)
+
+/**
+ * 郵便番号を判定するカスタムバリデーション
+ */
+const postalCode = helpers.withMessage(
+  '郵便番号は数字のみの7桁で入力してください。',
+  helpers.regex(/[0-9]{7}/)
+)
+
+/**
+ * 必須バリデーションルールをラップする関数
+ */
+const required = helpers.withMessage(
+  (_: MessageProps) => 'この項目は必須項目です。',
+  _required
+)
+
+/**
+ * メールアドレスバリデーションルールをラップする関数
+ */
+const email = helpers.withMessage(
+  'メールアドレスの形式で入力してください。',
+  _email
+)
+
+/**
+ * 文字列の最小の長さのバリデーションルールをラップする関数
+ * @param max
+ * @returns
+ */
+const minLength = (max: number | Ref<number>) =>
+  helpers.withMessage(
+    ({ $params }: MessageProps) => `${$params.max}文字以上入力してください。`,
+    _minLength(max)
+  )
+
+/**
+ * 文字列の最大の長さのバリデーションルールをラップする関数
+ * @param max
+ * @returns
+ */
+const maxLength = (max: number | Ref<number>) =>
+  helpers.withMessage(
+    ({ $params }: MessageProps) => `${$params.max}文字までです。`,
+    _maxLength(max)
+  )
+
+export { kana, tel, required, email, postalCode, minLength, maxLength }

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -7,6 +7,7 @@ import {
   minLength as _minLength,
   maxLength as _maxLength,
   minValue as _minValue,
+  sameAs as _sameAs,
 } from '@vuelidate/validators'
 
 /**
@@ -89,6 +90,18 @@ const minValue = (min: string | number | Ref<number> | Ref<string>) =>
     _minValue(min)
   )
 
+/**
+ * 入力値が別のプロパティとの一致しているかのバリデーションルールをラップする関数
+ * @param equalTo
+ * @param otherName
+ * @returns
+ */
+const sameAs = (equalTo: unknown, otherName?: string) =>
+  helpers.withMessage(
+    (_: MessageProps) => '一致しません。',
+    _sameAs(equalTo, otherName)
+  )
+
 export {
   kana,
   tel,
@@ -98,4 +111,5 @@ export {
   minLength,
   maxLength,
   minValue,
+  sameAs,
 }

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -58,13 +58,13 @@ const email = helpers.withMessage(
 
 /**
  * 文字列の最小の長さのバリデーションルールをラップする関数
- * @param max
+ * @param min
  * @returns
  */
-const minLength = (max: number | Ref<number>) =>
+const minLength = (min: number | Ref<number>) =>
   helpers.withMessage(
-    ({ $params }: MessageProps) => `${$params.max}文字以上入力してください。`,
-    _minLength(max)
+    ({ $params }: MessageProps) => `${$params.min}文字以上入力してください。`,
+    _minLength(min)
   )
 
 /**

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -1,0 +1,18 @@
+import { helpers } from '@vuelidate/validators'
+
+/**
+ * ひらがなを判定する関数
+ * @param value
+ * @returns
+ */
+const kanaValidator = (value: string): boolean => {
+  const kanaRegex = /^[\u3040-\u309F]+$/
+  return kanaRegex.test(value)
+}
+
+/**
+ * ひらがなを判定するカスタムバリデーションルール
+ */
+const kana = helpers.withMessage('ひらがなを入力してください。', kanaValidator)
+
+export { kana }

--- a/web/admin/src/pages/accounts/password/index.vue
+++ b/web/admin/src/pages/accounts/password/index.vue
@@ -5,34 +5,34 @@
       <v-container>
         <form @submit.prevent="handleSubmit">
           <v-text-field
-            v-model="formData.oldPassword"
+            v-model="v$.oldPassword.$model"
+            :error-messages="getErrorMessage(v$.oldPassword.$errors)"
             class="mx-4"
-            minlength="8"
-            maxlength="32"
             label="現在のパスワード"
             :append-icon="oldPasswordShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="oldPasswordShow ? 'text' : 'password'"
             @click:append="oldPasswordShow = !oldPasswordShow"
           />
           <v-text-field
-            v-model="formData.newPassword"
+            v-model="v$.newPassword.$model"
+            :error-messages="getErrorMessage(v$.newPassword.$errors)"
             class="mx-4"
-            minlength="8"
-            maxlength="32"
             label="新しいパスワード"
             :append-icon="newPasswordShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="newPasswordShow ? 'text' : 'password'"
             @click:append="newPasswordShow = !newPasswordShow"
           />
           <v-text-field
-            v-model="formData.passwordConfirmation"
+            v-model="v$.passwordConfirmation.$model"
             class="mx-4"
-            min-length="8"
-            maxlength="32"
             label="新しいパスワード(確認用)"
             :append-icon="passwordConfirmationShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="passwordConfirmationShow ? 'text' : 'password'"
-            :error-messages="isMatch ? '' : 'パスワードが一致しません'"
+            :error-messages="
+              getErrorMessage(v$.passwordConfirmation.$errors) === ''
+                ? ''
+                : 'パスワードが一致しません。'
+            "
             @click:append="passwordConfirmationShow = !passwordConfirmationShow"
           />
           <div class="d-flex justify-end mr-4">
@@ -48,17 +48,20 @@
 <script lang="ts">
 import { computed, useRouter } from '@nuxtjs/composition-api'
 import { defineComponent, reactive, ref } from '@vue/composition-api'
+import { useVuelidate } from '@vuelidate/core'
 
 import { useAlert } from '~/lib/hooks'
+import {
+  required,
+  minLength,
+  maxLength,
+  sameAs,
+  getErrorMessage,
+} from '~/lib/validations'
 import { useAuthStore } from '~/store/auth'
 import { UpdateAuthPasswordRequest } from '~/types/api'
 
 export default defineComponent({
-  /*
-  TODO: validation追加
-  newPassowrd passwordConfirmationの一致、入力文字数の制限、必須文字のcheck
-  */
-
   setup() {
     const router = useRouter()
     const formData = reactive<UpdateAuthPasswordRequest>({
@@ -67,17 +70,34 @@ export default defineComponent({
       passwordConfirmation: '',
     })
 
+    const rules = computed(() => ({
+      oldPassword: { required },
+      newPassword: {
+        required,
+        minLength: minLength(8),
+        maxLength: maxLength(32),
+      },
+      passwordConfirmation: { required, sameAs: sameAs(formData.newPassword) },
+    }))
+
+    const v$ = useVuelidate(rules, formData)
+
     const isMatch = computed(() => {
       return formData.newPassword === formData.passwordConfirmation
     })
 
-    const oldPasswordShow = ref<Boolean>(false)
-    const newPasswordShow = ref<Boolean>(false)
-    const passwordConfirmationShow = ref<Boolean>(false)
+    const oldPasswordShow = ref<boolean>(false)
+    const newPasswordShow = ref<boolean>(false)
+    const passwordConfirmationShow = ref<boolean>(false)
+
     const { alertType, isShow, alertText, show } = useAlert('error')
     const authStore = useAuthStore()
 
     const handleSubmit = async (): Promise<void> => {
+      const result = await v$.value.$validate()
+      if (!result) {
+        return
+      }
       try {
         await authStore.passwordUpdate(formData)
         router.push('/')
@@ -91,12 +111,14 @@ export default defineComponent({
       alertType,
       isShow,
       alertText,
+      v$,
       formData,
       oldPasswordShow,
       newPasswordShow,
       passwordConfirmationShow,
       isMatch,
       handleSubmit,
+      getErrorMessage,
     }
   },
 })

--- a/web/admin/src/pages/accounts/password/index.vue
+++ b/web/admin/src/pages/accounts/password/index.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <v-card-title>パスワード変更</v-card-title>
-    <v-card>
-      <v-container>
-        <form @submit.prevent="handleSubmit">
+    <v-alert v-model="isShow" :type="alertType" v-text="alertText" />
+    <form @submit.prevent="handleSubmit">
+      <v-card>
+        <v-card-text>
           <v-text-field
             v-model="v$.oldPassword.$model"
             :error-messages="getErrorMessage(v$.oldPassword.$errors)"
-            class="mx-4"
             label="現在のパスワード"
             :append-icon="oldPasswordShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="oldPasswordShow ? 'text' : 'password'"
@@ -16,7 +16,6 @@
           <v-text-field
             v-model="v$.newPassword.$model"
             :error-messages="getErrorMessage(v$.newPassword.$errors)"
-            class="mx-4"
             label="新しいパスワード"
             :append-icon="newPasswordShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="newPasswordShow ? 'text' : 'password'"
@@ -24,7 +23,6 @@
           />
           <v-text-field
             v-model="v$.passwordConfirmation.$model"
-            class="mx-4"
             label="新しいパスワード(確認用)"
             :append-icon="passwordConfirmationShow ? 'mdi-eye' : 'mdi-eye-off'"
             :type="passwordConfirmationShow ? 'text' : 'password'"
@@ -35,13 +33,12 @@
             "
             @click:append="passwordConfirmationShow = !passwordConfirmationShow"
           />
-          <div class="d-flex justify-end mr-4">
-            <v-btn outlined color="primary" type="submit"> 変更 </v-btn>
-          </div>
-        </form>
-      </v-container>
-      <v-alert v-model="isShow" :type="alertType" v-text="alertText" />
-    </v-card>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn block outlined color="primary" type="submit"> 変更 </v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </div>
 </template>
 

--- a/web/admin/src/pages/coordinator/add.vue
+++ b/web/admin/src/pages/coordinator/add.vue
@@ -3,36 +3,52 @@
     <v-card-title>コーディネーター登録</v-card-title>
     <v-card elevation="0">
       <v-card-text>
-        <v-text-field v-model="formData.storeName" label="店舗名" />
+        <v-text-field
+          v-model="v$.storeName.$model"
+          :error-messages="getErrorMessage(v$.storeName.$errors)"
+          label="店舗名"
+        />
         <div class="mb-2">
           <the-file-upload-filed text="コーディネーター画像" />
         </div>
-        <v-text-field v-model="formData.companyName" label="会社名" />
+        <v-text-field
+          v-model="v$.companyName.$model"
+          :error-messages="getErrorMessage(v$.companyName.$errors)"
+          label="会社名"
+        />
         <div class="d-flex">
           <v-text-field
-            v-model="formData.lastname"
+            v-model="v$.lastname.$model"
+            :error-messages="getErrorMessage(v$.lastname.$errors)"
             class="mr-4"
             label="コーディネーター:姓"
           />
           <v-text-field
-            v-model="formData.firstname"
+            v-model="v$.firstname.$model"
+            :error-messages="getErrorMessage(v$.firstname.$errors)"
             label="コーディネーター:名"
           />
         </div>
         <div class="d-flex">
           <v-text-field
-            v-model="formData.lastnameKana"
+            v-model="v$.lastnameKana.$model"
+            :error-messages="getErrorMessage(v$.lastnameKana.$errors)"
             class="mr-4"
             label="コーディネーター:姓（ふりがな）"
           />
           <v-text-field
-            v-model="formData.firstnameKana"
+            v-model="v$.firstnameKana.$model"
             label="コーディネーター:名（ふりがな）"
           />
         </div>
-        <v-text-field v-model="formData.email" label="連絡先（Email）" />
         <v-text-field
-          v-model="formData.phoneNumber"
+          v-model="v$.email.$model"
+          label="連絡先（Email）"
+          :error-messages="getErrorMessage(v$.email.$errors)"
+        />
+        <v-text-field
+          v-model="v$.phoneNumber.$model"
+          :error-messages="getErrorMessage(v$.phoneNumber.$errors)"
           type="tel"
           label="連絡先（電話番号）"
         />
@@ -56,9 +72,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from '@nuxtjs/composition-api'
+import { computed, defineComponent, reactive } from '@nuxtjs/composition-api'
+import { useVuelidate } from '@vuelidate/core'
 
 import { useSearchAddress } from '~/lib/hooks'
+import {
+  kana,
+  getErrorMessage,
+  required,
+  email,
+  tel,
+  maxLength,
+} from '~/lib/validations'
 import { useCoordinatorStore } from '~/store/coordinator'
 import { CreateCoordinatorRequest } from '~/types/api'
 
@@ -85,6 +110,18 @@ export default defineComponent({
       addressLine2: '',
     })
 
+    const rules = computed(() => ({
+      storeName: { required, maxLength: maxLength(64) },
+      companyName: { required, maxLength: maxLength(64) },
+      firstname: { required, maxLength: maxLength(16) },
+      lastname: { required, maxLength: maxLength(16) },
+      firstnameKana: { required, kana },
+      lastnameKana: { required, kana },
+      phoneNumber: { required, tel },
+      email: { required, email },
+    }))
+
+    const v$ = useVuelidate(rules, formData)
     const { createCoordinator } = useCoordinatorStore()
 
     const {
@@ -105,6 +142,10 @@ export default defineComponent({
     }
 
     const handleSubmit = async () => {
+      const result = await v$.value.$validate()
+      if (!result) {
+        return
+      }
       await createCoordinator({
         ...formData,
         phoneNumber: formData.phoneNumber.replace('0', '+81'),
@@ -113,6 +154,8 @@ export default defineComponent({
 
     return {
       formData,
+      v$,
+      getErrorMessage,
       searchLoading,
       searchErrorMessage,
       searchAddress,

--- a/web/admin/src/pages/products/add.vue
+++ b/web/admin/src/pages/products/add.vue
@@ -208,9 +208,9 @@ import {
   ref,
 } from '@vue/composition-api'
 import { useVuelidate } from '@vuelidate/core'
-import { required, minValue } from '@vuelidate/validators'
 
 import { useAlert } from '~/lib/hooks'
+import { required, minValue } from '~/lib/validations'
 import { useCategoryStore } from '~/store/category'
 import { useProducerStore } from '~/store/producer'
 import { useProductStore } from '~/store/product'


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

- コーディーネータ登録時にバリデーションを追加
- パスワード変更画面にバリデーションを追加

![localhost_3000_accounts_password](https://user-images.githubusercontent.com/27722351/189482116-9369ddb2-8133-4611-b0a0-2074ea39244d.png)

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
