### PR TITLE
メールアドレス更新フォームでフロントエンド側でバリデーションを追加した

### DIFF
--- a/web/admin/src/components/templates/AuthEditEmail.vue
+++ b/web/admin/src/components/templates/AuthEditEmail.vue
@@ -1,44 +1,58 @@
 <script lang="ts" setup>
+import useVuelidate from '@vuelidate/core'
 import { UpdateAuthEmailRequest } from '~/types/api'
 import { AlertType } from '~/lib/hooks'
+import { required, email, getErrorMessage } from '~/lib/validations'
 
-const props = defineProps({
-  isAlert: {
-    type: Boolean,
-    default: false
-  },
-  alertType: {
-    type: String as PropType<AlertType>,
-    default: undefined
-  },
-  alertText: {
-    type: String,
-    default: ''
-  },
-  formData: {
-    type: Object as PropType<UpdateAuthEmailRequest>,
-    default: () => ({
-      email: ''
-    })
+interface Props {
+  isAlert: boolean,
+  alertType: AlertType,
+  alertText: string,
+  formData: UpdateAuthEmailRequest
+}
+
+const props = defineProps<Props>()
+
+const emits = defineEmits<{
+  (e: 'submit'): void,
+  (e: 'update:isAlert', val: boolean): void
+  (e: 'update:formData', val: UpdateAuthEmailRequest): void
+}>()
+
+const isAlertValue = computed({
+  get: () => props.isAlert,
+  set: (val: boolean) => emits('update:isAlert', val)
+})
+
+const formDataValue = computed({
+  get: () => props.formData,
+  set: (val: UpdateAuthEmailRequest) => emits('update:formData', val)
+})
+
+const rules = computed(() => {
+  return {
+    email: { required, email }
   }
 })
 
-const emit = defineEmits<{
-  (e: 'submit'): void
-}>()
+const v$ = useVuelidate(rules, formDataValue)
 
-const onSubmit = (): void => {
-  emit('submit')
+const onSubmit = async () => {
+  const result = await v$.value.$validate()
+  if (!result) {
+    return
+  }
+  emits('submit')
 }
 </script>
 
 <template>
-  <v-alert v-model="props.isAlert" :type="props.alertType" :text="props.alertText" />
+  <v-alert v-model="isAlertValue" :type="props.alertType" :text="props.alertText" class="mb-2" />
   <v-card elevation="0">
     <v-card-title>メールアドレス変更</v-card-title>
     <v-form @submit.prevent="onSubmit">
       <v-card-text>
-        <v-text-field v-model="props.formData.email" label="新規メールアドレス" />
+        <v-text-field v-model="v$.email.$model" :error-messages="getErrorMessage(v$.email.$errors)" label="新規メールアドレス" />
       </v-card-text>
       <v-card-actions>
         <v-btn type="submit" block color="primary" variant="outlined">


### PR DESCRIPTION
## やったこと

- メールアドレス更新フォームでフロントエンド側でバリデーションを追加した

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
