### PR TITLE
商品削除ボタンをクリックしても詳細画面に遷移しないようにする

### DIFF
--- a/web/admin/src/components/templates/ProductList.vue
+++ b/web/admin/src/components/templates/ProductList.vue
@@ -192,7 +192,7 @@ const onClickDelete = (): void => {
           </v-chip>
         </template>
         <template #[`item.actions`]="{ item }">
-          <v-btn variant="outlined" color="primary" size="small" @click="toggleDeleteDialog(item.raw)">
+          <v-btn variant="outlined" color="primary" size="small" @click.stop="toggleDeleteDialog(item.raw)">
             <v-icon size="small" :icon="mdiDelete" />
             削除
           </v-btn>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

- 削除ボタンクリックに`.stop`修飾子をつけてボタンクリック後の`row-click`イベントを伝播させないようにした。


## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
