### PR TITLE
Feat(store) implement GetLive gateway

### DIFF
--- a/api/config/gateway/admin/rbac/policy.csv
+++ b/api/config/gateway/admin/rbac/policy.csv
@@ -57,6 +57,7 @@ p, notification_create, /v1/notifications, POST, allow
 p, notification_update, /v1/notifications/*, PATCH, allow
 p, notification_delete, /v1/notifications/*, DELETE, allow
 p, schedule_create, /v1/schedules, POST, allow
+p, live_get, /v1/schedules/*/lives/*, GET, allow
 p, message_list, /v1/messages, GET, allow
 p, message_get, /v1/messages/*, GET, allow
 p, postal_code_search, /v1/postal-codes/*, GET, allow
@@ -119,6 +120,7 @@ g, administrator, notification_create
 g, administrator, notification_update
 g, administrator, notification_delete
 g, administrator, schedule_create
+g, administrator, live_get
 g, administrator, message_list
 g, administrator, message_get
 g, administrator, postal_code_search
@@ -156,6 +158,7 @@ g, coordinator, notification_create
 g, coordinator, notification_update
 g, coordinator, notification_delete
 g, coordinator, schedule_create
+g, coordinator, live_get
 g, coordinator, message_list
 g, coordinator, message_get
 g, coordinator, postal_code_search
@@ -174,6 +177,7 @@ g, producer, order_list
 g, producer, order_get
 g, producer, notification_list
 g, producer, notification_get
+g, producer, live_get
 g, producer, message_list
 g, producer, message_get
 g, producer, postal_code_search

--- a/api/internal/gateway/admin/v1/handler/api.go
+++ b/api/internal/gateway/admin/v1/handler/api.go
@@ -112,6 +112,7 @@ func (h *handler) Routes(rg *gin.RouterGroup) {
 	h.contactRoutes(v1.Group("/contacts"))
 	h.messageRoutes(v1.Group("/messages"))
 	h.scheduleRoutes(v1.Group("/schedules"))
+	h.liveRoutes(v1.Group("/schedules/:scheduleId/lives"))
 	h.userRoutes(v1.Group("/users"))
 	h.postalCodeRoutes(v1.Group("/postal-codes"))
 	v1.GET("/categories/-/product-types", h.authentication, h.ListProductTypes)

--- a/api/internal/gateway/admin/v1/handler/live.go
+++ b/api/internal/gateway/admin/v1/handler/live.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/response"
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/service"
+	"github.com/and-period/furumaru/api/internal/gateway/util"
+	"github.com/and-period/furumaru/api/internal/store"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
+)
+
+func (h *handler) liveRoutes(rg *gin.RouterGroup) {
+	arg := rg.Use(h.authentication)
+	arg.GET("/:liveId", h.GetLive)
+}
+
+func (h *handler) GetLive(ctx *gin.Context) {
+	live, err := h.getLive(ctx, util.GetParam(ctx, "liveId"))
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
+
+	res := &response.LiveResponse{
+		Live: live.Response(),
+	}
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (h *handler) getLive(ctx context.Context, liveID string) (*service.Live, error) {
+	in := &store.GetLiveInput{
+		LiveID: liveID,
+	}
+	slive, err := h.store.GetLive(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	live := service.NewLive(slive)
+	var (
+		products service.Products
+		producer *service.Producer
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		productIDs := make([]string, 0, len(live.Products))
+		for i := range live.Products {
+			productIDs = append(productIDs, live.Products[i].ID)
+		}
+		products, err = h.multiGetProducts(ectx, productIDs)
+		if err != nil {
+			return err
+		}
+		if len(products) != len(productIDs) {
+			return errors.New("error: invalid argument")
+		}
+		return nil
+	})
+	eg.Go(func() (err error) {
+		producer, err = h.getProducer(ectx, live.ProducerID)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	live.Fill(producer, products.Map())
+	return live, nil
+}

--- a/api/internal/gateway/admin/v1/handler/live.go
+++ b/api/internal/gateway/admin/v1/handler/live.go
@@ -46,15 +46,11 @@ func (h *handler) getLive(ctx context.Context, liveID string) (*service.Live, er
 	)
 	eg, ectx := errgroup.WithContext(ctx)
 	eg.Go(func() (err error) {
-		productIDs := make([]string, 0, len(live.Products))
-		for i := range live.Products {
-			productIDs = append(productIDs, live.Products[i].ID)
-		}
-		products, err = h.multiGetProducts(ectx, productIDs)
+		products, err = h.multiGetProducts(ectx, live.ProductIDs)
 		if err != nil {
 			return err
 		}
-		if len(products) != len(productIDs) {
+		if len(products) != len(live.ProductIDs) {
 			return errors.New("error: invalid argument")
 		}
 		return nil

--- a/api/internal/gateway/admin/v1/handler/live.go
+++ b/api/internal/gateway/admin/v1/handler/live.go
@@ -40,6 +40,13 @@ func (h *handler) getLive(ctx context.Context, liveID string) (*service.Live, er
 		return nil, err
 	}
 	live := service.NewLive(slive)
+	if err := h.getLiveDetails(ctx, live); err != nil {
+		return nil, err
+	}
+	return live, nil
+}
+
+func (h *handler) getLiveDetails(ctx context.Context, live *service.Live) error {
 	var (
 		products service.Products
 		producer *service.Producer
@@ -60,9 +67,8 @@ func (h *handler) getLive(ctx context.Context, liveID string) (*service.Live, er
 		return
 	})
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return err
 	}
-
 	live.Fill(producer, products.Map())
-	return live, nil
+	return nil
 }

--- a/api/internal/gateway/admin/v1/handler/live_test.go
+++ b/api/internal/gateway/admin/v1/handler/live_test.go
@@ -1,0 +1,283 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/common"
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/response"
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/service"
+	"github.com/and-period/furumaru/api/internal/store"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/internal/user"
+	uentity "github.com/and-period/furumaru/api/internal/user/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/golang/mock/gomock"
+)
+
+func TestGetLive(t *testing.T) {
+	t.Parallel()
+
+	coordinatorIn := &user.GetCoordinatorInput{
+		CoordinatorID: "coordinator-id",
+	}
+	coordinator := &uentity.Coordinator{
+		Admin: uentity.Admin{
+			ID:            "coordinator-id",
+			Lastname:      "&.",
+			Firstname:     "管理者",
+			LastnameKana:  "あんどどっと",
+			FirstnameKana: "かんりしゃ",
+			Email:         "test-coordinator@and-period.jp",
+		},
+		AdminID:          "coordinator-id",
+		CompanyName:      "&.株式会社",
+		StoreName:        "&.農園",
+		ThumbnailURL:     "https://and-period.jp/thumbnail.png",
+		HeaderURL:        "https://and-period.jp/header.png",
+		TwitterAccount:   "twitter-id",
+		InstagramAccount: "instagram-id",
+		FacebookAccount:  "facebook-id",
+		PhoneNumber:      "+819012345678",
+		PostalCode:       "1000014",
+		Prefecture:       "東京都",
+		City:             "千代田区",
+		CreatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		UpdatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
+	}
+	producerIn := &user.GetProducerInput{
+		ProducerID: "producer-id",
+	}
+	producer := &uentity.Producer{
+		Admin: uentity.Admin{
+			ID:            "producer-id",
+			Lastname:      "&.",
+			Firstname:     "管理者",
+			LastnameKana:  "あんどどっと",
+			FirstnameKana: "かんりしゃ",
+			Email:         "test-producer@and-period.jp",
+		},
+		AdminID:       "producer-id",
+		CoordinatorID: "coordinator-id",
+		StoreName:     "&.農園",
+		ThumbnailURL:  "https://and-period.jp/thumbnail.png",
+		HeaderURL:     "https://and-period.jp/header.png",
+		PhoneNumber:   "+819012345678",
+		PostalCode:    "1000014",
+		Prefecture:    "東京都",
+		City:          "千代田区",
+		CreatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		UpdatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
+	}
+	categoriesIn := &store.MultiGetCategoriesInput{
+		CategoryIDs: []string{"category-id"},
+	}
+	categories := sentity.Categories{
+		{
+			ID:        "category-id",
+			Name:      "野菜",
+			CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		},
+	}
+	productTypesIn := &store.MultiGetProductTypesInput{
+		ProductTypeIDs: []string{"product-type-id"},
+	}
+	productTypes := sentity.ProductTypes{
+		{
+			ID:         "product-type-id",
+			Name:       "じゃがいも",
+			CategoryID: "category-id",
+			IconURL:    "https://and-period.jp/icon.png",
+			CreatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			UpdatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		},
+	}
+	productsIn := &store.MultiGetProductsInput{
+		ProductIDs: []string{"product-id"},
+	}
+	product := &sentity.Product{
+		ID:              "product-id",
+		TypeID:          "product-type-id",
+		ProducerID:      "producer-id",
+		Name:            "新鮮なじゃがいも",
+		Description:     "新鮮なじゃがいもをお届けします。",
+		Public:          true,
+		Inventory:       100,
+		Weight:          1300,
+		WeightUnit:      sentity.WeightUnitGram,
+		Item:            1,
+		ItemUnit:        "袋",
+		ItemDescription: "1袋あたり100gのじゃがいも",
+		Media: sentity.MultiProductMedia{
+			{
+				URL:         "https://and-period.jp/thumbnail01.png",
+				IsThumbnail: true,
+				Images: common.Images{
+					{URL: "https://and-period.jp/thumbnail01_240.png", Size: common.ImageSizeSmall},
+					{URL: "https://and-period.jp/thumbnail01_675.png", Size: common.ImageSizeMedium},
+					{URL: "https://and-period.jp/thumbnail01_900.png", Size: common.ImageSizeLarge},
+				},
+			},
+			{
+				URL:         "https://and-period.jp/thumbnail02.png",
+				IsThumbnail: false,
+				Images: common.Images{
+					{URL: "https://and-period.jp/thumbnail02_240.png", Size: common.ImageSizeSmall},
+					{URL: "https://and-period.jp/thumbnail02_675.png", Size: common.ImageSizeMedium},
+					{URL: "https://and-period.jp/thumbnail02_900.png", Size: common.ImageSizeLarge},
+				},
+			},
+		},
+		Price:            400,
+		DeliveryType:     sentity.DeliveryTypeNormal,
+		Box60Rate:        50,
+		Box80Rate:        40,
+		Box100Rate:       30,
+		OriginPrefecture: "滋賀県",
+		OriginCity:       "彦根市",
+		CreatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		UpdatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
+	}
+	products := sentity.Products{product}
+	liveIn := &store.GetLiveInput{
+		LiveID: "live-id",
+	}
+	live := &sentity.Live{
+		LiveProducts: sentity.LiveProducts{
+			{
+				LiveID:    "live-id",
+				ProductID: "product-id",
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+		},
+		ID:             "live-id",
+		ScheduleID:     "schedule-id",
+		Title:          "配信タイトル",
+		Description:    "配信の説明",
+		Status:         sentity.LiveStatusWaiting,
+		Published:      false,
+		Canceled:       false,
+		ProducerID:     "producer-id",
+		ChannelArn:     "channel-arn",
+		StreamKeyArn:   "streamKey-arn",
+		StartAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		EndAt:          jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		CreatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		UpdatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+		ChannelName:    "配信チャンネル",
+		IngestEndpoint: "ingest-endpoint",
+		StreamKey:      "streamKey-value",
+		StreamID:       "stream-id",
+		PlaybackURL:    "playback-url",
+		ViewerCount:    100,
+	}
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		scheduleID string
+		liveID     string
+		expect     *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.store.EXPECT().MultiGetCategories(gomock.Any(), categoriesIn).Return(categories, nil)
+				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(productTypes, nil)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
+			},
+			scheduleID: "schedule-id",
+			liveID:     "live-id",
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.LiveResponse{
+					Live: &response.Live{
+						ID:           "live-id",
+						ScheduleID:   "schedule-id",
+						Title:        "配信タイトル",
+						Description:  "配信の説明",
+						Status:       1,
+						Published:    false,
+						Canceled:     false,
+						ProducerID:   "producer-id",
+						ProducerName: "&. 管理者",
+						Products: []*response.Product{
+							{
+								ID:              "product-id",
+								TypeID:          "product-type-id",
+								TypeName:        "じゃがいも",
+								TypeIconURL:     "https://and-period.jp/icon.png",
+								CategoryID:      "category-id",
+								CategoryName:    "野菜",
+								ProducerID:      "producer-id",
+								StoreName:       "&.農園",
+								Name:            "新鮮なじゃがいも",
+								Description:     "新鮮なじゃがいもをお届けします。",
+								Public:          true,
+								Inventory:       100,
+								Weight:          1.3,
+								ItemUnit:        "袋",
+								ItemDescription: "1袋あたり100gのじゃがいも",
+								Media: []*response.ProductMedia{
+									{
+										URL:         "https://and-period.jp/thumbnail01.png",
+										IsThumbnail: true,
+										Images: []*response.Image{
+											{URL: "https://and-period.jp/thumbnail01_240.png", Size: int32(service.ImageSizeSmall)},
+											{URL: "https://and-period.jp/thumbnail01_675.png", Size: int32(service.ImageSizeMedium)},
+											{URL: "https://and-period.jp/thumbnail01_900.png", Size: int32(service.ImageSizeLarge)},
+										},
+									},
+									{
+										URL:         "https://and-period.jp/thumbnail02.png",
+										IsThumbnail: false,
+										Images: []*response.Image{
+											{URL: "https://and-period.jp/thumbnail02_240.png", Size: int32(service.ImageSizeSmall)},
+											{URL: "https://and-period.jp/thumbnail02_675.png", Size: int32(service.ImageSizeMedium)},
+											{URL: "https://and-period.jp/thumbnail02_900.png", Size: int32(service.ImageSizeLarge)},
+										},
+									},
+								},
+								Price:            400,
+								DeliveryType:     1,
+								Box60Rate:        50,
+								Box80Rate:        40,
+								Box100Rate:       30,
+								OriginPrefecture: "滋賀県",
+								OriginCity:       "彦根市",
+								CreatedAt:        1640962800,
+								UpdatedAt:        1640962800,
+							},
+						},
+						ChannelArn:     "channel-arn",
+						StreamKeyArn:   "streamKey-arn",
+						StartAt:        1640962800,
+						EndAt:          1640962800,
+						CreatedAt:      1640962800,
+						UpdatedAt:      1640962800,
+						ChannelName:    "配信チャンネル",
+						IngestEndpoint: "ingest-endpoint",
+						StreamKey:      "streamKey-value",
+						StreamID:       "stream-id",
+						PlaybackURL:    "playback-url",
+						ViewerCount:    100,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			const format = "v1/schedules/%s/lives/%s"
+			path := fmt.Sprintf(format, tt.scheduleID, tt.liveID)
+			testGet(t, tt.setup, tt.expect, path)
+		})
+	}
+}

--- a/api/internal/gateway/admin/v1/handler/live_test.go
+++ b/api/internal/gateway/admin/v1/handler/live_test.go
@@ -14,6 +14,7 @@ import (
 	uentity "github.com/and-period/furumaru/api/internal/user/entity"
 	"github.com/and-period/furumaru/api/pkg/jst"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLive(t *testing.T) {
@@ -245,6 +246,87 @@ func TestGetLive(t *testing.T) {
 						ViewerCount:    100,
 					},
 				},
+			},
+		},
+		{
+			name: "failed to get live",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(nil, assert.AnError)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "failed to get producer",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(nil, assert.AnError)
+				mocks.user.EXPECT().MultiGetProducers(gomock.Any(), producersIn).Return(producers, nil)
+				mocks.store.EXPECT().MultiGetCategories(gomock.Any(), categoriesIn).Return(categories, nil)
+				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(productTypes, nil)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "failed to multi get producers",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.user.EXPECT().MultiGetProducers(gomock.Any(), producersIn).Return(nil, assert.AnError)
+				mocks.store.EXPECT().MultiGetCategories(gomock.Any(), categoriesIn).Return(categories, nil)
+				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(productTypes, nil)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "failed to get catogory",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.user.EXPECT().MultiGetProducers(gomock.Any(), producersIn).Return(producers, nil)
+				mocks.store.EXPECT().MultiGetCategories(gomock.Any(), categoriesIn).Return(nil, assert.AnError)
+				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(productTypes, nil)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "failed to get product type",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.user.EXPECT().MultiGetProducers(gomock.Any(), producersIn).Return(producers, nil)
+				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(nil, assert.AnError)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "failed to multi get products",
+			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
+				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(nil, assert.AnError)
+			},
+			liveID: "live-id",
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
 			},
 		},
 	}

--- a/api/internal/gateway/admin/v1/handler/live_test.go
+++ b/api/internal/gateway/admin/v1/handler/live_test.go
@@ -19,35 +19,11 @@ import (
 func TestGetLive(t *testing.T) {
 	t.Parallel()
 
-	coordinatorIn := &user.GetCoordinatorInput{
-		CoordinatorID: "coordinator-id",
-	}
-	coordinator := &uentity.Coordinator{
-		Admin: uentity.Admin{
-			ID:            "coordinator-id",
-			Lastname:      "&.",
-			Firstname:     "管理者",
-			LastnameKana:  "あんどどっと",
-			FirstnameKana: "かんりしゃ",
-			Email:         "test-coordinator@and-period.jp",
-		},
-		AdminID:          "coordinator-id",
-		CompanyName:      "&.株式会社",
-		StoreName:        "&.農園",
-		ThumbnailURL:     "https://and-period.jp/thumbnail.png",
-		HeaderURL:        "https://and-period.jp/header.png",
-		TwitterAccount:   "twitter-id",
-		InstagramAccount: "instagram-id",
-		FacebookAccount:  "facebook-id",
-		PhoneNumber:      "+819012345678",
-		PostalCode:       "1000014",
-		Prefecture:       "東京都",
-		City:             "千代田区",
-		CreatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
-		UpdatedAt:        jst.Date(2022, 1, 1, 0, 0, 0, 0),
-	}
 	producerIn := &user.GetProducerInput{
 		ProducerID: "producer-id",
+	}
+	producersIn := &user.MultiGetProducersInput{
+		ProducerIDs: []string{"producer-id"},
 	}
 	producer := &uentity.Producer{
 		Admin: uentity.Admin{
@@ -70,6 +46,7 @@ func TestGetLive(t *testing.T) {
 		CreatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
 		UpdatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
 	}
+	producers := uentity.Producers{producer}
 	categoriesIn := &store.MultiGetCategoriesInput{
 		CategoryIDs: []string{"category-id"},
 	}
@@ -185,8 +162,8 @@ func TestGetLive(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
 				mocks.store.EXPECT().GetLive(gomock.Any(), liveIn).Return(live, nil)
-				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.user.EXPECT().GetProducer(gomock.Any(), producerIn).Return(producer, nil)
+				mocks.user.EXPECT().MultiGetProducers(gomock.Any(), producersIn).Return(producers, nil)
 				mocks.store.EXPECT().MultiGetCategories(gomock.Any(), categoriesIn).Return(categories, nil)
 				mocks.store.EXPECT().MultiGetProductTypes(gomock.Any(), productTypesIn).Return(productTypes, nil)
 				mocks.store.EXPECT().MultiGetProducts(gomock.Any(), productsIn).Return(products, nil)
@@ -275,7 +252,7 @@ func TestGetLive(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			const format = "v1/schedules/%s/lives/%s"
+			const format = "/v1/schedules/%s/lives/%s"
 			path := fmt.Sprintf(format, tt.scheduleID, tt.liveID)
 			testGet(t, tt.setup, tt.expect, path)
 		})

--- a/api/internal/gateway/admin/v1/response/live.go
+++ b/api/internal/gateway/admin/v1/response/live.go
@@ -14,16 +14,16 @@ type Live struct {
 	Canceled       bool       `json:"canceled"`       // 配信中止
 	Status         int32      `json:"status"`         // 配信ステータス
 	Products       []*Product `json:"products"`       // 商品一覧
-	ChannelArn     string     `json:"ChannelArn"`     // チャンネルArn
-	StreamKeyArn   string     `json:"StreamKeyArn"`   // ストリームキーArn
+	ChannelArn     string     `json:"channelArn"`     // チャンネルArn
+	StreamKeyArn   string     `json:"streamKeyArn"`   // ストリームキーArn
 	CreatedAt      int64      `json:"createdAt"`      // 作成日時
-	UpdatedAt      int64      `json:"UpdatedAt"`      // 作成日時
-	ChannelName    string     `json:"ChannelName"`    // チャンネル名
-	IngestEndpoint string     `json:"IngestEndpoint"` // 配信エンドポイント
-	StreamKey      string     `json:"StreamKey"`      // ストリームキー
-	StreamID       string     `json:"SrtreamID"`      // ストリームID
-	PlaybackURL    string     `json:"PlaybackURL"`    // 再生用URL
-	ViewerCount    int64      `json:"ViewerCount"`    // 視聴者数
+	UpdatedAt      int64      `json:"updatedAt"`      // 作成日時
+	ChannelName    string     `json:"channelName"`    // チャンネル名
+	IngestEndpoint string     `json:"ingestEndpoint"` // 配信エンドポイント
+	StreamKey      string     `json:"streamKey"`      // ストリームキー
+	StreamID       string     `json:"srtreamID"`      // ストリームID
+	PlaybackURL    string     `json:"playbackURL"`    // 再生用URL
+	ViewerCount    int64      `json:"viewerCount"`    // 視聴者数
 }
 
 type LiveResponse struct {

--- a/api/internal/gateway/admin/v1/response/live.go
+++ b/api/internal/gateway/admin/v1/response/live.go
@@ -2,20 +2,28 @@ package response
 
 // 配信情報
 type Live struct {
-	ID           string     `json:"id"`           // ライブ配信ID
-	ScheduleID   string     `json:"scheduleId"`   // スケジュールID
-	Title        string     `json:"title"`        // タイトル
-	Description  string     `json:"description"`  // 説明
-	ProducerID   string     `json:"producerId"`   // 生産者ID
-	ProducerName string     `json:"producerName"` // 生産者名
-	StartAt      int64      `json:"startAt"`      // 配信開始日時
-	EndAt        int64      `json:"endAt"`        // 配信終了日時
-	Published    bool       `json:"published"`    // 配信公開フラグ
-	Canceled     bool       `json:"canceled"`     // 配信中止
-	Status       int32      `json:"status"`       // 配信ステータス
-	Products     []*Product `json:"products"`     // 商品一覧
-	CreatedAt    int64      `json:"createdAt"`    // 作成日時
-	UpdatedAt    int64      `json:"UpdatedAt"`    // 作成日時
+	ID             string     `json:"id"`             // ライブ配信ID
+	ScheduleID     string     `json:"scheduleId"`     // スケジュールID
+	Title          string     `json:"title"`          // タイトル
+	Description    string     `json:"description"`    // 説明
+	ProducerID     string     `json:"producerId"`     // 生産者ID
+	ProducerName   string     `json:"producerName"`   // 生産者名
+	StartAt        int64      `json:"startAt"`        // 配信開始日時
+	EndAt          int64      `json:"endAt"`          // 配信終了日時
+	Published      bool       `json:"published"`      // 配信公開フラグ
+	Canceled       bool       `json:"canceled"`       // 配信中止
+	Status         int32      `json:"status"`         // 配信ステータス
+	Products       []*Product `json:"products"`       // 商品一覧
+	ChannelArn     string     `json:"ChannelArn"`     // チャンネルArn
+	StreamKeyArn   string     `json:"StreamKeyArn"`   // ストリームキーArn
+	CreatedAt      int64      `json:"createdAt"`      // 作成日時
+	UpdatedAt      int64      `json:"UpdatedAt"`      // 作成日時
+	ChannelName    string     `json:"ChannelName"`    // チャンネル名
+	IngestEndpoint string     `json:"IngestEndpoint"` // 配信エンドポイント
+	StreamKey      string     `json:"StreamKey"`      // ストリームキー
+	StreamID       string     `json:"SrtreamID"`      // ストリームID
+	PlaybackURL    string     `json:"PlaybackURL"`    // 再生用URL
+	ViewerCount    int64      `json:"ViewerCount"`    // 視聴者数
 }
 
 type LiveResponse struct {

--- a/api/internal/gateway/admin/v1/service/live.go
+++ b/api/internal/gateway/admin/v1/service/live.go
@@ -18,7 +18,7 @@ const (
 
 type Live struct {
 	response.Live
-	productIDs []string
+	ProductIDs []string
 }
 
 type Lives []*Live
@@ -45,19 +45,27 @@ func (s LiveStatus) Response() int32 {
 func NewLive(live *entity.Live) *Live {
 	return &Live{
 		Live: response.Live{
-			ID:          live.ID,
-			ScheduleID:  live.ScheduleID,
-			Title:       live.Title,
-			Description: live.Description,
-			ProducerID:  live.ProducerID,
-			StartAt:     live.StartAt.Unix(),
-			EndAt:       live.EndAt.Unix(),
-			Canceled:    live.Canceled,
-			Status:      NewLiveStatus(live.Status).Response(),
-			CreatedAt:   live.CreatedAt.Unix(),
-			UpdatedAt:   live.UpdatedAt.Unix(),
+			ID:             live.ID,
+			ScheduleID:     live.ScheduleID,
+			Title:          live.Title,
+			Description:    live.Description,
+			ProducerID:     live.ProducerID,
+			StartAt:        live.StartAt.Unix(),
+			EndAt:          live.EndAt.Unix(),
+			Canceled:       live.Canceled,
+			Status:         NewLiveStatus(live.Status).Response(),
+			ChannelArn:     live.ChannelArn,
+			StreamKeyArn:   live.StreamKeyArn,
+			CreatedAt:      live.CreatedAt.Unix(),
+			UpdatedAt:      live.UpdatedAt.Unix(),
+			ChannelName:    live.ChannelName,
+			IngestEndpoint: live.IngestEndpoint,
+			StreamKey:      live.StreamKey,
+			StreamID:       live.StreamID,
+			PlaybackURL:    live.PlaybackURL,
+			ViewerCount:    live.ViewerCount,
 		},
-		productIDs: live.LiveProducts.ProductIDs(),
+		ProductIDs: live.LiveProducts.ProductIDs(),
 	}
 }
 
@@ -65,13 +73,13 @@ func (l *Live) Fill(producer *Producer, products map[string]*Product) {
 	if producer != nil {
 		l.ProducerName = producer.Name()
 	}
-	ps := make(Products, len(l.productIDs))
-	for i, productID := range l.productIDs {
+	ps := make(Products, 0, len(l.ProductIDs))
+	for _, productID := range l.ProductIDs {
 		p, ok := products[productID]
 		if !ok {
 			continue
 		}
-		ps[i] = p
+		ps = append(ps, p)
 	}
 	l.Products = ps.Response()
 }

--- a/api/internal/gateway/admin/v1/service/live_test.go
+++ b/api/internal/gateway/admin/v1/service/live_test.go
@@ -56,7 +56,7 @@ func TestLive(t *testing.T) {
 					CreatedAt:   1640962800,
 					UpdatedAt:   1640962800,
 				},
-				productIDs: []string{"product-id"},
+				ProductIDs: []string{"product-id"},
 			},
 		},
 	}
@@ -99,7 +99,7 @@ func TestLive_Fill(t *testing.T) {
 					CreatedAt:    1640962800,
 					UpdatedAt:    1640962800,
 				},
-				productIDs: []string{"product-id"},
+				ProductIDs: []string{"product-id"},
 			},
 			producer: &Producer{
 				Producer: response.Producer{
@@ -223,7 +223,7 @@ func TestLive_Fill(t *testing.T) {
 					CreatedAt:    1640962800,
 					UpdatedAt:    1640962800,
 				},
-				productIDs: []string{"product-id"},
+				ProductIDs: []string{"product-id"},
 			},
 		},
 	}

--- a/api/internal/store/service.go
+++ b/api/internal/store/service.go
@@ -73,6 +73,8 @@ type Service interface {
 	DeletePromotion(ctx context.Context, in *DeletePromotionInput) error
 	// 開催スケジュール登録
 	CreateSchedule(ctx context.Context, in *CreateScheduleInput) (*entity.Schedule, entity.Lives, error)
+	// 配信詳細取得
+	GetLive(ctx context.Context, in *GetLiveInput) (*entity.Live, error)
 	// 注文履歴一覧取得
 	ListOrders(ctx context.Context, in *ListOrdersInput) (entity.Orders, int64, error)
 	// 注文履歴取得

--- a/api/mock/store/service.go
+++ b/api/mock/store/service.go
@@ -227,6 +227,21 @@ func (mr *MockServiceMockRecorder) GetCategory(ctx, in interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCategory", reflect.TypeOf((*MockService)(nil).GetCategory), ctx, in)
 }
 
+// GetLive mocks base method.
+func (m *MockService) GetLive(ctx context.Context, in *store.GetLiveInput) (*entity.Live, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLive", ctx, in)
+	ret0, _ := ret[0].(*entity.Live)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLive indicates an expected call of GetLive.
+func (mr *MockServiceMockRecorder) GetLive(ctx, in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLive", reflect.TypeOf((*MockService)(nil).GetLive), ctx, in)
+}
+
 // GetOrder mocks base method.
 func (m *MockService) GetOrder(ctx context.Context, in *store.GetOrderInput) (*entity.Order, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- 権限追加
- liveのresponse修正
- GetLiveのGateway追加
- make mockgen

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->
https://calmato.kibe.la/notes/727#%E3%83%95%E3%83%AD%E3%83%BC

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
テスト落ちます…助けてください…
```
=== CONT  TestGetLive/success
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/api_test.go:246:
        	Error Trace:	/Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/api_test.go:246
        	            				/Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/api_test.go:154
        	            				/Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:280
        	Error:      	Not equal:
        	            	expected: 200
        	            	actual  : 404
        	Test:       	TestGetLive/success
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_store.MockService.MultiGetProducts(is anything, is equal to &{[product-id]} (*store.MultiGetProductsInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:192
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_store.MockService.GetLive(is anything, is equal to &{live-id} (*store.GetLiveInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:187
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_user.MockService.GetCoordinator(is anything, is equal to &{coordinator-id} (*user.GetCoordinatorInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:188
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_user.MockService.GetProducer(is anything, is equal to &{producer-id} (*user.GetProducerInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:189
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_store.MockService.MultiGetCategories(is anything, is equal to &{[category-id]} (*store.MultiGetCategoriesInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:190
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: missing call(s) to *mock_store.MockService.MultiGetProductTypes(is anything, is equal to &{[product-type-id]} (*store.MultiGetProductTypesInput)) /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/live_test.go:191
    /Users/kaito/Documents/calmato/marche/api/internal/gateway/admin/v1/handler/controller.go:269: aborting test due to missing call(s)
--- FAIL: TestGetLive (0.00s)
    --- FAIL: TestGetLive/success (0.00s)
```
