### PR TITLE
ユーザー側ページのフォント変更と枠内背景色の更新

### DIFF
--- a/web/user/src/assets/css/tailwind.css
+++ b/web/user/src/assets/css/tailwind.css
@@ -1,10 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap');
 @tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @layer base {
   html {
     @apply text-typography tracking-wide;
+    font-family: 'Noto Sans JP', sans-serif;
   }
 }
 
-@tailwind components;
-@tailwind utilities;

--- a/web/user/src/components/atoms/cards/TheCard.vue
+++ b/web/user/src/components/atoms/cards/TheCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-slate-50 flex flex-col">
+  <div class="bg-white flex flex-col">
     <slot />
   </div>
 </template>

--- a/web/user/tailwind.config.ts
+++ b/web/user/tailwind.config.ts
@@ -3,6 +3,9 @@ import type { Config } from 'tailwindcss'
 export default <Partial<Config>>{
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Noto Sans JP', 'sans-serif']
+      },
       colors: {
         base: '#F9F6EA',
         main: '#604C3F',


### PR DESCRIPTION
## やったこと

- ユーザー画面側のフォント設定を`Noto Sans JP`に変更
- 認証系画面の枠内の背景色を`#FFFFFF`に変更

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
