### PR TITLE
データテーブルから「編集」ボタンで詳細画面に遷移する部分を行クリックで遷移するように書き換えた

### DIFF
--- a/web/admin/src/components/molecules/ShippingRateForm.vue
+++ b/web/admin/src/components/molecules/ShippingRateForm.vue
@@ -1,0 +1,73 @@
+<script setup lang='ts'>
+import useVuelidate from '@vuelidate/core'
+import { PrefecturesListSelectItems } from '~/lib/prefectures'
+import { required, getErrorMessage, minValue, minLengthArray } from '~/lib/validations'
+import { CreateShippingRate } from '~/types/api'
+
+interface Props {
+  modelValue: CreateShippingRate
+  selectablePrefectureList: PrefecturesListSelectItems[]
+}
+
+const props = defineProps<Props>()
+
+interface Emits {
+  (e: 'update:modelValue', val: CreateShippingRate): void
+  (e: 'click:selectAll'): void
+}
+
+const emits = defineEmits<Emits>()
+
+const formDataValue = computed({
+  get: () => props.modelValue,
+  set: (val: CreateShippingRate) => emits('update:modelValue', val)
+})
+
+const rules = computed(() => {
+  return {
+    name: { required },
+    price: { required, minValue: minValue(1) },
+    prefectures: { minLengthArray: minLengthArray(1) }
+  }
+})
+
+const v$ = useVuelidate<CreateShippingRate>(rules, formDataValue)
+
+const handleClickSelectAll = () => {
+  emits('click:selectAll')
+}
+</script>
+
+<template>
+  <v-text-field
+    v-model="v$.name.$model"
+    label="名前"
+    :error-messages="getErrorMessage(v$.name.$errors)"
+  />
+  <v-text-field
+    v-model.number="formDataValue.price"
+    label="価格"
+    type="number"
+    :error-messages="getErrorMessage(v$.price.$errors)"
+  />
+  <v-select
+    v-model="v$.prefectures.$model"
+    label="都道府県"
+    chips
+    multiple
+    :items="selectablePrefectureList"
+    :error-messages="getErrorMessage(v$.prefectures.$errors)"
+    item-title="text"
+    item-value="value"
+  >
+    <template #prepend-item>
+      <v-list-item
+        ripple
+        @click="handleClickSelectAll"
+        @mousedown.prevent
+      >
+        <v-list-item-title> すべて選択 </v-list-item-title>
+      </v-list-item>
+    </template>
+  </v-select>
+</template>

--- a/web/admin/src/components/templates/ContactList.vue
+++ b/web/admin/src/components/templates/ContactList.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
   (e: 'click:update-page', page: number): void
   (e: 'click:update-items-per-page', page: number): void
   (e: 'click:update-sort-by'): void
-  (e: 'click:edit', categoryId: string): void
+  (e: 'click:row', item: ContactsResponseContactsInner): void
   (e: 'update:sort-by', sortBy: VDataTable['sortBy']): void
 }>()
 
@@ -64,11 +64,6 @@ const headers: VDataTable['headers'] = [
   {
     title: 'ステータス',
     key: 'status'
-  },
-  {
-    title: 'Actions',
-    key: 'actions',
-    sortable: false
   }
 ]
 
@@ -140,8 +135,8 @@ const onClickUpdateSortBy = (sortBy: VDataTable['sortBy']): void => {
   emit('update:sort-by', sortBy)
 }
 
