### PR TITLE
Feat/get live/service layer

### DIFF
--- a/api/internal/store/entity/live.go
+++ b/api/internal/store/entity/live.go
@@ -20,21 +20,28 @@ const (
 
 // ライブ配信情報
 type Live struct {
-	LiveProducts `gorm:"-"`
-	ID           string         `gorm:"primaryKey;<-:create"` // ライブ配信ID
-	ScheduleID   string         `gorm:""`                     // 開催スケジュールID
-	ProducerID   string         `gorm:""`                     // 生産者ID
-	Title        string         `gorm:""`                     // タイトル
-	Description  string         `gorm:""`                     // 説明
-	Status       LiveStatus     `gorm:"-"`                    // 配信ステータス
-	Published    bool           `gorm:""`                     // 配信公開フラグ
-	Canceled     bool           `gorm:""`                     // 配信中止フラグ
-	StartAt      time.Time      `gorm:""`                     // 配信開始日時
-	EndAt        time.Time      `gorm:""`                     // 配信終了日時
-	ChannelArn   string         `gorm:"default:null"`         // チャンネルArn
-	CreatedAt    time.Time      `gorm:"<-:create"`            // 登録日時
-	UpdatedAt    time.Time      `gorm:""`                     // 更新日時
-	DeletedAt    gorm.DeletedAt `gorm:"default:null"`         // 削除日時
+	LiveProducts   `gorm:"-"`
+	ID             string         `gorm:"primaryKey;<-:create"` // ライブ配信ID
+	ScheduleID     string         `gorm:""`                     // 開催スケジュールID
+	ProducerID     string         `gorm:""`                     // 生産者ID
+	Title          string         `gorm:""`                     // タイトル
+	Description    string         `gorm:""`                     // 説明
+	Status         LiveStatus     `gorm:"-"`                    // 配信ステータス
+	Published      bool           `gorm:""`                     // 配信公開フラグ
+	Canceled       bool           `gorm:""`                     // 配信中止フラグ
+	StartAt        time.Time      `gorm:""`                     // 配信開始日時
+	EndAt          time.Time      `gorm:""`                     // 配信終了日時
+	ChannelArn     string         `gorm:"default:null"`         // チャンネルArn
+	StreamKeyArn   string         `gorm:"default:null"`         // ストリームキーArn
+	CreatedAt      time.Time      `gorm:"<-:create"`            // 登録日時
+	UpdatedAt      time.Time      `gorm:""`                     // 更新日時
+	DeletedAt      gorm.DeletedAt `gorm:"default:null"`         // 削除日時
+	ChannelName    string         `gorm:"-"`                    // チャンネル名
+	IngestEndpoint string         `gorm:"-"`                    // 配信エンドポイント
+	StreamKey      string         `gorm:"-"`                    // ストリームキー
+	StreamID       string         `gorm:"-"`                    // ストリームID
+	PlaybackURL    string         `gorm:"-"`                    // 再生用URL
+	ViewerCount    int64          `gorm:"-"`                    // 視聴者数
 }
 
 type Lives []*Live
@@ -46,6 +53,15 @@ type NewLiveParams struct {
 	Description string
 	StartAt     time.Time
 	EndAt       time.Time
+}
+
+type FillLiveIvsParams struct {
+	ChannelName    string
+	IngestEndpoint string
+	StreamKey      string
+	PlaybackURL    string
+	StreamID       string
+	ViewerCount    int64
 }
 
 func NewLive(params *NewLiveParams) *Live {
@@ -63,6 +79,15 @@ func NewLive(params *NewLiveParams) *Live {
 func (l *Live) Fill(products LiveProducts, now time.Time) {
 	l.LiveProducts = products
 	l.Status = l.status(now)
+}
+
+func (l *Live) FillIVS(params FillLiveIvsParams) {
+	l.ChannelName = params.ChannelName
+	l.IngestEndpoint = params.IngestEndpoint
+	l.StreamKey = params.StreamKey
+	l.PlaybackURL = params.PlaybackURL
+	l.StreamID = params.StreamID
+	l.ViewerCount = params.ViewerCount
 }
 
 func (l *Live) status(now time.Time) LiveStatus {

--- a/api/internal/store/entity/live_test.go
+++ b/api/internal/store/entity/live_test.go
@@ -303,6 +303,54 @@ func TestLive_Fill(t *testing.T) {
 	}
 }
 
+func TestLive_FillIVS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		live   *Live
+		params FillLiveIvsParams
+		expect *Live
+	}{
+		{
+			name: "success",
+			live: &Live{
+				ID:           "live-id",
+				ChannelArn:   "channel-arn",
+				StreamKeyArn: "streamKey-arn",
+			},
+			params: FillLiveIvsParams{
+				ChannelName:    "配信チャンネル",
+				IngestEndpoint: "ingest-endpoint",
+				StreamKey:      "streamKey-value",
+				StreamID:       "stream-id",
+				PlaybackURL:    "playback-url",
+				ViewerCount:    100,
+			},
+			expect: &Live{
+				ID:             "live-id",
+				ChannelArn:     "channel-arn",
+				StreamKeyArn:   "streamKey-arn",
+				ChannelName:    "配信チャンネル",
+				IngestEndpoint: "ingest-endpoint",
+				StreamKey:      "streamKey-value",
+				StreamID:       "stream-id",
+				PlaybackURL:    "playback-url",
+				ViewerCount:    100,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.live.FillIVS(tt.params)
+			assert.Equal(t, tt.expect, tt.live)
+		})
+	}
+}
+
 func TestLives_ProducerIDs(t *testing.T) {
 	t.Parallel()
 

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -307,6 +307,10 @@ type CreateScheduleLive struct {
 	EndAt       time.Time `validate:"required"`
 }
 
+type GetLiveInput struct {
+	LiveID string `validate:"required"`
+}
+
 type ListOrdersInput struct {
 	CoordinatorID string             `validate:"omitempty"`
 	Limit         int64              `validate:"required,max=200"`

--- a/api/internal/store/service/live.go
+++ b/api/internal/store/service/live.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/store"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/ivs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func (s *service) GetLive(ctx context.Context, in *store.GetLiveInput) (*entity.Live, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, exception.InternalError(err)
+	}
+
+	live, err := s.db.Live.Get(ctx, in.LiveID)
+	if err != nil {
+		return nil, exception.InternalError(err)
+	}
+
+	channelIn := &ivs.GetChannelParams{
+		Arn: live.ChannelArn,
+	}
+	channel, err := s.ivs.GetChannel(ctx, channelIn)
+	if err != nil {
+		return nil, exception.InternalError(err)
+	}
+
+	streamIn := &ivs.GetStreamParams{
+		ChannelArn: live.ChannelArn,
+	}
+	stream, err := s.ivs.GetStream(ctx, streamIn)
+	if err != nil {
+		return nil, exception.InternalError(err)
+	}
+
+	streamKeyIn := &ivs.GetStreamKeyParams{
+		StreamKeyArn: live.StreamKeyArn,
+	}
+	streamKey, err := s.ivs.GetStreamKey(ctx, streamKeyIn)
+	if err != nil {
+		return nil, exception.InternalError(err)
+	}
+
+	fillIvsParams := &entity.FillLiveIvsParams{
+		ChannelName:    aws.ToString(channel.Name),
+		IngestEndpoint: aws.ToString(channel.IngestEndpoint),
+		StreamKey:      aws.ToString(streamKey.Value),
+		PlaybackURL:    aws.ToString(channel.PlaybackUrl),
+		StreamID:       aws.ToString(stream.StreamId),
+		ViewerCount:    aws.ToInt64(&stream.ViewerCount),
+	}
+	live.FillIVS(*fillIvsParams)
+	return live, nil
+}

--- a/api/internal/store/service/live_test.go
+++ b/api/internal/store/service/live_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/and-period/furumaru/api/pkg/ivs"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ivs/types"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,9 +64,9 @@ func TestGetLive(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Live.EXPECT().Get(ctx, "live-id").Return(live, nil)
-				mocks.ivs.EXPECT().GetChannel(ctx, channelIn).Return(channel, nil)
-				mocks.ivs.EXPECT().GetStream(ctx, streamIn).Return(stream, nil)
-				mocks.ivs.EXPECT().GetStreamKey(ctx, streamKeyIn).Return(streamKey, nil)
+				mocks.ivs.EXPECT().GetChannel(gomock.Any(), channelIn).Return(channel, nil)
+				mocks.ivs.EXPECT().GetStream(gomock.Any(), streamIn).Return(stream, nil)
+				mocks.ivs.EXPECT().GetStreamKey(gomock.Any(), streamKeyIn).Return(streamKey, nil)
 			},
 			input: &store.GetLiveInput{
 				LiveID: "live-id",
@@ -105,7 +106,9 @@ func TestGetLive(t *testing.T) {
 			name: "failed to not found channel",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Live.EXPECT().Get(ctx, "live-id").Return(live, nil)
-				mocks.ivs.EXPECT().GetChannel(ctx, channelIn).Return(nil, exception.ErrNotFound)
+				mocks.ivs.EXPECT().GetChannel(gomock.Any(), channelIn).Return(nil, exception.ErrNotFound)
+				mocks.ivs.EXPECT().GetStream(gomock.Any(), streamIn).Return(stream, nil)
+				mocks.ivs.EXPECT().GetStreamKey(gomock.Any(), streamKeyIn).Return(streamKey, nil)
 			},
 			input: &store.GetLiveInput{
 				LiveID: "live-id",
@@ -117,8 +120,9 @@ func TestGetLive(t *testing.T) {
 			name: "failed to not found stream",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Live.EXPECT().Get(ctx, "live-id").Return(live, nil)
-				mocks.ivs.EXPECT().GetChannel(ctx, channelIn).Return(channel, nil)
-				mocks.ivs.EXPECT().GetStream(ctx, streamIn).Return(nil, exception.ErrNotFound)
+				mocks.ivs.EXPECT().GetChannel(gomock.Any(), channelIn).Return(channel, nil)
+				mocks.ivs.EXPECT().GetStream(gomock.Any(), streamIn).Return(nil, exception.ErrNotFound)
+				mocks.ivs.EXPECT().GetStreamKey(gomock.Any(), streamKeyIn).Return(streamKey, nil)
 			},
 			input: &store.GetLiveInput{
 				LiveID: "live-id",
@@ -130,9 +134,9 @@ func TestGetLive(t *testing.T) {
 			name: "failed to not found streamKey",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Live.EXPECT().Get(ctx, "live-id").Return(live, nil)
-				mocks.ivs.EXPECT().GetChannel(ctx, channelIn).Return(channel, nil)
-				mocks.ivs.EXPECT().GetStream(ctx, streamIn).Return(stream, nil)
-				mocks.ivs.EXPECT().GetStreamKey(ctx, streamKeyIn).Return(nil, exception.ErrNotFound)
+				mocks.ivs.EXPECT().GetChannel(gomock.Any(), channelIn).Return(channel, nil)
+				mocks.ivs.EXPECT().GetStream(gomock.Any(), streamIn).Return(stream, nil)
+				mocks.ivs.EXPECT().GetStreamKey(gomock.Any(), streamKeyIn).Return(nil, exception.ErrNotFound)
 			},
 			input: &store.GetLiveInput{
 				LiveID: "live-id",

--- a/api/internal/store/service/live_test.go
+++ b/api/internal/store/service/live_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/store"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/ivs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ivs/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLive(t *testing.T) {
+	t.Parallel()
+	live := &entity.Live{
+		ID:           "live-id",
+		ChannelArn:   "channel-arn",
+		StreamKeyArn: "streamKey-arn",
+	}
+
+	channelIn := &ivs.GetChannelParams{
+		Arn: "channel-arn",
+	}
+
+	streamIn := &ivs.GetStreamParams{
+		ChannelArn: "channel-arn",
+	}
+
+	streamKeyIn := &ivs.GetStreamKeyParams{
+		StreamKeyArn: "streamKey-arn",
+	}
+
+	channel := &types.Channel{
+		Arn:            aws.String("channel-arn"),
+		IngestEndpoint: aws.String("ingest-endpoint"),
+		Name:           aws.String("配信チャンネル"),
+		PlaybackUrl:    aws.String("playback-url"),
+	}
+
+	stream := &types.Stream{
+		ChannelArn:  aws.String("channel-arn"),
+		StreamId:    aws.String("stream-id"),
+		ViewerCount: 100,
+	}
+
+	streamKey := &types.StreamKey{
+		Arn:        aws.String("streamKey-arn"),
+		ChannelArn: aws.String("channel-arn"),
+		Value:      aws.String("streamKey-value"),
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(ctx context.Context, mocks *mocks)
+		input     *store.GetLiveInput
+		expect    *entity.Live
+		expectErr error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Live.EXPECT().Get(ctx, "live-id").Return(live, nil)
+				mocks.ivs.EXPECT().GetChannel(ctx, channelIn).Return(channel, nil)
+				mocks.ivs.EXPECT().GetStream(ctx, streamIn).Return(stream, nil)
+				mocks.ivs.EXPECT().GetStreamKey(ctx, streamKeyIn).Return(streamKey, nil)
+			},
+			input: &store.GetLiveInput{
+				LiveID: "live-id",
+			},
+			expect: &entity.Live{
+				ID:             "live-id",
+				ChannelArn:     "channel-arn",
+				StreamKeyArn:   "streamKey-arn",
+				ChannelName:    "配信チャンネル",
+				IngestEndpoint: "ingest-endpoint",
+				StreamKey:      "streamKey-value",
+				StreamID:       "stream-id",
+				PlaybackURL:    "playback-url",
+				ViewerCount:    100,
+			},
+			expectErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			actual, err := service.GetLive(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expectErr)
+			assert.Equal(t, tt.expect, actual)
+		}))
+	}
+}

