### PR TITLE
商品登録・更新の選択とバリデーションの実装

### DIFF
--- a/web/admin/src/lib/validations/rule.ts
+++ b/web/admin/src/lib/validations/rule.ts
@@ -131,6 +131,22 @@ const minLengthArray = (minLength: number | Ref<number>) => {
   )
 }
 
+/**
+ * 配列の最代の長さのバリデーションルール（カスタム）
+ * @param maxLength 最小の要素数
+ * @returns
+ */
+const maxLengthArray = (maxLength: number | Ref<number>) => {
+  const maxLengthValue = isRef(maxLength) ? maxLength.value : maxLength
+  return helpers.withMessage(
+    `この項目は最大${maxLengthValue}件まです。${maxLengthValue}件以下に修正してください。`,
+    helpers.withParams(
+      { type: 'minLengthArray', minLength: maxLength },
+      value => Array.isArray(value) && value.length <= maxLengthValue
+    )
+  )
+}
+
 export {
   kana,
   tel,
@@ -142,5 +158,6 @@ export {
   minValue,
   maxValue,
   sameAs,
-  minLengthArray
+  minLengthArray,
+  maxLengthArray
 }

--- a/web/admin/src/pages/products/[id].vue
+++ b/web/admin/src/pages/products/[id].vue
@@ -18,7 +18,7 @@ const router = useRouter()
 
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const formData = reactive<UpdateProductRequest>({
+const formData = ref<UpdateProductRequest>({
   name: '',
   description: '',
   producerId: '',
@@ -51,7 +51,7 @@ const fetchState = useAsyncData(async () => {
       producerStore.fetchProducers()
     ])
     const data = await productStore.getProduct(id)
-    Object.assign(formData, data)
+    formData.value = data
   } catch (error) {
     if (error instanceof ApiBaseError) {
       show(error.message)
@@ -82,7 +82,7 @@ const handleImageUpload = async (files?: FileList) => {
     try {
       const uploadImage: UploadImageResponse =
         await productStore.uploadProductImage(file)
-      formData.media.push({
+      formData.value.media.push({
         ...uploadImage,
         isThumbnail: false
       })
@@ -93,7 +93,7 @@ const handleImageUpload = async (files?: FileList) => {
 }
 
 const handleDeleteThumbnailImageButton = (index: number) => {
-  formData.media = formData.media.filter((_, i) => {
+  formData.value.media = formData.value.media.filter((_, i) => {
     return i !== index
   })
 }
@@ -116,7 +116,7 @@ const handleSubmit = async () => {
   }
 
   try {
-    await productStore.updateProduct(id, formData)
+    await productStore.updateProduct(id, formData.value)
     commonStore.addSnackbar({
       color: 'success',
       message: '商品を更新しました。'

--- a/web/admin/src/pages/products/add.vue
+++ b/web/admin/src/pages/products/add.vue
@@ -44,7 +44,7 @@ const breadcrumbsItem = [
   }
 ]
 
-const formData = reactive<CreateProductRequest>({
+const formData = ref<CreateProductRequest>({
   name: '',
   description: '',
   producerId: '',
@@ -70,7 +70,7 @@ const handleImageUpload = async (files: FileList) => {
   for (const [index, file] of Array.from(files).entries()) {
     try {
       const uploadImage: UploadImageResponse = await uploadProductImage(file)
-      formData.media.push({
+      formData.value.media.push({
         ...uploadImage,
         isThumbnail: index === 0
       })
@@ -81,7 +81,7 @@ const handleImageUpload = async (files: FileList) => {
 }
 
 const handleDeleteThumbnailImageButton = (index: number) => {
-  formData.media = formData.media.filter((_, i) => {
+  formData.value.media = formData.value.media.filter((_, i) => {
     return i !== index
   })
 }
@@ -98,7 +98,7 @@ const handleFormSubmit = async () => {
     return
   }
   try {
-    await createProduct(formData)
+    await createProduct(formData.value)
     router.push('/products')
   } catch (error) {
     if (error instanceof ApiBaseError) {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

- 商品登録・更新でサムネイルの選択肢を使えるようにした
- バリデーションをかけた

## スクリーンショット

![image](https://user-images.githubusercontent.com/27722351/234308135-59b9b626-e78e-4faa-96db-faee25356738.png)


<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
