### PR TITLE
カテゴリー登録のバリデーションを調整

### DIFF
--- a/web/admin/src/components/organisms/CategoryList.vue
+++ b/web/admin/src/components/organisms/CategoryList.vue
@@ -107,10 +107,10 @@ const handleDelete = async (): Promise<void> => {
   <div>
     <v-data-table-server
       :headers="categoryHeaders"
-      :items="props.categories"
-      :items-per-page="props.tableItemsPerPage"
-      :items-length="props.tableItemsLength"
-      :footer-props="props.tableFooterOptions"
+      :items="categories"
+      :items-per-page="tableItemsPerPage"
+      :items-length="tableItemsLength"
+      :footer-props="tableFooterOptions"
       @update:page="handleUpdatePage"
       @update:items-per-page="handleUpdateItemsPerPage"
     >

--- a/web/admin/src/components/templates/CategoryList.vue
+++ b/web/admin/src/components/templates/CategoryList.vue
@@ -1,21 +1,31 @@
 <script lang="ts" setup>
 import { mdiPlus } from '@mdi/js'
 
+import { useVuelidate } from '@vuelidate/core'
+import { Category } from '~/types/props'
 import { AlertType } from '~/lib/hooks'
 import { CreateCategoryRequest, CategoriesResponseCategoriesInner, ProductTypesResponseProductTypesInner, CreateProductTypeRequest } from '~/types/api'
-import { Category } from '~/types/props'
+
+import {
+  required,
+  getErrorMessage,
+  maxLength,
+  minValue,
+  maxValue
+} from '~/lib/validations'
 
 const props = defineProps({
   loading: {
     type: Boolean,
     default: false
   },
-  dialog: {
-    type: Object,
-    default: () => ({
-      dialog: false,
-      productType: false
-    })
+  categoryDialog: {
+    type: Boolean,
+    default: false
+  },
+  productTypeDialog: {
+    type: Boolean,
+    default: false
   },
   isAlert: {
     type: Boolean,
@@ -68,7 +78,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits<{
+const emits = defineEmits<{
   (e: 'click:category-update-page', page: number): void
   (e: 'click:category-update-items-per-page', page: number): void
   (e: 'click:category-more-page'): void
@@ -76,6 +86,10 @@ const emit = defineEmits<{
   (e: 'click:product-type-update-page', page: number): void
   (e: 'click:product-type-update-items-per-page', page: number): void
   (e: 'click:product-type-close-dialog'): void
+  (e: 'update:category-dialog', val: boolean): void
+  (e: 'update:product-type-dialog', val: boolean): void
+  (e: 'update:category-form-data', val: CreateCategoryRequest): void
+  (e: 'update:product-type-form-data', val: CreateProductTypeRequest): void
   (e: 'update:tab', key: string): void
   (e: 'update:product-type-upload-icon', file: FileList): void
   (e: 'submit:category'): void
@@ -91,36 +105,73 @@ const selector = ref<string>('categories')
 const categoryId = ref<string>('')
 const productTypeIcon = ref<HTMLIFrameElement>()
 
+const categoryDialogValue = computed({
+  get: () => props.categoryDialog,
+  set: (val: boolean) => emits('update:category-dialog', val)
+})
+
+const productTypeDialogValue = computed({
+  get: () => props.productTypeDialog,
+  set: (val: boolean) => emits('update:product-type-dialog', val)
+})
+
+const categoryFormDataValue = computed({
+  get: () => props.categoryFormData,
+  set: (val: CreateCategoryRequest) => emits('update:category-form-data', val)
+})
+
+const categoryFormDataRules = computed(() => {
+  return {
+    name: { required, maxlength: maxLength(32) }
+  }
+})
+
+const cv$ = useVuelidate<CreateCategoryRequest>(categoryFormDataRules, categoryFormDataValue)
+
+const productTypeFormDataValue = computed({
+  get: () => props.productTypeFormData,
+  set: (val: CreateProductTypeRequest) => emits('update:product-type-form-data', val)
+})
+
+const productTypeFormDataRules = computed(() => {
+  return {
+    name: { required, maxlength: maxLength(32) },
+    iconUrl: { required }
+  }
+})
+
+const pv$ = useVuelidate<CreateProductTypeRequest>(productTypeFormDataRules, productTypeFormDataValue)
+
 watch(selector, () => {
-  emit('update:tab', selector.value)
+  emits('update:tab', selector.value)
 })
 
 const onClickCategoryPage = (page: number): void => {
-  emit('click:category-update-page', page)
+  emits('click:category-update-page', page)
 }
 
 const onClickCategoryItemsPerPage = (page: number): void => {
-  emit('click:category-update-items-per-page', page)
+  emits('click:category-update-items-per-page', page)
 }
 
 const onClickCategoryMorePage = (): void => {
-  emit('click:category-more-page')
+  emits('click:category-more-page')
 }
 
 const onClickCategoryCloseDialog = (): void => {
-  emit('click:category-close-dialog')
+  emits('click:category-close-dialog')
 }
 
 const onClickProductTypePage = (page: number): void => {
-  emit('click:product-type-update-page', page)
+  emits('click:product-type-update-page', page)
 }
 
 const onClickProductTypeItemsPerPage = (page: number): void => {
-  emit('click:product-type-update-items-per-page', page)
+  emits('click:product-type-update-items-per-page', page)
 }
 
 const onClickProductTypeCloseDialog = (): void => {
-  emit('click:product-type-close-dialog')
+  emits('click:product-type-close-dialog')
 }
 
 const onUploadProductTypeIcon = (event: Event): void => {
@@ -128,157 +179,168 @@ const onUploadProductTypeIcon = (event: Event): void => {
   if (!target.files) {
     return
   }
-  emit('update:product-type-upload-icon', target.files)
+  emits('update:product-type-upload-icon', target.files)
 }
 
-const onSubmitCategory = (): void => {
-  emit('submit:category')
+const onSubmitCategory = async () => {
+  const result = await cv$.value.$validate()
+  if (!result) {
+    return
+  }
+  emits('submit:category')
 }
 
 const onSubmitProductType = (): void => {
-  emit('submit:product-type', categoryId.value)
+  emits('submit:product-type', categoryId.value)
 }
 </script>
 
 <template>
   <v-alert v-show="props.isAlert" :type="props.alertType" v-text="props.alertText" />
   <v-card-title>カテゴリー・品目設定</v-card-title>
-  <v-tabs v-model="selector" grow color="dark">
-    <v-tab v-for="item in tabs" :key="item.value" :value="item.value">
-      {{ item.name }}
-    </v-tab>
-  </v-tabs>
 
-  <v-window v-model="selector">
-    <v-window-item value="categories">
-      <v-dialog v-model="props.dialog.category" width="500">
-        <template #activator="{ props }">
-          <div class="d-flex pt-3 pr-3">
-            <v-spacer />
-            <v-btn variant="outlined" color="primary" v-bind="props">
-              <v-icon start :icon="mdiPlus" />
-              追加
-            </v-btn>
-          </div>
-        </template>
+  <v-card>
+    <v-tabs v-model="selector" grow color="dark">
+      <v-tab v-for="item in tabs" :key="item.value" :value="item.value">
+        {{ item.name }}
+      </v-tab>
+    </v-tabs>
 
-        <v-card :loading="props.loading">
-          <v-card-title class="text-h6 primaryLight">
-            カテゴリー登録
-          </v-card-title>
-          <v-text-field
-            v-model="props.categoryFormData.name"
-            class="mx-4"
-            maxlength="32"
-            label="カテゴリー"
-          />
-          <v-divider />
+    <v-card-text>
+      <v-window v-model="selector">
+        <v-window-item value="categories">
+          <v-dialog v-model="categoryDialogValue" width="500">
+            <template #activator="{ props: attrs }">
+              <div class="d-flex pt-3 pr-3">
+                <v-spacer />
+                <v-btn variant="outlined" color="primary" v-bind="attrs">
+                  <v-icon start :icon="mdiPlus" />
+                  追加
+                </v-btn>
+              </div>
+            </template>
 
-          <v-card-actions>
-            <v-spacer />
-            <v-btn color="error" variant="text" @click="onClickCategoryCloseDialog">
-              キャンセル
-            </v-btn>
-            <v-btn color="primary" variant="outlined" @click="onSubmitCategory">
-              登録
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-      <organisms-category-list
-        :categories="props.categories"
-        :table-items-per-page="props.categoryTableItemsPerPage"
-        :table-items-length="props.categoryTableItemsTotal"
-        @update:page="onClickCategoryPage"
-        @update:items-per-page="onClickCategoryItemsPerPage"
-      />
-    </v-window-item>
-
-    <v-window-item value="productTypes">
-      <v-dialog v-model="props.dialog.productType" width="500">
-        <template #activator="{ props }">
-          <div class="d-flex pt-3 pr-3">
-            <v-spacer />
-            <v-btn variant="outlined" color="primary" v-bind="props">
-              <v-icon start :icon="mdiPlus" />
-              追加
-            </v-btn>
-          </div>
-        </template>
-        <v-card :loading="props.loading">
-          <v-card-title class="primaryLight">
-            品目登録
-          </v-card-title>
-          <v-card-text class="mt-4">
-            <v-autocomplete
-              v-model="categoryId"
-              :items="categories"
-              item-title="name"
-              item-value="id"
-              label="カテゴリー"
-            >
-              <template #append-item>
-                <div class="pa-2">
-                  <v-btn block color="primary" variant="outlined" @click="onClickCategoryMorePage">
-                    <v-icon :icon="mdiPlus" />
-                    さらに読み込む
-                  </v-btn>
-                </div>
-              </template>
-            </v-autocomplete>
-            <v-spacer />
-            <v-text-field
-              v-model="props.productTypeFormData.name"
-              maxlength="32"
-              label="品目"
-            />
-          </v-card-text>
-          <v-card class="text-center" role="button" flat @click="onSubmitProductType">
-            <v-card-text>
-              <v-avatar size="96">
-                <v-icon v-if="props.productTypeFormData.iconUrl === ''" size="x-large" :icon="mdiPlus" />
-                <v-img
-                  v-else
-                  :src="props.productTypeFormData.iconUrl"
-                  aspect-ratio="1"
-                  max-height="150"
-                  cover
+            <v-card :loading="loading">
+              <v-card-title class="text-h6 primaryLight">
+                カテゴリー登録
+              </v-card-title>
+              <v-card-text>
+                <v-text-field
+                  v-model="cv$.name.$model"
+                  class="mx-4"
+                  label="カテゴリー名"
+                  :error-messages="getErrorMessage(cv$.name.$errors)"
                 />
-              </v-avatar>
-              <input
-                ref="productTypeIcon"
-                type="file"
-                class="d-none"
-                accept="image/png, image/jpeg"
-                @change="onUploadProductTypeIcon"
-              >
-              <p class="ma-0">
-                アイコン画像を選択
-              </p>
-            </v-card-text>
-          </v-card>
-          <v-divider />
+              </v-card-text>
+              <v-divider />
 
-          <v-card-actions>
-            <v-spacer />
-            <v-btn color="error" variant="text" @click="onClickProductTypeCloseDialog">
-              キャンセル
-            </v-btn>
-            <v-btn color="primary" variant="outlined" @click="onSubmitProductType">
-              登録
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-      <organisms-product-type-list
-        :product-types="props.productTypes"
-        :categories="props.categories"
-        :table-items-per-page="props.productTypeTableItemsPerPage"
-        :table-items-length="props.productTypeTableItemsTotal"
-        @update:page="onClickProductTypePage"
-        @update:items-per-page="onClickProductTypeItemsPerPage"
-        @click:more-item="onClickCategoryMorePage"
-      />
-    </v-window-item>
-  </v-window>
+              <v-card-actions>
+                <v-spacer />
+                <v-btn color="error" variant="text" @click="onClickCategoryCloseDialog">
+                  キャンセル
+                </v-btn>
+                <v-btn color="primary" variant="outlined" @click="onSubmitCategory">
+                  登録
+                </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <organisms-category-list
+            :categories="categories"
+            :table-items-per-page="categoryTableItemsPerPage"
+            :table-items-length="categoryTableItemsTotal"
+            @update:page="onClickCategoryPage"
+            @update:items-per-page="onClickCategoryItemsPerPage"
+          />
+        </v-window-item>
+
+        <v-window-item value="productTypes">
+          <v-dialog v-model="productTypeDialogValue" width="500">
+            <template #activator="{ props: attrs }">
+              <div class="d-flex pt-3 pr-3">
+                <v-spacer />
+                <v-btn variant="outlined" color="primary" v-bind="attrs">
+                  <v-icon start :icon="mdiPlus" />
+                  追加
+                </v-btn>
+              </div>
+            </template>
+            <v-card :loading="loading">
+              <v-card-title class="primaryLight">
+                品目登録
+              </v-card-title>
+              <v-card-text class="mt-4">
+                <v-autocomplete
+                  v-model="categoryId"
+                  :items="categories"
+                  item-title="name"
+                  item-value="id"
+                  label="カテゴリー"
+                >
+                  <template #append-item>
+                    <div class="pa-2">
+                      <v-btn block color="primary" variant="outlined" @click="onClickCategoryMorePage">
+                        <v-icon :icon="mdiPlus" />
+                        さらに読み込む
+                      </v-btn>
+                    </div>
+                  </template>
+                </v-autocomplete>
+                <v-spacer />
+                <v-text-field
+                  v-model="pv$.name.$model"
+                  :error-messages="getErrorMessage(pv$.name.$errors)"
+                  label="品目"
+                />
+                <v-card class="text-center" role="button" flat>
+                  <v-card-text>
+                    <v-avatar size="96">
+                      <v-icon v-if="productTypeFormData.iconUrl === ''" size="x-large" :icon="mdiPlus" />
+                      <v-img
+                        v-else
+                        :src="productTypeFormData.iconUrl"
+                        aspect-ratio="1"
+                        max-height="150"
+                        cover
+                      />
+                    </v-avatar>
+                    <input
+                      ref="productTypeIcon"
+                      type="file"
+                      class="d-none"
+                      accept="image/png, image/jpeg"
+                      @change="onUploadProductTypeIcon"
+                    >
+                    <p class="ma-0">
+                      アイコン画像を選択
+                    </p>
+                  </v-card-text>
+                </v-card>
+              </v-card-text>
+              <v-divider />
+
+              <v-card-actions>
+                <v-spacer />
+                <v-btn color="error" variant="text" @click="onClickProductTypeCloseDialog">
+                  キャンセル
+                </v-btn>
+                <v-btn color="primary" variant="outlined" @click="onSubmitProductType">
+                  登録
+                </v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <organisms-product-type-list
+            :product-types="productTypes"
+            :categories="categories"
+            :table-items-per-page="productTypeTableItemsPerPage"
+            :table-items-length="productTypeTableItemsTotal"
+            @update:page="onClickProductTypePage"
+            @update:items-per-page="onClickProductTypeItemsPerPage"
+            @click:more-item="onClickCategoryMorePage"
+          />
+        </v-window-item>
+      </v-window>
+    </v-card-text>
+  </v-card>
 </template>

--- a/web/admin/src/pages/categories/index.vue
+++ b/web/admin/src/pages/categories/index.vue
@@ -77,7 +77,9 @@ const handleCreateCategory = async (): Promise<void> => {
   try {
     await categoryStore.createCategory(categoryFormData)
     categoryCloseDialog()
+    categoryFormData.name = ''
   } catch (err) {
+    categoryCloseDialog()
     if (err instanceof Error) {
       show(err.message)
     }
@@ -173,7 +175,8 @@ try {
 
 <template>
   <templates-category-list
-    v-model:dialog="dialog"
+    v-model:category-dialog="dialog.category"
+    v-model:product-type-dialog="dialog.productType"
     v-model:category-form-data="categoryFormData"
     v-model:product-type-form-data="productTypeFormData"
     :loading="isLoading()"


### PR DESCRIPTION
- wip: 品目登録側は要対応

## やったこと

- カテゴリー登録のバリデーションを調整
- `props`書き換えまくっていたのでリファクタした。

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

* [ ] 品目側のバリデーション…
* [ ] サーバサイドで行われるバリデーションへの対応

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