--- a/api/internal/store/service/service.go
+++ b/api/internal/store/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/and-period/furumaru/api/internal/store/database"
 	"github.com/and-period/furumaru/api/internal/user"
+	"github.com/and-period/furumaru/api/pkg/ivs"
 	"github.com/and-period/furumaru/api/pkg/jst"
 	"github.com/and-period/furumaru/api/pkg/postalcode"
 	"github.com/and-period/furumaru/api/pkg/validator"
@@ -23,6 +24,7 @@ type Params struct {
 	Messenger  messenger.Service
 	Media      media.Service
 	PostalCode postalcode.Client
+	Ivs        ivs.Client
 }
 
 type service struct {
@@ -36,6 +38,7 @@ type service struct {
 	messenger   messenger.Service
 	media       media.Service
 	postalCode  postalcode.Client
+	ivs         ivs.Client
 }
 
 type options struct {
@@ -68,5 +71,6 @@ func NewService(params *Params, opts ...Option) store.Service {
 		messenger:   params.Messenger,
 		media:       params.Media,
 		postalCode:  params.PostalCode,
+		ivs:         params.Ivs,
 	}
 }

--- a/api/internal/store/service/service_test.go
+++ b/api/internal/store/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/store/database"
 	mock_media "github.com/and-period/furumaru/api/mock/media"
 	mock_messenger "github.com/and-period/furumaru/api/mock/messenger"
+	mock_ivs "github.com/and-period/furumaru/api/mock/pkg/ivs"
 	mock_postalcode "github.com/and-period/furumaru/api/mock/pkg/postalcode"
 	mock_database "github.com/and-period/furumaru/api/mock/store/database"
 	mock_user "github.com/and-period/furumaru/api/mock/user"
@@ -24,6 +25,7 @@ type mocks struct {
 	messenger  *mock_messenger.MockService
 	media      *mock_media.MockService
 	postalCode *mock_postalcode.MockClient
+	ivs        *mock_ivs.MockClient
 }
 
 type dbMocks struct {
@@ -34,6 +36,7 @@ type dbMocks struct {
 	Promotion   *mock_database.MockPromotion
 	Shipping    *mock_database.MockShipping
 	Schedule    *mock_database.MockSchedule
+	Live        *mock_database.MockLive
 }
 
 type testOptions struct {
@@ -59,6 +62,7 @@ func newMocks(ctrl *gomock.Controller) *mocks {
 		messenger:  mock_messenger.NewMockService(ctrl),
 		media:      mock_media.NewMockService(ctrl),
 		postalCode: mock_postalcode.NewMockClient(ctrl),
+		ivs:        mock_ivs.NewMockClient(ctrl),
 	}
 }
 
@@ -71,6 +75,7 @@ func newDBMocks(ctrl *gomock.Controller) *dbMocks {
 		Promotion:   mock_database.NewMockPromotion(ctrl),
 		Shipping:    mock_database.NewMockShipping(ctrl),
 		Schedule:    mock_database.NewMockSchedule(ctrl),
+		Live:        mock_database.NewMockLive(ctrl),
 	}
 }
 
@@ -91,11 +96,13 @@ func newService(mocks *mocks, opts ...testOption) *service {
 			Promotion:   mocks.db.Promotion,
 			Shipping:    mocks.db.Shipping,
 			Schedule:    mocks.db.Schedule,
+			Live:        mocks.db.Live,
 		},
 		User:       mocks.user,
 		Messenger:  mocks.messenger,
 		Media:      mocks.media,
 		PostalCode: mocks.postalCode,
+		Ivs:        mocks.ivs,
 	}
 	service := NewService(params).(*service)
 	service.now = func() time.Time {

--- a/api/mock/pkg/ivs/client.go
+++ b/api/mock/pkg/ivs/client.go
@@ -10,6 +10,7 @@ import (
 
 	ivs "github.com/and-period/furumaru/api/pkg/ivs"
 	ivs0 "github.com/aws/aws-sdk-go-v2/service/ivs"
+	types "github.com/aws/aws-sdk-go-v2/service/ivs/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -66,10 +67,10 @@ func (mr *MockClientMockRecorder) DeleteChannel(ctx, params interface{}) *gomock
 }
 
 // GetChannel mocks base method.
-func (m *MockClient) GetChannel(ctx context.Context, params *ivs.GetChannelParams) (*ivs0.GetChannelOutput, error) {
+func (m *MockClient) GetChannel(ctx context.Context, params *ivs.GetChannelParams) (*types.Channel, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChannel", ctx, params)
-	ret0, _ := ret[0].(*ivs0.GetChannelOutput)
+	ret0, _ := ret[0].(*types.Channel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -81,10 +82,10 @@ func (mr *MockClientMockRecorder) GetChannel(ctx, params interface{}) *gomock.Ca
 }
 
 // GetStream mocks base method.
-func (m *MockClient) GetStream(ctx context.Context, params *ivs.GetStreamParams) (*ivs0.GetStreamOutput, error) {
+func (m *MockClient) GetStream(ctx context.Context, params *ivs.GetStreamParams) (*types.Stream, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStream", ctx, params)
-	ret0, _ := ret[0].(*ivs0.GetStreamOutput)
+	ret0, _ := ret[0].(*types.Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -93,4 +94,19 @@ func (m *MockClient) GetStream(ctx context.Context, params *ivs.GetStreamParams)
 func (mr *MockClientMockRecorder) GetStream(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStream", reflect.TypeOf((*MockClient)(nil).GetStream), ctx, params)
+}
+
+// GetStreamKey mocks base method.
+func (m *MockClient) GetStreamKey(ctx context.Context, params *ivs.GetStreamKeyParams) (*types.StreamKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStreamKey", ctx, params)
+	ret0, _ := ret[0].(*types.StreamKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStreamKey indicates an expected call of GetStreamKey.
+func (mr *MockClientMockRecorder) GetStreamKey(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamKey", reflect.TypeOf((*MockClient)(nil).GetStreamKey), ctx, params)
 }

--- a/api/pkg/ivs/channel.go
+++ b/api/pkg/ivs/channel.go
@@ -36,7 +36,7 @@ func (c *client) CreateChannel(ctx context.Context, params *CreateChannelParams)
 	return out, nil
 }
 
-func (c *client) GetChannel(ctx context.Context, params *GetChannelParams) (*ivs.GetChannelOutput, error) {
+func (c *client) GetChannel(ctx context.Context, params *GetChannelParams) (*types.Channel, error) {
 	in := &ivs.GetChannelInput{
 		Arn: aws.String(params.Arn),
 	}
@@ -45,7 +45,7 @@ func (c *client) GetChannel(ctx context.Context, params *GetChannelParams) (*ivs
 	if err != nil {
 		return nil, c.streamError(err)
 	}
-	return out, nil
+	return out.Channel, nil
 }
 
 func (c *client) DeleteChannel(ctx context.Context, params *DeleteChannelParams) error {

--- a/api/pkg/ivs/client.go
+++ b/api/pkg/ivs/client.go
@@ -21,14 +21,16 @@ type Client interface {
 	// チャンネル作成
 	CreateChannel(ctx context.Context, params *CreateChannelParams) (*ivs.CreateChannelOutput, error)
 	// チャンネル取得
-	GetChannel(ctx context.Context, params *GetChannelParams) (*ivs.GetChannelOutput, error)
+	GetChannel(ctx context.Context, params *GetChannelParams) (*types.Channel, error)
 	// チャンネル削除
 	DeleteChannel(ctx context.Context, params *DeleteChannelParams) error
 	// ######################
 	// ストリーム関連
 	// ######################
 	// ストリーム取得
-	GetStream(ctx context.Context, params *GetStreamParams) (*ivs.GetStreamOutput, error)
+	GetStream(ctx context.Context, params *GetStreamParams) (*types.Stream, error)
+	// ストリームキー取得
+	GetStreamKey(ctx context.Context, params *GetStreamKeyParams) (*types.StreamKey, error)
 }
 
 var (

--- a/api/pkg/ivs/stream.go
+++ b/api/pkg/ivs/stream.go
@@ -5,13 +5,18 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ivs"
+	"github.com/aws/aws-sdk-go-v2/service/ivs/types"
 )
 
 type GetStreamParams struct {
 	ChannelArn string
 }
 
-func (c *client) GetStream(ctx context.Context, params *GetStreamParams) (*ivs.GetStreamOutput, error) {
+type GetStreamKeyParams struct {
+	StreamKeyArn string
+}
+
+func (c *client) GetStream(ctx context.Context, params *GetStreamParams) (*types.Stream, error) {
 	in := &ivs.GetStreamInput{
 		ChannelArn: aws.String(params.ChannelArn),
 	}
@@ -19,5 +24,16 @@ func (c *client) GetStream(ctx context.Context, params *GetStreamParams) (*ivs.G
 	if err != nil {
 		return nil, c.streamError(err)
 	}
-	return out, nil
+	return out.Stream, nil
+}
+
+func (c *client) GetStreamKey(ctx context.Context, params *GetStreamKeyParams) (*types.StreamKey, error) {
+	in := &ivs.GetStreamKeyInput{
+		Arn: aws.String(params.StreamKeyArn),
+	}
+	out, err := c.ivs.GetStreamKey(ctx, in)
+	if err != nil {
+		return nil, c.streamError(err)
+	}
+	return out.StreamKey, nil
 }

--- a/infra/mysql/schema/2022111901-stores-alter-column-lives.sql
+++ b/infra/mysql/schema/2022111901-stores-alter-column-lives.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `stores`.`lives` ADD COLUMN `stream_key_arn` VARCHAR(256) NULL DEFAULT NULL AFTER `channel_arn`;


### PR DESCRIPTION
## やったこと
- livesテーブルにstreamkey_arn 用のカラムを追加
- GetLiveのservice層実装
- Liveのentity修正
- LiveのentityにFillIVSメソッド追加
- GetLiveのテスト実装
## リファレンス
https://calmato.kibe.la/notes/727#%E8%A6%96%E8%81%B4%E8%80%85%E6%95%B0%E3%82%92%E5%8F%96%E5%BE%97
- [channel](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ivs@v1.18.6/types#Channel)
- [stream](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ivs@v1.18.6/types#Stream)
- [streamKey](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ivs@v1.18.6/types#StreamKey)
<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->
gateway実装
## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