-const onClickEdit = (contactId: string): void => {
-  emit('click:edit', contactId)
+const onClickRow = (contactItem: ContactsResponseContactsInner): void => {
+  emit('click:row', contactItem)
 }
 </script>
 
@@ -156,10 +151,12 @@ const onClickEdit = (contactId: string): void => {
         :items-per-page="props.tableItemsPerPage"
         :items-length="props.tableItemsTotal"
         :multi-sort="true"
+        hover
         :sort-by="props.sortBy"
         @update:page="onClickUpdatePage"
         @update:items-per-page="onClickUpdateItemsPerPage"
         @update:sort-by="onClickUpdateSortBy"
+        @click:row="(_:any, {item}: any) => onClickRow(item.raw)"
       >
         <template #[`item.priority`]="{ item }">
           <v-chip :color="getPriorityColor(item.raw.priority)" size="small">
@@ -170,12 +167,6 @@ const onClickEdit = (contactId: string): void => {
           <v-chip :color="getStatusColor(item.raw.status)" size="small">
             {{ getStatus(item.raw.status) }}
           </v-chip>
-        </template>
-        <template #[`item.actions`]="{ item }">
-          <v-btn variant="outlined" color="primary" size="small" @click="onClickEdit(item.raw.id)">
-            <v-icon size="small" :icon="mdiPencil" />
-            編集
-          </v-btn>
         </template>
       </v-data-table-server>
     </v-card-text>

--- a/web/admin/src/lib/prefectures/helper.ts
+++ b/web/admin/src/lib/prefectures/helper.ts
@@ -1,7 +1,7 @@
 import { prefecturesList, PrefecturesListItem } from '~/constants'
 import { CreateShippingRate } from '~/types/api'
 
-interface PrefecturesListSelectItems extends PrefecturesListItem {
+export interface PrefecturesListSelectItems extends PrefecturesListItem {
   disabled: boolean
 }
 

--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -10,6 +10,8 @@ import {
   sameAs as _sameAs
 } from '@vuelidate/validators'
 
+import { isRef } from 'vue'
+
 /**
  * ひらがなを判定する関数
  * @param value
@@ -113,6 +115,22 @@ const sameAs = (equalTo: unknown, otherName?: string) =>
     _sameAs(equalTo, otherName)
   )
 
+/**
+ * 配列の最小の長さのバリデーションルール（カスタム）
+ * @param minLength 最小の要素数
+ * @returns
+ */
+const minLengthArray = (minLength: number | Ref<number>) => {
+  const minLengthValue = isRef(minLength) ? minLength.value : minLength
+  return helpers.withMessage(
+    `少なくとも${minLengthValue}つ以上選択してください。`,
+    helpers.withParams(
+      { type: 'minLengthArray', minLength },
+      value => Array.isArray(value) && value.length >= minLengthValue
+    )
+  )
+}
+
 export {
   kana,
   tel,
@@ -123,5 +141,6 @@ export {
   maxLength,
   minValue,
   maxValue,
-  sameAs
+  sameAs,
+  minLengthArray
 }

--- a/web/admin/src/pages/contacts/index.vue
+++ b/web/admin/src/pages/contacts/index.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { VDataTable } from 'vuetify/lib/labs/components'
 
+import { ContactsResponseContactsInner } from '~/types/api'
 import { useAlert, usePagination } from '~/lib/hooks'
 import { useContactStore } from '~/store'
 
@@ -60,8 +61,8 @@ const handleClickSortBy = (item: VDataTable['sortBy']): void => {
   sortBy.splice(0, sortBy.length, ...item)
 }
 
-const handleEditCategory = (contactId: string) => {
-  router.push(`/contacts/edit/${contactId}`)
+const handleRowClick = (contactItem: ContactsResponseContactsInner) => {
+  router.push(`/contacts/edit/${contactItem.id}`)
 }
 
 const isLoading = (): boolean => {
@@ -87,7 +88,7 @@ try {
     :table-items-total="contactTotal"
     @click:update-page="handleUpdatePage"
     @click:update-items-per-page="handleUpdateItemsPerPage"
-    @click:edit="handleEditCategory"
+    @click:row="handleRowClick"
     @update:sort-by="handleClickSortBy"
   />
 </template>

--- a/web/admin/src/pages/coordinators/edit/[id].vue
+++ b/web/admin/src/pages/coordinators/edit/[id].vue
@@ -241,103 +241,106 @@ try {
   <div>
     <v-card-title>コーディネーター編集</v-card-title>
 
-    <v-tabs v-model="tab" grow color="dark">
-      <v-tabs-slider color="accent" />
-      <v-tab
-        v-for="tabItem in tabItems"
-        :key="tabItem.value"
-        :value="tabItem.value"
-      >
-        {{ tabItem.name }}
-      </v-tab>
-    </v-tabs>
+    <v-card>
+      <v-tabs v-model="tab" grow color="dark">
+        <v-tabs-slider color="accent" />
+        <v-tab
+          v-for="tabItem in tabItems"
+          :key="tabItem.value"
+          :value="tabItem.value"
+        >
+          {{ tabItem.name }}
+        </v-tab>
+      </v-tabs>
 
-    <v-window v-model="tab">
-      <v-window-item value="coordinators">
-        <v-skeleton-loader v-if="isLoading()" type="article" />
+      <v-window v-model="tab">
+        <v-window-item value="coordinators">
+          <v-skeleton-loader v-if="isLoading()" type="article" />
 
-        <organisms-coordinator-edit-form
-          v-else
-          :form-data="formData"
-          :thumbnail-upload-status="thumbnailUploadStatus"
-          :header-upload-status="headerUploadStatus"
-          :search-loading="searchLoading"
-          :search-error-message="searchErrorMessage"
-          @update:thumbnail-file="handleUpdateThumbnail"
-          @update:header-file="handleUpdateHeader"
-          @submit="handleSubmit"
-          @click:search="searchAddress"
-        />
-      </v-window-item>
+          <organisms-coordinator-edit-form
+            v-else
+            :form-data="formData"
+            :thumbnail-upload-status="thumbnailUploadStatus"
+            :header-upload-status="headerUploadStatus"
+            :search-loading="searchLoading"
+            :search-error-message="searchErrorMessage"
+            @update:thumbnail-file="handleUpdateThumbnail"
+            @update:header-file="handleUpdateHeader"
+            @submit="handleSubmit"
+            @click:search="searchAddress"
+          />
+        </v-window-item>
 
-      <v-window-item value="relationProducers">
-        <v-dialog v-model="dialog" width="500">
-          <template #activator="{ props }">
-            <div class="d-flex pt-3 pr-3">
-              <v-spacer />
-              <v-btn variant="outlined" color="primary" v-bind="props">
-                <v-icon start :icon="mdiPlus" />
+        <v-window-item value="relationProducers">
+          <v-dialog v-model="dialog" width="500">
+            <template #activator="{ props }">
+              <div class="d-flex pt-3 pr-3">
+                <v-spacer />
+                <v-btn variant="outlined" color="primary" v-bind="props">
+                  <v-icon start :icon="mdiPlus" />
+                  生産者紐付け
+                </v-btn>
+              </div>
+            </template>
+            <v-card>
+              <v-card-title class="primaryLight">
                 生産者紐付け
-              </v-btn>
-            </div>
-          </template>
+              </v-card-title>
 
-          <v-card>
-            <v-card-title class="primaryLight">
-              生産者紐付け
-            </v-card-title>
-
-            <v-autocomplete
-              v-model="producers"
-              chips
-              label="関連生産者"
-              multiple
-              filled
-              :items="producerItems"
-              item-title="firstname"
-              item-value="id"
-            >
-              <template #selection="data">
-                <v-chip close @click:close="remove(data.item.id)">
-                  <v-avatar start>
-                    <v-img :src="data.item.thumbnailUrl" />
-                  </v-avatar>
-                  {{ data.item.firstname }}
-                </v-chip>
-              </template>
-              <template #item="data">
-                <v-list-item-avatar>
-                  <img :src="data.item.thumbnailUrl">
-                </v-list-item-avatar>
-                <v-list-item-content>
-                  <v-list-item-title>
+              <v-autocomplete
+                v-model="producers"
+                chips
+                label="関連生産者"
+                multiple
+                filled
+                :items="producerItems"
+                item-title="firstname"
+                item-value="id"
+              >
+                <template #selection="data">
+                  <v-chip close @click:close="remove(data.item.id)">
+                    <v-avatar start>
+                      <v-img :src="data.item.thumbnailUrl" />
+                    </v-avatar>
                     {{ data.item.firstname }}
-                  </v-list-item-title>
-                  <v-list-item-subtitle>
-                    {{ data.item.storeName }}
-                  </v-list-item-subtitle>
-                </v-list-item-content>
-              </template>
-            </v-autocomplete>
+                  </v-chip>
+                </template>
+                <template #item="data">
+                  <v-list-item-avatar>
+                    <img :src="data.item.thumbnailUrl">
+                  </v-list-item-avatar>
+                  <v-list-item-content>
+                    <v-list-item-title>
+                      {{ data.item.firstname }}
+                    </v-list-item-title>
+                    <v-list-item-subtitle>
+                      {{ data.item.storeName }}
+                    </v-list-item-subtitle>
+                  </v-list-item-content>
+                </template>
+              </v-autocomplete>
 
-            <v-card-actions>
-              <v-spacer />
-              <v-btn color="error" variant="text" @click="cancel">
-                キャンセル
-              </v-btn>
-              <v-btn color="primary" variant="outlined" @click="relateProducers">
-                更新
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
+              <v-card-actions>
+                <v-spacer />
+                <v-btn color="error" variant="text" @click="cancel">
+                  キャンセル
+                </v-btn>
+                <v-btn color="primary" variant="outlined" @click="relateProducers">
+                  更新
+                </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
 
-        <organisms-related-producer-list
-          :table-footer-props="producersOptions"
-          @update:items-per-page="handleUpdateProducersItemsPerPage"
-          @update:page="handleUpdateProducersPage"
-        />
-      </v-window-item>
-    </v-window>
+          <v-card-text>
+            <organisms-related-producer-list
+              :table-footer-props="producersOptions"
+              @update:items-per-page="handleUpdateProducersItemsPerPage"
+              @update:page="handleUpdateProducersPage"
+            />
+          </v-card-text>
+        </v-window-item>
+      </v-window>
+    </v-card>
   </div>
 </template>

--- a/web/admin/src/pages/coordinators/index.vue
+++ b/web/admin/src/pages/coordinators/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { mdiPlus, mdiSearchWeb, mdiAccount, mdiPencil, mdiDelete } from '@mdi/js'
+import { mdiPlus, mdiAccount, mdiDelete } from '@mdi/js'
 import { VDataTable } from 'vuetify/labs/components'
 
 import { useAlert, usePagination } from '~/lib/hooks'
@@ -95,7 +95,7 @@ const handleClickAddButton = () => {
   router.push('/coordinators/add')
 }
 
-const handleEdit = (item: CoordinatorsResponseCoordinatorsInner) => {
+const handleClickRow = (item: CoordinatorsResponseCoordinatorsInner) => {
   router.push(`/coordinators/edit/${item.id}`)
 }
 
@@ -191,12 +191,13 @@ try {
         <v-data-table-server
           :headers="headers"
           :items="coordinators"
-          :no-results-text="noResultsText"
           :items-length="totalItems"
           :footer-props="options"
+          hover
           no-data-text="登録されているコーディネータがいません。"
           @update:items-per-page="handleUpdateItemsPerPage"
           @update:page="handleUpdatePage"
+          @click:row="(_:any, {item}: any) => handleClickRow(item.raw)"
         >
           <template #[`item.thumbnail`]="{ item }">
             <v-avatar>
@@ -217,15 +218,11 @@ try {
             {{ `${item.raw.phoneNumber}`.replace('+81', '0') }}
           </template>
           <template #[`item.actions`]="{ item }">
-            <v-btn class="mr-2" variant="outlined" color="primary" size="small" @click="handleEdit(item.raw)">
-              <v-icon size="small" :icon="mdiPencil" />
-              編集
-            </v-btn>
             <v-btn
               variant="outlined"
               color="primary"
               size="small"
-              @click="handleClickDeleteButton(item.raw)"
+              @click.stop="handleClickDeleteButton(item.raw)"
             >
               <v-icon size="small" :icon="mdiDelete" />
               削除

--- a/web/admin/src/pages/customers/edit/[id].vue
+++ b/web/admin/src/pages/customers/edit/[id].vue
@@ -3,6 +3,7 @@ import { VDataTable } from 'vuetify/lib/labs/components'
 import { Customer } from '~/types/props/customer'
 
 const tab = ref<string>('customers')
+
 const tabItems: Customer[] = [
   { name: '顧客情報', value: 'customers' },
   { name: '購入に関して', value: 'customerItems' }
@@ -72,85 +73,88 @@ const items = [
 <template>
   <div>
     <v-card-title>顧客管理</v-card-title>
-    <v-tabs v-model="tab" grow color="dark">
-      <v-tabs-slider color="accent" />
-      <v-tab
-        v-for="tabItem in tabItems"
-        :key="tabItem.value"
-        :href="`#${tabItem.value}`"
-      >
-        {{ tabItem.name }}
-      </v-tab>
-    </v-tabs>
 
-    <v-tabs-items v-model="tab">
-      <v-tab-item value="customers">
-        <v-card-text>
-          <v-text-field name="name" label="名前" value="testName" readonly />
+    <v-card>
+      <v-tabs v-model="tab" grow color="dark">
+        <v-tabs-slider color="accent" />
+        <v-tab
+          v-for="tabItem in tabItems"
+          :key="tabItem.value"
+          :value="tabItem.value"
+        >
+          {{ tabItem.name }}
+        </v-tab>
+      </v-tabs>
 
-          <span>アカウントの有無：</span>
-          <v-chip color="primary">
-            {{ accountValue }}
-          </v-chip>
+      <v-card-text>
+        <v-window v-model="tab">
+          <v-window-item value="customers">
+            <v-text-field name="name" label="名前" value="testName" readonly />
 
-          <v-text-field
-            name="email"
-            label="連絡先:Email"
-            value="and-period-assistant@gmail.com"
-            readonly
-          />
+            <span>アカウントの有無：</span>
+            <v-chip color="primary">
+              {{ accountValue }}
+            </v-chip>
 
-          <v-text-field
-            name="telePhone"
-            label="連絡先:電話番号"
-            value="09012345678"
-            readonly
-          />
+            <v-text-field
+              name="email"
+              label="連絡先:Email"
+              value="and-period-assistant@gmail.com"
+              readonly
+            />
 
-          <v-text-field
-            name="prefecture"
-            label="都道府県"
-            value="広島県"
-            readonly
-          />
+            <v-text-field
+              name="telePhone"
+              label="連絡先:電話番号"
+              value="09012345678"
+              readonly
+            />
 
-          <v-text-field
-            name="city"
-            label="市区町村"
-            value="豊田郡大崎上島町"
-            readonly
-          />
+            <v-text-field
+              name="prefecture"
+              label="都道府県"
+              value="広島県"
+              readonly
+            />
 
-          <v-text-field
-            name="address"
-            label="番地"
-            value="2067番地1"
-            readonly
-          />
+            <v-text-field
+              name="city"
+              label="市区町村"
+              value="豊田郡大崎上島町"
+              readonly
+            />
 
-          <v-text-field
-            name="building"
-            label="建物名・部屋番号"
-            value="フルマルビルディング 201"
-            readonly
-          />
-        </v-card-text>
-      </v-tab-item>
+            <v-text-field
+              name="address"
+              label="番地"
+              value="2067番地1"
+              readonly
+            />
 
-      <v-tab-item value="customerItems">
-        <v-data-table :headers="headers" :items="items">
-          <template #foot>
-            <tfoot>
-              <tr>
-                <td :colspan="headers.length - 1">
-                  合計
-                </td>
-                <td>¥21,000</td>
-              </tr>
-            </tfoot>
-          </template>
-        </v-data-table>
-      </v-tab-item>
-    </v-tabs-items>
+            <v-text-field
+              name="building"
+              label="建物名・部屋番号"
+              value="フルマルビルディング 201"
+              readonly
+            />
+          </v-window-item>
+
+          <v-window-item value="customerItems">
+            <v-data-table :headers="headers" :items="items">
+              <template #foot>
+                <tfoot>
+                  <tr>
+                    <td :colspan="headers.length - 1">
+                      合計
+                    </td>
+                    <td>¥21,000</td>
+                  </tr>
+                </tfoot>
+              </template>
+            </v-data-table>
+          </v-window-item>
+        </v-window>
+      </v-card-text>
+    </v-card>
   </div>
 </template>

--- a/web/admin/src/pages/customers/index.vue
+++ b/web/admin/src/pages/customers/index.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import { VDataTable } from 'vuetify/labs/components'
-import { mdiPencil, mdiDelete } from '@mdi/js'
+import { mdiDelete } from '@mdi/js'
 
 import { usePagination } from '~/lib/hooks'
 import { useUserStore } from '~/store/customer'
+import { UsersResponseUsersInner } from '~/types/api'
 
 const router = useRouter()
 const userStore = useUserStore()
@@ -14,7 +15,6 @@ const {
   updateCurrentPage,
   handleUpdateItemsPerPage
 } = usePagination()
-const id = 'ThisIsID'
 
 const headers: VDataTable['headers'] = [
   {
@@ -39,7 +39,8 @@ const headers: VDataTable['headers'] = [
   },
   {
     title: 'Action',
-    key: 'action'
+    key: 'action',
+    sortable: false
   }
 ]
 
@@ -79,8 +80,12 @@ const registerStatus = (registered: boolean): string => {
   return registered ? '有' : '無'
 }
 
-const handleEdit = () => {
-  router.push(`/customers/edit/${id}`)
+const handleRowClick = (item: UsersResponseUsersInner): void => {
+  router.push(`/customers/edit/${item.id}`)
+}
+
+const handleDeleteButtonClick = () => {
+  console.log('削除ボタンクリック')
 }
 
 try {
@@ -101,8 +106,10 @@ try {
           :items-per-page="itemsPerPage"
           :footer-props="options"
           no-data-text="登録されている顧客情報がありません"
+          hover
           @update:page="handleUpdatePage"
           @update:items-per-page="handleUpdateItemsPerPage"
+          @click:row="(_: any, { item }: any) => handleRowClick(item.raw)"
         >
           <template #[`item.name`]="{ item }">
             {{ `${item.raw.lastname} ${item.raw.firstname}` }}
@@ -116,11 +123,7 @@ try {
             </v-chip>
           </template>
           <template #[`item.action`]>
-            <v-btn class="mr-2" variant="outlined" color="primary" size="small" @click="handleEdit()">
-              <v-icon size="small" :icon="mdiPencil" />
-              詳細
-            </v-btn>
-            <v-btn variant="outlined" color="primary" size="small">
+            <v-btn variant="outlined" color="primary" size="small" @click.stop="handleDeleteButtonClick">
               <v-icon size="small" :icon="mdiDelete" />
               削除
             </v-btn>

--- a/web/admin/src/pages/notifications/index.vue
+++ b/web/admin/src/pages/notifications/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { mdiPlus, mdiPencil, mdiDelete } from '@mdi/js'
+import { mdiPlus, mdiDelete } from '@mdi/js'
 import * as dayjs from 'dayjs'
 import { VDataTable } from 'vuetify/labs/components'
 
@@ -129,7 +129,7 @@ const handleClickAddButton = () => {
   router.push('/notifications/add')
 }
 
-const handleEdit = (item: NotificationsResponseNotificationsInner) => {
+const handleClickRow = (item: NotificationsResponseNotificationsInner) => {
   router.push(`/notifications/edit/${item.id}`)
 }
 
@@ -191,11 +191,13 @@ try {
           :items-length="total"
           :footer-props="options"
           :multi-sort="true"
+          hover
           no-data-text="登録されているお知らせ情報がありません"
           @update:page="handleUpdatePage"
           @update:items-per-page="handleUpdateItemsPerPage"
           @update:sort-by="fetchState.refresh"
           @update:sort-desc="fetchState.refresh"
+          @click:row="(_, {item}:any) => handleClickRow(item.raw)"
         >
           <template #[`item.public`]="{ item }">
             <v-chip size="small" :color="getStatusColor(item.raw.public)">
@@ -209,15 +211,11 @@ try {
             {{ getDay(item.raw.publishedAt) }}
           </template>
           <template #[`item.actions`]="{ item }">
-            <v-btn class="mr-2" variant="outlined" color="primary" size="small" @click="handleEdit(item.raw)">
-              <v-icon size="small" :icon="mdiPencil" />
-              編集
-            </v-btn>
             <v-btn
               variant="outlined"
               color="primary"
               size="small"
-              @click="openDeleteDialog(item.raw)"
+              @click.stop="openDeleteDialog(item.raw)"
             >
               <v-icon size="small" :icon="mdiDelete" />
               削除

--- a/web/admin/src/pages/orders/[id].vue
+++ b/web/admin/src/pages/orders/[id].vue
@@ -505,11 +505,8 @@ try {
         </v-card>
       </v-window-item>
       <v-window-item value="orderInformation">
-        <v-card-text>
-          <v-card elevation="0">
-            <p class="text-h6">
-              注文情報
-            </p>
+        <v-card elevation="0">
+          <v-card-text>
             <v-text-field
               v-model="formData.id"
               name="id"
@@ -632,8 +629,8 @@ try {
               name="addressLine2"
               label="ビル名・号室など"
             />
-          </v-card>
-        </v-card-text>
+          </v-card-text>
+        </v-card>
       </v-window-item>
     </v-window>
   </div>

--- a/web/admin/src/pages/orders/index.vue
+++ b/web/admin/src/pages/orders/index.vue
@@ -55,11 +55,6 @@ const headers: VDataTable['headers'] = [
     key: 'payment.paymentId'
   },
   {
-    title: 'Actions',
-    key: 'actions',
-    sortable: false
-  },
-  {
     title: '注文ID',
     key: 'id'
   }
@@ -140,7 +135,7 @@ const deliveryCompanyList = [
   { deliveryCompany: 'ヤマト運輸', value: 'ヤマト運輸' }
 ]
 
-const handleEdit = (item: OrderResponse) => {
+const handleRowClick = (item: OrderResponse): void => {
   router.push(`/orders/${item.id}`)
 }
 
@@ -242,8 +237,10 @@ try {
           :items-length="totalItems"
           :footer-props="options"
           no-data-text="表示する注文がありません"
+          hover
           @update:items-per-page="handleUpdateItemsPerPage"
           @update:page="handleUpdatePage"
+          @click:row="(_: any, { item }: any) => handleRowClick(item.raw)"
         >
           <template #[`item.payment.status`]="{ item }">
             <v-chip size="small" :color="getStatusColor(item.raw.payment.status)">
@@ -255,12 +252,6 @@ try {
           </template>
           <template #[`item.orderedAt`]="{ item }">
             {{ getDay(item.raw.orderedAt) }}
-          </template>
-          <template #[`item.actions`]="{ item }">
-            <v-btn variant="outlined" color="primary" size="small" @click="handleEdit(item.raw)">
-              <v-icon size="small" :icon="mdiPencil" />
-              詳細
-            </v-btn>
           </template>
         </v-data-table-server>
       </v-card-text>

--- a/web/admin/src/pages/producers/index.vue
+++ b/web/admin/src/pages/producers/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { mdiPlus, mdiAccount, mdiPencil, mdiDelete } from '@mdi/js'
+import { mdiPlus, mdiAccount, mdiDelete } from '@mdi/js'
 import { VDataTable } from 'vuetify/lib/labs/components'
 
 import { useAlert, usePagination } from '~/lib/hooks'
@@ -99,7 +99,7 @@ const handleClickAddButton = () => {
   router.push('/producers/add')
 }
 
-const handleEdit = (item: ProducersResponseProducersInner) => {
+const handleClickRow = (item: ProducersResponseProducersInner) => {
   router.push(`/producers/edit/${item.id}`)
 }
 
@@ -201,13 +201,13 @@ try {
         <v-data-table-server
           :headers="headers"
           :items="producers"
-          :search="query"
-          :no-results-text="noResultsText"
           :items-length="totalItems"
           :footer-props="options"
+          hover
           no-data-text="登録されている生産者がいません。"
           @update:items-per-page="handleUpdateItemsPerPage"
           @update:page="handleUpdatePage"
+          @click:row="(_:any, {item}:any) => handleClickRow(item.raw)"
         >
           <template #[`item.thumbnail`]="{ item }">
             <v-avatar>
@@ -228,22 +228,18 @@ try {
             {{ `${item.raw.phoneNumber}`.replace('+81', '0') }}
           </template>
           <template #[`item.actions`]="{ item }">
-            <v-btn class="mr-2" variant="outlined" color="primary" size="small" @click="handleEdit(item.raw)">
-              <v-icon size="small" :icon="mdiPencil" />
-              編集
-            </v-btn>
             <v-btn
               color="primary"
               size="small"
               variant="outlined"
-              @click="handleClickDeleteButton(item.raw)"
+              @click.stop="handleClickDeleteButton(item.raw)"
             >
               <v-icon size="small" :icon="mdiDelete" />
               削除
             </v-btn>
           </template>
           <template #[`item.video`]="{ item }">
-            <v-btn variant="outlined" color="primary" size="small" @click="handleAddVideo(item.raw)">
+            <v-btn variant="outlined" color="primary" size="small" @click.stop="handleAddVideo(item.raw)">
               <v-icon size="small" :icon="mdiPlus" />
               追加
             </v-btn>

--- a/web/admin/src/pages/promotions/index.vue
+++ b/web/admin/src/pages/promotions/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { mdiPlus, mdiPencil, mdiDelete } from '@mdi/js'
+import { mdiPlus, mdiDelete } from '@mdi/js'
 import * as dayjs from 'dayjs'
 import { VDataTable } from 'vuetify/lib/labs/components'
 
@@ -79,7 +79,7 @@ const handleDelete = async (): Promise<void> => {
   deleteDialog.value = false
 }
 
-const handleEdit = (item: PromotionsResponsePromotionsInner) => {
+const handleClickRow = (item: PromotionsResponsePromotionsInner) => {
   router.push(`/promotions/edit/${item.id}`)
 }
 
@@ -161,7 +161,9 @@ try {
         <v-data-table
           :headers="headers"
           :items="promotions"
+          hover
           no-data-text="登録されているセール情報がありません。"
+          @click:row="(_: any, {item}: any) => handleClickRow(item.raw)"
         >
           <template #[`item.title`]="{ item }">
             {{ item.raw.title }}
@@ -187,15 +189,11 @@ try {
             {{ getDay(item.raw.endAt) }}
           </template>
           <template #[`item.actions`]="{ item }">
-            <v-btn class="mr-2" variant="outlined" color="primary" size="small" @click="handleEdit(item.raw)">
-              <v-icon size="small" :icon="mdiPencil" />
-              編集
-            </v-btn>
             <v-btn
               color="primary"
               size="small"
               variant="outlined"
-              @click="openDeleteDialog(item.raw)"
+              @click.stop="openDeleteDialog(item.raw)"
             >
               <v-icon size="small" :icon="mdiDelete" />
               削除

--- a/web/admin/src/pages/shippings/add.vue
+++ b/web/admin/src/pages/shippings/add.vue
@@ -63,10 +63,6 @@ const addBox100RateItem = () => {
   })
 }
 
-const handleClickRemoveItemButton = () => {
-  // FIXME: template側で指定されていたため、定義のみ行う
-}
-
 const { createShipping } = useShippingStore()
 
 const { alertType, isShow, alertText, show } = useAlert('error')
@@ -92,7 +88,7 @@ const handleSubmit = async (): Promise<void> => {
   }
 }
 
-const handleClickCloseButton = (rate: '60' | '80' | '100', index: number) => {
+const handleClickRemoveItemButton = (rate: '60' | '80' | '100', index: number) => {
   switch (rate) {
     case '60':
       formData.box60Rates.splice(index, 1)
@@ -111,7 +107,7 @@ const handleClickCloseButton = (rate: '60' | '80' | '100', index: number) => {
   <div>
     <v-card-title>配送情報登録</v-card-title>
 
-    <v-alert v-model="isShow" :type="alertType" v-text="alertText" />
+    <v-alert v-model="isShow" :type="alertType" class="mb-2" v-text="alertText" />
 
     <organisms-shipping-form
       v-model="formData"

--- a/web/admin/src/pages/shippings/edit/[id].vue
+++ b/web/admin/src/pages/shippings/edit/[id].vue
@@ -132,7 +132,7 @@ try {
   <div>
     <v-card-title>配送設定編集</v-card-title>
 
-    <v-alert v-model="isShow" :type="alertType" v-text="alertText" />
+    <v-alert v-model="isShow" :type="alertType" class="mb-2" v-text="alertText" />
 
     <organisms-shipping-form
       v-model="formData"

--- a/web/admin/src/pages/shippings/index.vue
+++ b/web/admin/src/pages/shippings/index.vue
@@ -5,6 +5,7 @@ import { prefecturesList } from '~/constants'
 import { dateTimeFormatter, moneyFormat } from '~/lib/formatter'
 import { usePagination } from '~/lib/hooks'
 import { useShippingStore } from '~/store'
+import { ShippingsResponseShippingsInner } from '~/types/api'
 
 const shippingStore = useShippingStore()
 const router = useRouter()
@@ -29,10 +30,6 @@ const headers: VDataTable['headers'] = [
   {
     title: '更新日',
     key: 'updatedAt'
-  },
-  {
-    title: '',
-    key: 'actions'
   }
 ]
 
@@ -60,8 +57,8 @@ const handleClickAddButton = () => {
   router.push('/shippings/add')
 }
 
-const handleClickEditButton = (id: string) => {
-  router.push(`/shippings/edit/${id}`)
+const handleClickRow = (item: ShippingsResponseShippingsInner) => {
+  router.push(`/shippings/edit/${item.id}`)
 }
 
 try {
@@ -89,9 +86,11 @@ try {
           :footer-props="options"
           :items="shippings"
           show-expand
+          hover
           class="elevation-0"
           @update:page="updateCurrentPage"
           @update:items-per-page="handleUpdateItemsPerPage"
+          @click:row="(_: any, {item}: any) => handleClickRow(item.raw)"
         >
           <template #[`item.hasFreeShipping`]="{ item }">
             <v-chip size="small">
@@ -101,18 +100,6 @@ try {
 
           <template #[`item.updatedAt`]="{ item }">
             {{ dateTimeFormatter(item.raw.updatedAt) }}
-          </template>
-
-          <template #[`item.actions`]="{ item }">
-            <v-btn
-              variant="outlined"
-              color="primary"
-              size="small"
-              @click="handleClickEditButton(item.raw.id)"
-            >
-              <v-icon :icon="mdiPencil" />
-              編集
-            </v-btn>
           </template>
 
           <template #expanded-item="{ item }">


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

- データテーブルから「編集」ボタンで詳細画面に遷移する部分を行クリックで遷移するように書き換えた

https://calmato.atlassian.net/jira/software/c/projects/FA/boards/4?modal=detail&selectedIssue=FA-13

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
