### PR TITLE
feta(store): implement CreateLive database layer

### DIFF
--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -23,6 +23,7 @@ type Database struct {
 	Promotion   Promotion
 	Shipping    Shipping
 	Schedule    Schedule
+	Live        Live
 }
 
 func NewDatabase(params *Params) *Database {
@@ -33,6 +34,7 @@ func NewDatabase(params *Params) *Database {
 		Promotion:   NewPromotion(params.Database),
 		Shipping:    NewShipping(params.Database),
 		Schedule:    NewSchedule(params.Database),
+		Live:        NewLive(params.Database),
 	}
 }
 
@@ -88,6 +90,10 @@ type Shipping interface {
 
 type Schedule interface {
 	Create(ctx context.Context, schedule *entity.Schedule) error
+}
+
+type Live interface {
+	Create(ctx context.Context, live *entity.Live) error
 }
 
 /**

--- a/api/internal/store/database/live.go
+++ b/api/internal/store/database/live.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"context"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/database"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"gorm.io/gorm"
+)
+
+const liveTable = "lives"
+
+type live struct {
+	db  *database.Client
+	now func() time.Time
+}
+
+func NewLive(db *database.Client) Live {
+	return &live{
+		db:  db,
+		now: jst.Now,
+	}
+}
+
+func (l *live) Create(ctx context.Context, live *entity.Live) error {
+	_, err := l.db.Transaction(ctx, func(tx *gorm.DB) (interface{}, error) {
+		if err := live.FillJSON(); err != nil {
+			return nil, err
+		}
+
+		now := l.now()
+		live.CreatedAt, live.UpdatedAt = now, now
+
+		err := tx.WithContext(ctx).Table(liveTable).Create(&live).Error
+		return nil, err
+	})
+	return exception.InternalError(err)
+}

--- a/api/internal/store/database/live_test.go
+++ b/api/internal/store/database/live_test.go
@@ -1,0 +1,102 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLive(t *testing.T) {
+	assert.NotNil(t, NewLive(nil))
+}
+
+func TestLive_Create(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m, err := newMocks(ctrl)
+	require.NoError(t, err)
+	current := jst.Date(2022, 8, 1, 0, 0, 0, 0)
+	now := func() time.Time {
+		return current
+	}
+
+	_ = m.dbDelete(ctx, liveTable)
+
+	type args struct {
+		live *entity.Live
+	}
+	type want struct {
+		hasErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				live: testLive("live-id", "schedule-id", "producer-id", now()),
+			},
+			want: want{
+				hasErr: false,
+			},
+		},
+		{
+			name: "failed to duplicate entry",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				live := testLive("live-id", "schedule-id", "producer-id", now())
+				err = m.db.DB.Create(&live).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				live: testLive("live-id", "schedule-id", "producer-id", now()),
+			},
+			want: want{
+				hasErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := m.dbDelete(ctx, liveTable)
+			require.NoError(t, err)
+			tt.setup(ctx, t, m)
+
+			db := &live{db: m.db, now: now}
+			err = db.Create(ctx, tt.args.live)
+			assert.Equal(t, tt.want.hasErr, err != nil, err)
+		})
+	}
+}
+
+func testLive(id, scheduleID, producerID string, now time.Time) *entity.Live {
+	l := &entity.Live{
+		ID:          id,
+		ScheduleID:  scheduleID,
+		Title:       "配信のタイトル",
+		Description: "配信の説明",
+		ProducerID:  producerID,
+		StartAt:     now,
+		EndAt:       now,
+		Recommends:  []string{"product-id1", "product-id2"},
+	}
+	_ = l.FillJSON()
+	return l
+}

--- a/api/internal/store/entity/live.go
+++ b/api/internal/store/entity/live.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/and-period/furumaru/api/pkg/uuid"
@@ -46,4 +47,20 @@ func NewLive(params *NewLiveParams) *Live {
 		EndAt:       params.EndAt,
 		Recommends:  params.Recommends,
 	}
+}
+
+func (l *Live) FillJSON() error {
+	v, err := Marshal(l.Recommends)
+	if err != nil {
+		return err
+	}
+	l.RecommendsJSON = datatypes.JSON(v)
+	return nil
+}
+
+func Marshal(s []string) ([]byte, error) {
+	if len(s) == 0 {
+		return []byte{}, nil
+	}
+	return json.Marshal(s)
 }

--- a/api/internal/store/entity/live_test.go
+++ b/api/internal/store/entity/live_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/and-period/furumaru/api/pkg/jst"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
 )
 
 func TestLive(t *testing.T) {
@@ -43,6 +44,49 @@ func TestLive(t *testing.T) {
 			actual := NewLive(tt.params)
 			actual.ID = "" // ignore
 			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestLive_FillJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		live   *Live
+		expect *Live
+		hasErr bool
+	}{
+		{
+			name: "success",
+			live: &Live{
+				ID:          "live-id",
+				Title:       "ライブのタイトル",
+				Description: "ライブの説明",
+				StartAt:     jst.Date(2022, 8, 1, 0, 0, 0, 0),
+				EndAt:       jst.Date(2022, 9, 1, 0, 0, 0, 0),
+				Recommends:  []string{"product-id1", "product-id2"},
+			},
+			expect: &Live{
+				ID:             "live-id",
+				Title:          "ライブのタイトル",
+				Description:    "ライブの説明",
+				StartAt:        jst.Date(2022, 8, 1, 0, 0, 0, 0),
+				EndAt:          jst.Date(2022, 9, 1, 0, 0, 0, 0),
+				Recommends:     []string{"product-id1", "product-id2"},
+				RecommendsJSON: datatypes.JSON([]byte(`["product-id1","product-id2"]`)),
+			},
+			hasErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.live.FillJSON()
+			assert.Equal(t, tt.hasErr, err != nil, err)
+			assert.Equal(t, tt.expect, tt.live)
 		})
 	}
 }

--- a/api/internal/store/entity/live_test.go
+++ b/api/internal/store/entity/live_test.go
@@ -46,3 +46,31 @@ func TestLive(t *testing.T) {
 		})
 	}
 }
+
+func TestLive_Marshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		recommends []string
+		expect     []byte
+		hasErr     bool
+	}{
+		{
+			name:       "success",
+			recommends: []string{"product-id1", "product-id2"},
+			expect:     []byte(`["product-id1", "product-id2"]`),
+			hasErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := Marshal(tt.recommends)
+			assert.Equal(t, tt.hasErr, err != nil, err)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/mock/store/database/database.go
+++ b/api/mock/store/database/database.go
@@ -689,3 +689,40 @@ func (mr *MockScheduleMockRecorder) Create(ctx, schedule interface{}) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSchedule)(nil).Create), ctx, schedule)
 }
+
+// MockLive is a mock of Live interface.
+type MockLive struct {
+	ctrl     *gomock.Controller
+	recorder *MockLiveMockRecorder
+}
+
+// MockLiveMockRecorder is the mock recorder for MockLive.
+type MockLiveMockRecorder struct {
+	mock *MockLive
+}
+
+// NewMockLive creates a new mock instance.
+func NewMockLive(ctrl *gomock.Controller) *MockLive {
+	mock := &MockLive{ctrl: ctrl}
+	mock.recorder = &MockLiveMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockLive) EXPECT() *MockLiveMockRecorder {
+	return m.recorder
+}
+
+// Create mocks base method.
+func (m *MockLive) Create(ctx context.Context, live *entity.Live) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, live)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockLiveMockRecorder) Create(ctx, live interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockLive)(nil).Create), ctx, live)
+}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- Marshalメソッド追加
- FillJSONメソッド追加
- CreateLiveのdatabase層実装
- make mockgen
## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計などの参照できるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->
https://calmato.kibe.la/notes/727

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->
- [ ] DDL
- [ ] entity
- [ ] database
- [ ] service
- [ ] swagger
- [ ] gateway

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどがあればここに -->
