### PR TITLE
Chanege architecture

### DIFF
--- a/api/internal/gateway/admin/v1/handler/contact_category.go
+++ b/api/internal/gateway/admin/v1/handler/contact_category.go
@@ -63,6 +63,20 @@ func (h *handler) GetContactCategory(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, res)
 }
 
+func (h *handler) multiGetContactCategories(ctx context.Context, categoryIDs []string) (service.ContactCategories, error) {
+	if len(categoryIDs) == 0 {
+		return service.ContactCategories{}, nil
+	}
+	in := &messenger.MultiGetContactCategoriesInput{
+		CategoryIDs: categoryIDs,
+	}
+	categories, err := h.messenger.MultiGetContactCategories(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewContactCategories(categories), nil
+}
+
 func (h *handler) getContactCategory(ctx context.Context, contactCategoryID string) (*service.ContactCategory, error) {
 	in := &messenger.GetContactCategoryInput{
 		CategoryID: contactCategoryID,

--- a/api/internal/gateway/admin/v1/response/contact.go
+++ b/api/internal/gateway/admin/v1/response/contact.go
@@ -29,9 +29,11 @@ type Contact struct {
 }
 
 type ContactResponse struct {
-	Contact  *Contact         `json:"contact"`  // お問い合わせ情報
-	Category *ContactCategory `json:"category"` // お問い合わせ種別情報
-	Threads  []*Thread        `json:"threads"`  // お問い合わせ会話履歴一覧
+	Contact   *Contact         `json:"contact"`   // お問い合わせ情報
+	Category  *ContactCategory `json:"category"`  // お問い合わせ種別情報
+	Threads   []*Thread        `json:"threads"`   // お問い合わせ会話履歴一覧
+	User      *User            `json:"user"`      // ユーザー情報
+	Responder *Admin           `json:"responder"` // 対応者情報
 }
 
 type ContactsResponse struct {

--- a/api/internal/gateway/admin/v1/response/contact.go
+++ b/api/internal/gateway/admin/v1/response/contact.go
@@ -37,6 +37,10 @@ type ContactResponse struct {
 }
 
 type ContactsResponse struct {
-	Contacts []*Contact `json:"contacts"` // お問い合わせ一覧
-	Total    int64      `json:"total"`    // お問い合わせ合計
+	Contacts   []*Contact         `json:"contacts"`   // お問い合わせ一覧
+	Categories []*ContactCategory `json:"categories"` // お問い合わせ種別一覧
+	Threads    []*Thread          `json:"threads"`    // お問い合わせ会話履歴一覧
+	Users      []*User            `json:"users"`      // ユーザー一覧
+	Responders []*Admin           `json:"admins"`     // 管理者一覧
+	Total      int64              `json:"total"`      // お問い合わせ合計
 }

--- a/api/internal/gateway/admin/v1/response/contact.go
+++ b/api/internal/gateway/admin/v1/response/contact.go
@@ -29,8 +29,9 @@ type Contact struct {
 }
 
 type ContactResponse struct {
-	*Contact
-	Threads []*Thread `json:"threads"`
+	Contact  *Contact         `json:"contact"`  // お問い合わせ情報
+	Category *ContactCategory `json:"category"` // お問い合わせ種別情報
+	Threads  []*Thread        `json:"threads"`  // お問い合わせ会話履歴一覧
 }
 
 type ContactsResponse struct {

--- a/api/internal/gateway/admin/v1/response/thread.go
+++ b/api/internal/gateway/admin/v1/response/thread.go
@@ -12,10 +12,14 @@ type Thread struct {
 }
 
 type ThreadResponse struct {
-	*Thread
+	Thread *Thread `json:"thread"` // お問い合わせ会話履歴
+	User   *User   `json:"user"`   // 送信者情報(ユーザー)
+	Admin  *Admin  `json:"admin"`  // 送信者情報(管理者)
 }
 
 type ThreadsResponse struct {
 	Threads []*Thread `json:"threads"` // お問い合わせ会話履歴一覧
+	Users   []*User   `json:"users"`   // 送信者一覧
+	Admins  []*Admin  `json:"admins"`  // 送信者一覧
 	Total   int64     `json:"total"`   // 会話履歴合計
 }

--- a/api/internal/gateway/admin/v1/service/thread.go
+++ b/api/internal/gateway/admin/v1/service/thread.go
@@ -5,11 +5,37 @@ import (
 	"github.com/and-period/furumaru/api/internal/messenger/entity"
 )
 
+type ThreadUserType int32
+
+const (
+	ThreadUserTypeUnknown ThreadUserType = iota // 不明
+	ThreadUserTypeAdmin                         // 管理者
+	ThreadUserTypeUser                          // ユーザー
+	ThreadUserTypeGuest                         // ゲスト(ユーザIDなし)
+)
+
+func NewThreadUserType(typ entity.ThreadUserType) ThreadUserType {
+	switch typ {
+	case entity.ThreadUserTypeAdmin:
+		return ThreadUserTypeAdmin
+	case entity.ThreadUserTypeUser:
+		return ThreadUserTypeUser
+	case entity.ThreadUserTypeGuest:
+		return ThreadUserTypeGuest
+	default:
+		return ThreadUserTypeUnknown
+	}
+}
+
 type Thread struct {
 	response.Thread
 }
 
 type Threads []*Thread
+
+func (t ThreadUserType) Response() int32 {
+	return int32(t)
+}
 
 func NewThread(thread *entity.Thread) *Thread {
 	return &Thread{
@@ -17,7 +43,7 @@ func NewThread(thread *entity.Thread) *Thread {
 			ID:        thread.ID,
 			ContactID: thread.ContactID,
 			UserID:    thread.UserID,
-			UserType:  thread.UserType,
+			UserType:  NewThreadUserType(thread.UserType).Response(),
 			Content:   thread.Content,
 			CreatedAt: thread.CreatedAt.Unix(),
 			UpdatedAt: thread.UpdatedAt.Unix(),

--- a/api/internal/gateway/admin/v1/service/thread.go
+++ b/api/internal/gateway/admin/v1/service/thread.go
@@ -27,6 +27,19 @@ func NewThreadUserType(typ entity.ThreadUserType) ThreadUserType {
 	}
 }
 
+func (t ThreadUserType) StoreEntity() entity.ThreadUserType {
+	switch t {
+	case ThreadUserTypeAdmin:
+		return entity.ThreadUserTypeAdmin
+	case ThreadUserTypeUser:
+		return entity.ThreadUserTypeUser
+	case ThreadUserTypeGuest:
+		return entity.ThreadUserTypeGuest
+	default:
+		return entity.ThreadUserTypeUnknown
+	}
+}
+
 type Thread struct {
 	response.Thread
 }

--- a/api/internal/messenger/database/contact_category.go
+++ b/api/internal/messenger/database/contact_category.go
@@ -42,6 +42,15 @@ func (c *contactCategory) List(
 	return categories, exception.InternalError(err)
 }
 
+func (c *contactCategory) MultiGet(ctx context.Context, categoryIDs []string, fields ...string) (entity.ContactCategories, error) {
+	var categories entity.ContactCategories
+
+	err := c.db.Statement(ctx, c.db.DB, contactCategoryTable, fields...).
+		Where("id IN (?)", categoryIDs).
+		Find(&categories).Error
+	return categories, exception.InternalError(err)
+}
+
 func (c *contactCategory) Get(ctx context.Context, categoryID string, fields ...string) (*entity.ContactCategory, error) {
 	category, err := c.get(ctx, c.db.DB, categoryID, fields...)
 	return category, exception.InternalError(err)

--- a/api/internal/messenger/database/contact_category_test.go
+++ b/api/internal/messenger/database/contact_category_test.go
@@ -83,6 +83,74 @@ func TestContactCategory_List(t *testing.T) {
 	}
 }
 
+func TestContactCategory_MultiGet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	contactCategories := make(entity.ContactCategories, 3)
+	contactCategories[0] = testContactCategory("contactCategory-id01", "種別1", now())
+	contactCategories[1] = testContactCategory("contactCategory-id02", "種別2", now())
+	contactCategories[2] = testContactCategory("contactCategory-id03", "種別3", now())
+	err = db.DB.Create(&contactCategories).Error
+	require.NoError(t, err)
+
+	type args struct {
+		categoryIDs []string
+	}
+	type want struct {
+		contactCategories entity.ContactCategories
+		hasErr            bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *database.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *database.Client) {},
+			args: args{
+				categoryIDs: []string{
+					"contactCategory-id01",
+					"contactCategory-id02",
+					"contactCategory-id03",
+				},
+			},
+			want: want{
+				contactCategories: contactCategories,
+				hasErr:            false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &contactCategory{db: db, now: now}
+			actual, err := db.MultiGet(ctx, tt.args.categoryIDs)
+			assert.Equal(t, tt.want.hasErr, err != nil, err)
+			assert.ElementsMatch(t, tt.want.contactCategories, actual)
+		})
+	}
+}
+
 func TestContactCategory_Get(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/internal/messenger/database/database.go
+++ b/api/internal/messenger/database/database.go
@@ -59,6 +59,7 @@ type Contact interface {
 type ContactCategory interface {
 	Get(ctx context.Context, categoryID string, fields ...string) (*entity.ContactCategory, error)
 	List(ctx context.Context, params *ListContactCategoriesParams, fields ...string) (entity.ContactCategories, error)
+	MultiGet(ctx context.Context, categoryIDs []string, fields ...string) (entity.ContactCategories, error)
 	Create(ctx context.Context, category *entity.ContactCategory) error
 }
 

--- a/api/internal/messenger/database/database.go
+++ b/api/internal/messenger/database/database.go
@@ -245,7 +245,7 @@ func (p *ListThreadsByContactIDParams) stmt(stmt *gorm.DB) *gorm.DB {
 type UpdateThreadParams struct {
 	Content  string
 	UserID   string
-	UserType int32
+	UserType entity.ThreadUserType
 }
 
 type UpdateContactParams struct {

--- a/api/internal/messenger/entity/contact.go
+++ b/api/internal/messenger/entity/contact.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"time"
 
+	"github.com/and-period/furumaru/api/pkg/set"
 	"github.com/and-period/furumaru/api/pkg/uuid"
 	"gorm.io/gorm"
 )
@@ -68,4 +69,27 @@ func (c *Contact) Fill(categoryID, userID, responderID string) {
 	if responderID != "" {
 		c.ResponderID = responderID
 	}
+}
+
+func (cs Contacts) IDs() []string {
+	return set.UniqBy(cs, func(c *Contact) string {
+		return c.ID
+	})
+}
+func (cs Contacts) CategoryIDs() []string {
+	return set.UniqBy(cs, func(c *Contact) string {
+		return c.CategoryID
+	})
+}
+
+func (cs Contacts) UserIDs() []string {
+	return set.UniqBy(cs, func(c *Contact) string {
+		return c.UserID
+	})
+}
+
+func (cs Contacts) ResponderIDs() []string {
+	return set.UniqBy(cs, func(c *Contact) string {
+		return c.ResponderID
+	})
 }

--- a/api/internal/messenger/entity/contact.go
+++ b/api/internal/messenger/entity/contact.go
@@ -76,6 +76,7 @@ func (cs Contacts) IDs() []string {
 		return c.ID
 	})
 }
+
 func (cs Contacts) CategoryIDs() []string {
 	return set.UniqBy(cs, func(c *Contact) string {
 		return c.CategoryID

--- a/api/internal/messenger/entity/contact_test.go
+++ b/api/internal/messenger/entity/contact_test.go
@@ -181,3 +181,111 @@ func TestContact_Fill(t *testing.T) {
 		})
 	}
 }
+
+func TestContacts_ContactCategoryIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		contacts Contacts
+		expect   []string
+	}{
+		{
+			name: "success",
+			contacts: Contacts{
+				{
+					ID:          "contact-id",
+					Title:       "お問い合わせ件名",
+					Content:     "お問い合わせ内容",
+					Username:    "お問い合わせ氏名",
+					Email:       "test-user@and-period.jp",
+					PhoneNumber: "+819012345678",
+					Status:      ContactStatusUnknown,
+					Note:        "",
+					CategoryID:  "category-id",
+					UserID:      "",
+					ResponderID: "responder-id",
+				},
+			},
+			expect: []string{"category-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expect, tt.contacts.CategoryIDs())
+		})
+	}
+}
+
+func TestContacts_UserIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		contacts Contacts
+		expect   []string
+	}{
+		{
+			name: "success",
+			contacts: Contacts{
+				{
+					ID:          "contact-id",
+					Title:       "お問い合わせ件名",
+					Content:     "お問い合わせ内容",
+					Username:    "お問い合わせ氏名",
+					Email:       "test-user@and-period.jp",
+					PhoneNumber: "+819012345678",
+					Status:      ContactStatusUnknown,
+					Note:        "",
+					CategoryID:  "category-id",
+					UserID:      "user-id",
+					ResponderID: "responder-id",
+				},
+			},
+			expect: []string{"user-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expect, tt.contacts.UserIDs())
+		})
+	}
+}
+
+func TestContacts_ResponderIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		contacts Contacts
+		expect   []string
+	}{
+		{
+			name: "success",
+			contacts: Contacts{
+				{
+					ID:          "contact-id",
+					Title:       "お問い合わせ件名",
+					Content:     "お問い合わせ内容",
+					Username:    "お問い合わせ氏名",
+					Email:       "test-user@and-period.jp",
+					PhoneNumber: "+819012345678",
+					Status:      ContactStatusUnknown,
+					Note:        "",
+					CategoryID:  "category-id",
+					UserID:      "user-id",
+					ResponderID: "responder-id",
+				},
+			},
+			expect: []string{"responder-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.expect, tt.contacts.ResponderIDs())
+		})
+	}
+}

--- a/api/internal/messenger/entity/thread.go
+++ b/api/internal/messenger/entity/thread.go
@@ -3,8 +3,18 @@ package entity
 import (
 	"time"
 
+	"github.com/and-period/furumaru/api/pkg/set"
 	"github.com/and-period/furumaru/api/pkg/uuid"
 	"gorm.io/gorm"
+)
+
+type ThreadUserType int32
+
+const (
+	ThreadUserTypeUnknown ThreadUserType = iota // 不明
+	ThreadUserTypeAdmin                         // 管理者
+	ThreadUserTypeUser                          // ユーザー
+	ThreadUserTypeGuest                         // ゲスト(ユーザIDなし)
 )
 
 // Thread - お問い合わせ会話履歴
@@ -12,7 +22,7 @@ type Thread struct {
 	ID        string         `gorm:"primaryKey;<-:create"` // お問い合わせ会話履歴ID
 	ContactID string         `gorm:""`                     // お問い合わせID
 	UserID    string         `gorm:"default:null"`         // 送信者ID(ゲストの場合null)
-	UserType  int32          `gorm:""`                     // 送信者の種別(不明:0, admin:1, user:2, guest:3)
+	UserType  ThreadUserType `gorm:""`                     // 送信者の種別(不明:0, admin:1, user:2, guest:3)
 	Content   string         `gorm:""`                     // 内容
 	CreatedAt time.Time      `gorm:"<-:create"`            // 登録日時
 	UpdatedAt time.Time      `gorm:""`                     // 更新日時
@@ -22,7 +32,7 @@ type Thread struct {
 type Threads []*Thread
 
 type NewThreadParams struct {
-	UserType  int32
+	UserType  ThreadUserType
 	ContactID string
 	Content   string
 }
@@ -39,5 +49,28 @@ func NewThread(params *NewThreadParams) *Thread {
 func (t *Thread) Fill(userID string) {
 	if userID != "" {
 		t.UserID = userID
+	}
+}
+
+func (ts Threads) IDs() []string {
+	return set.UniqBy(ts, func(t *Thread) string {
+		return t.ID
+	})
+}
+
+func (ts Threads) UserIDs() []string {
+	return set.UniqBy(ts, func(t *Thread) string {
+		return t.UserID
+	})
+}
+
+func (ts Threads) Fill() {
+	userIDs := ts.UserIDs()
+	for _, t := range ts {
+		for _, userID := range userIDs {
+			if t.UserID == userID {
+				t.UserID = userID
+			}
+		}
 	}
 }

--- a/api/internal/messenger/entity/thread.go
+++ b/api/internal/messenger/entity/thread.go
@@ -60,6 +60,18 @@ func (ts Threads) IDs() []string {
 
 func (ts Threads) UserIDs() []string {
 	return set.UniqBy(ts, func(t *Thread) string {
+		if t.UserType != ThreadUserTypeUser {
+			return ""
+		}
+		return t.UserID
+	})
+}
+
+func (ts Threads) AdminIDs() []string {
+	return set.UniqBy(ts, func(t *Thread) string {
+		if t.UserType != ThreadUserTypeAdmin {
+			return ""
+		}
 		return t.UserID
 	})
 }

--- a/api/internal/messenger/entity/thread_test.go
+++ b/api/internal/messenger/entity/thread_test.go
@@ -92,3 +92,67 @@ func TestThread_Fill(t *testing.T) {
 		})
 	}
 }
+
+func TestThreads_IDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		threads *Threads
+		expect  []string
+	}{
+		{
+			name: "success",
+			threads: &Threads{
+				{
+					ID:        "thread-id1",
+					ContactID: "contact-id",
+					UserType:  1,
+					Content:   "content",
+					UserID:    "user-id",
+				},
+			},
+			expect: []string{"thread-id1"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.threads.IDs()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestThreads_UserIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		threads *Threads
+		expect  []string
+	}{
+		{
+			name: "success",
+			threads: &Threads{
+				{
+					ID:        "thread-id1",
+					ContactID: "contact-id",
+					UserType:  1,
+					Content:   "content",
+					UserID:    "user-id",
+				},
+			},
+			expect: []string{"user-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.threads.UserIDs()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/messenger/input.go
+++ b/api/internal/messenger/input.go
@@ -141,10 +141,10 @@ type ListThreadsByContactIDInput struct {
 }
 
 type CreateThreadInput struct {
-	ContactID string `validate:"required"`
-	UserID    string `validate:""`
-	UserType  int32  `validate:"required"`
-	Content   string `validate:"required,max=2000"`
+	ContactID string                `validate:"required"`
+	UserID    string                `validate:""`
+	UserType  entity.ThreadUserType `validate:"required"`
+	Content   string                `validate:"required,max=2000"`
 }
 
 type GetThreadInput struct {
@@ -152,10 +152,10 @@ type GetThreadInput struct {
 }
 
 type UpdateThreadInput struct {
-	ThreadID string `validate:"required"`
-	Content  string `validate:"required,max=2000"`
-	UserID   string `validate:""`
-	UserType int32  `validate:"required"`
+	ThreadID string                `validate:"required"`
+	Content  string                `validate:"required,max=2000"`
+	UserID   string                `validate:""`
+	UserType entity.ThreadUserType `validate:"required"`
 }
 
 type DeleteThreadInput struct {

--- a/api/internal/messenger/input.go
+++ b/api/internal/messenger/input.go
@@ -133,6 +133,10 @@ type GetContactCategoryInput struct {
 	CategoryID string `validate:"required"`
 }
 
+type MultiGetContactCategoriesInput struct {
+	CategoryIDs []string `validate:"opitempty,dive,required"`
+}
+
 type ListThreadsByContactIDInput struct {
 	ContactID string `validate:"required"`
 	UserID    string `validate:""`

--- a/api/internal/messenger/service.go
+++ b/api/internal/messenger/service.go
@@ -41,6 +41,8 @@ type Service interface {
 	DeleteContact(ctx context.Context, in *DeleteContactInput) error
 	// お問い合わせ種別一覧取得
 	ListContactCategories(ctx context.Context, in *ListContactCategoriesInput) (entity.ContactCategories, error)
+	// お問い合わせ種別一覧取得(ID指定)
+	MultiGetContactCategories(ctx context.Context, in *MultiGetContactCategoriesInput) (entity.ContactCategories, error)
 	// お問い合わせ種別取得
 	GetContactCategory(ctx context.Context, in *GetContactCategoryInput) (*entity.ContactCategory, error)
 	// お問い合わせ会話履歴一覧取得(お問い合わせID指定)

--- a/api/internal/messenger/service/contact_category.go
+++ b/api/internal/messenger/service/contact_category.go
@@ -24,6 +24,16 @@ func (s *service) ListContactCategories(ctx context.Context, in *messenger.ListC
 	return categories, nil
 }
 
+func (s *service) MultiGetContactCategories(
+	ctx context.Context, in *messenger.MultiGetContactCategoriesInput,
+) (entity.ContactCategories, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, exception.InternalError(err)
+	}
+	categories, err := s.db.ContactCategory.MultiGet(ctx, in.CategoryIDs)
+	return categories, exception.InternalError(err)
+}
+
 func (s *service) GetContactCategory(ctx context.Context, in *messenger.GetContactCategoryInput) (*entity.ContactCategory, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return nil, exception.InternalError(err)

--- a/api/mock/messenger/database/database.go
+++ b/api/mock/messenger/database/database.go
@@ -210,6 +210,26 @@ func (mr *MockContactCategoryMockRecorder) List(ctx, params interface{}, fields 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockContactCategory)(nil).List), varargs...)
 }
 
+// MultiGet mocks base method.
+func (m *MockContactCategory) MultiGet(ctx context.Context, categoryIDs []string, fields ...string) (entity.ContactCategories, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, categoryIDs}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MultiGet", varargs...)
+	ret0, _ := ret[0].(entity.ContactCategories)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiGet indicates an expected call of MultiGet.
+func (mr *MockContactCategoryMockRecorder) MultiGet(ctx, categoryIDs interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, categoryIDs}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiGet", reflect.TypeOf((*MockContactCategory)(nil).MultiGet), varargs...)
+}
+
 // MockContactRead is a mock of ContactRead interface.
 type MockContactRead struct {
 	ctrl     *gomock.Controller

--- a/api/mock/messenger/service.go
+++ b/api/mock/messenger/service.go
@@ -307,6 +307,21 @@ func (mr *MockServiceMockRecorder) ListThreadsByContactID(ctx, in interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListThreadsByContactID", reflect.TypeOf((*MockService)(nil).ListThreadsByContactID), ctx, in)
 }
 
+// MultiGetContactCategories mocks base method.
+func (m *MockService) MultiGetContactCategories(ctx context.Context, in *messenger.MultiGetContactCategoriesInput) (entity.ContactCategories, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MultiGetContactCategories", ctx, in)
+	ret0, _ := ret[0].(entity.ContactCategories)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiGetContactCategories indicates an expected call of MultiGetContactCategories.
+func (mr *MockServiceMockRecorder) MultiGetContactCategories(ctx, in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiGetContactCategories", reflect.TypeOf((*MockService)(nil).MultiGetContactCategories), ctx, in)
+}
+
 // NotifyNotification mocks base method.
 func (m *MockService) NotifyNotification(ctx context.Context, in *messenger.NotifyNotificationInput) error {
 	m.ctrl.T.Helper()

--- a/docs/swagger/admin/components/schemas/entity/contact-category.yaml
+++ b/docs/swagger/admin/components/schemas/entity/contact-category.yaml
@@ -1,0 +1,28 @@
+contactCategory:
+  type: object
+  description: お問い合わせ種別情報
+  properties:
+    id:
+      type: string
+      description: お問い合わせ種別ID
+    title:
+      type: string
+      description: お問い合わせ種別名
+    createdAt:
+      type: integer
+      format: int64
+      description: 登録日時 (unixtime)
+    updatedAt:
+      type: integer
+      format: int64
+      description: 更新日時 (unixtime)
+  required:
+  - id
+  - title
+  - createdAt
+  - updatedAt
+  example:
+    id: "kSByoE6FetnPs5Byk3a9Zx"
+    title: お問い合わせ種別名
+    createdAt: 1580000000
+    updatedAt: 1580000000

--- a/docs/swagger/admin/components/schemas/entity/contact.yaml
+++ b/docs/swagger/admin/components/schemas/entity/contact.yaml
@@ -1,0 +1,207 @@
+contact:
+  type: object
+  description: お問い合わせ情報
+  properties:
+    id:
+      type: string
+      description: お問い合わせID
+    title:
+      type: string
+      description: 件名
+    categoryId:
+      type: string
+      description: お問い合わせ種別ID
+    content:
+      type: string
+      description: 内容
+    username:
+      type: string
+      description: 氏名
+    email:
+      type: string
+      format: email
+      description: メールアドレス
+    phoneNumber:
+      type: string
+      description: 電話番号(国際番号 + 電話番号)
+    status:
+      $ref: './../../../openapi.yaml#/components/schemas/contactStatus'
+    note:
+      type: string
+      description: 対応時メモ
+    createdAt:
+      type: integer
+      format: int64
+      description: 登録日時 (unixtime)
+    updatedAt:
+      type: integer
+      format: int64
+      description: 更新日時 (unixtime)
+    threads:
+      type: array
+      description: 会話履歴一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/v1ThreadResponse'
+  required:
+  - id
+  - title
+  - categoryId
+  - content
+  - username
+  - email
+  - phoneNumber
+  - status
+  - note
+  - createdAt
+  - updatedAt
+  - threads
+  example:
+    id: 'kSByoE6FetnPs5Byk3a9Zx'
+    title: 'お問い合わせ件名'
+    categoryId: 'kSByoE6FetnPs5Byk3a9Zx'
+    content: 'お問い合わせ内容です。'
+    username: '問合 太郎'
+    email: 'test-user@and-period.jp'
+    phoneNumber: '+819012345678'
+    status: 1
+    note: '対応者のメモです。'
+    createdAt: 1640962800
+    updatedAt: 1640962800
+    threads:
+      - id: "kSByoE6FetnPs5Byk3a9Zx"
+        contactId: "kSByoE6FetnPs5Byk3a9Zx"
+        userId: "kSByoE6FetnPs5Byk3a9Zx"
+        userType: 1
+        content: お問い合わせ内容
+        createdAt: 1580000000
+        updatedAt: 1580000000
+contactsResponse:
+  type: object
+  properties:
+    contacts:
+      type: array
+      description: お問い合わせ一覧
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            description: お問い合わせID
+          title:
+            type: string
+            description: 件名
+          categoryId:
+            type: string
+            description: お問い合わせ種別ID
+          content:
+            type: string
+            description: 内容
+          username:
+            type: string
+            description: 氏名
+          email:
+            type: string
+            format: email
+            description: メールアドレス
+          phoneNumber:
+            type: string
+            description: 電話番号(国際番号 + 電話番号)
+          status:
+            $ref: './../../../openapi.yaml#/components/schemas/contactStatus'
+          note:
+            type: string
+            description: 対応時メモ
+          createdAt:
+            type: integer
+            format: int64
+            description: 登録日時 (unixtime)
+          updatedAt:
+            type: integer
+            format: int64
+            description: 更新日時 (unixtime)
+          threads:
+            type: array
+            description: 会話履歴一覧
+            items:
+              $ref: './../../../openapi.yaml#/components/schemas/v1ThreadResponse'
+        required:
+        - id
+        - title
+        - categoryId
+        - content
+        - username
+        - email
+        - phoneNumber
+        - status
+        - note
+        - createdAt
+        - updatedAt
+        - threads
+        example:
+          id: 'kSByoE6FetnPs5Byk3a9Zx'
+          title: 'お問い合わせ件名'
+          categoryId: 'kSByoE6FetnPs5Byk3a9Zx'
+          content: 'お問い合わせ内容です。'
+          username: '問合 太郎'
+          email: 'test-user@and-period.jp'
+          phoneNumber: '+819012345678'
+          status: 1
+          note: '対応者のメモです。'
+          createdAt: 1640962800
+          updatedAt: 1640962800
+          threads:
+            - id: "kSByoE6FetnPs5Byk3a9Zx"
+              contactId: "kSByoE6FetnPs5Byk3a9Zx"
+              userId: "kSByoE6FetnPs5Byk3a9Zx"
+              userType: 1
+              content: お問い合わせ内容
+              createdAt: 1580000000
+              updatedAt: 1580000000
+    total:
+      type: integer
+      format: int64
+      description: 合計数
+  required:
+  - contacts
+  - total
+  example:
+    contacts:
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      title: 'お問い合わせ件名'
+      categpryId: 'kSByoE6FetnPs5Byk3a9Zx'
+      content: 'お問い合わせ内容です。'
+      username: '問合 太郎'
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      status: 1
+      note: '対応者のメモです。'
+      createdAt: 1640962800
+      updatedAt: 1640962800
+      threads:
+      - id: "kSByoE6FetnPs5Byk3a9Zx"
+        contactId: "kSByoE6FetnPs5Byk3a9Zx"
+        userId: "kSByoE6FetnPs5Byk3a9Zx"
+        userType: 1
+        content: お問い合わせ内容
+        createdAt: 1580000000
+        updatedAt: 1580000000
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      title: 'お問い合わせ件名'
+      categpryId: 'kSByoE6FetnPs5Byk3a9Zx'
+      content: 'お問い合わせ内容です。'
+      username: '問合 太郎'
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      status: 2
+      note: '対応者のメモです。'
+      createdAt: 1640962800
+      updatedAt: 1640962800
+      threads:
+      - id: "kSByoE6FetnPs5Byk3a9Zx"
+        contactId: "kSByoE6FetnPs5Byk3a9Zx"
+        userId: "kSByoE6FetnPs5Byk3a9Zx"
+        userType: 2
+        content: お問い合わせ内容
+        createdAt: 1580000000
+        updatedAt: 1580000000
+    total: 2

--- a/docs/swagger/admin/components/schemas/entity/thread.yaml
+++ b/docs/swagger/admin/components/schemas/entity/thread.yaml
@@ -1,0 +1,41 @@
+thread:
+  type: object
+  description: お問い合わせ会話履歴情報
+  properties:
+    id:
+      type: string
+      description: お問い合わせ会話履歴ID
+    contactId:
+      type: string
+      description: お問い合わせID
+    userId:
+      type: string
+      description: 送信者ID
+    userType:
+      $ref: './../../../openapi.yaml#/components/schemas/contactUserType'
+    content:
+      type: string
+      description: 会話内容
+    createdAt:
+      type: integer
+      format: int64
+      description: 登録日時 (unixtime)
+    updatedAt:
+      type: integer
+      format: int64
+      description: 更新日時 (unixtime)
+  required:
+  - id
+  - contactId
+  - userType
+  - content
+  - createdAt
+  - updatedAt
+  example:
+    id: "kSByoE6FetnPs5Byk3a9Zx"
+    contactId: "kSByoE6FetnPs5Byk3a9Zx"
+    userId: "kSByoE6FetnPs5Byk3a9Zx"
+    userType: 1
+    content: お問い合わせ内容
+    createdAt: 1580000000
+    updatedAt: 1580000000

--- a/docs/swagger/admin/components/schemas/v1/contact-category.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/contact-category.response.yaml
@@ -1,30 +1,16 @@
 contactCategoryResponse:
   type: object
   properties:
-    id:
-      type: string
-      description: お問い合わせ種別ID
-    title:
-      type: string
-      description: お問い合わせ種別名
-    createdAt:
-      type: integer
-      format: int64
-      description: 登録日時 (unixtime)
-    updatedAt:
-      type: integer
-      format: int64
-      description: 更新日時 (unixtime)
+    contactCategory:
+      $ref: './../../../openapi.yaml#/components/schemas/contactCategory'
   required:
-  - id
-  - title
-  - createdAt
-  - updatedAt
+  - contactCategory
   example:
-    id: "kSByoE6FetnPs5Byk3a9Zx"
-    title: お問い合わせ種別名
-    createdAt: 1580000000
-    updatedAt: 1580000000
+    contactCategory:
+      id: "kSByoE6FetnPs5Byk3a9Zx"
+      title: お問い合わせ種別名
+      createdAt: 1580000000
+      updatedAt: 1580000000
 contactCategoriesResponse:
   type: object
   properties:
@@ -32,26 +18,7 @@ contactCategoriesResponse:
       type: array
       description: お問い合わせ種別一覧
       items:
-        properties:
-          id:
-            type: string
-            description: お問い合わせ種別ID
-          title:
-            type: string
-            description: お問い合わせ種別名
-          createdAt:
-            type: integer
-            format: int64
-            description: 登録日時 (unixtime)
-          updatedAt:
-            type: integer
-            format: int64
-            description: 更新日時 (unixtime)
-        required:
-        - id
-        - title
-        - createdAt
-        - updatedAt
+        $ref: './../../../openapi.yaml#/components/schemas/contactCategory'
   required:
   - contactCategories
   example:

--- a/docs/swagger/admin/components/schemas/v1/contact.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/contact.response.yaml
@@ -149,7 +149,7 @@ contactsResponse:
       addressLine2: ''
       createdAt: 1640962800
       updatedAt: 1640962800
-    responder:
+    responders:
     - id: 'kSByoE6FetnPs5Byk3a9Zx'
       role: 2
       lastname: '&.'

--- a/docs/swagger/admin/components/schemas/v1/contact.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/contact.response.yaml
@@ -1,71 +1,41 @@
 contactResponse:
   type: object
   properties:
-    id:
-      type: string
-      description: お問い合わせID
-    title:
-      type: string
-      description: 件名
-    categoryId:
-      type: string
-      description: お問い合わせ種別ID
-    content:
-      type: string
-      description: 内容
-    username:
-      type: string
-      description: 氏名
-    email:
-      type: string
-      format: email
-      description: メールアドレス
-    phoneNumber:
-      type: string
-      description: 電話番号(国際番号 + 電話番号)
-    status:
-      $ref: './../../../openapi.yaml#/components/schemas/contactStatus'
-    note:
-      type: string
-      description: 対応時メモ
-    createdAt:
-      type: integer
-      format: int64
-      description: 登録日時 (unixtime)
-    updatedAt:
-      type: integer
-      format: int64
-      description: 更新日時 (unixtime)
+    contact:
+      $ref: './../../../openapi.yaml#/components/schemas/contact'
+    contactCategory:
+      $ref: './../../../openapi.yaml#/components/schemas/contactCategory'
     threads:
       type: array
       description: 会話履歴一覧
       items:
-        $ref: './../../../openapi.yaml#/components/schemas/v1ThreadResponse'
+        $ref: './../../../openapi.yaml#/components/schemas/thread'
+    user:
+      $ref: './../../../openapi.yaml#/components/schemas/user'
+    responder:
+      $ref: './../../../openapi.yaml#/components/schemas/admin'
   required:
-  - id
-  - title
-  - categoryId
-  - content
-  - username
-  - email
-  - phoneNumber
-  - status
-  - note
-  - createdAt
-  - updatedAt
+  - contact
+  - contactCategory
   - threads
   example:
-    id: 'kSByoE6FetnPs5Byk3a9Zx'
-    title: 'お問い合わせ件名'
-    categoryId: 'kSByoE6FetnPs5Byk3a9Zx'
-    content: 'お問い合わせ内容です。'
-    username: '問合 太郎'
-    email: 'test-user@and-period.jp'
-    phoneNumber: '+819012345678'
-    status: 1
-    note: '対応者のメモです。'
-    createdAt: 1640962800
-    updatedAt: 1640962800
+    contact:
+      id: 'kSByoE6FetnPs5Byk3a9Zx'
+      title: 'お問い合わせ件名'
+      categoryId: 'kSByoE6FetnPs5Byk3a9Zx'
+      content: 'お問い合わせ内容です。'
+      username: '問合 太郎'
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      status: 1
+      note: '対応者のメモです。'
+      createdAt: 1640962800
+      updatedAt: 1640962800
+    contactCategory:
+      id: "kSByoE6FetnPs5Byk3a9Zx"
+      title: お問い合わせ種別名
+      createdAt: 1580000000
+      updatedAt: 1580000000
     threads:
       - id: "kSByoE6FetnPs5Byk3a9Zx"
         contactId: "kSByoE6FetnPs5Byk3a9Zx"
@@ -74,6 +44,32 @@ contactResponse:
         content: お問い合わせ内容
         createdAt: 1580000000
         updatedAt: 1580000000
+    user:
+      id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastname: '&.'
+      firstname: '購入者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'こうにゅうしゃ'
+      registered: true
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      postalCode: '1000014'
+      prefecture: 'tokyo'
+      city: '千代田区'
+      addressLine1: '永田町1-7-1'
+      addressLine2: ''
+      createdAt: 1640962800
+      updatedAt: 1640962800
+    responder:
+      id: 'kSByoE6FetnPs5Byk3a9Zx'
+      role: 2
+      lastname: '&.'
+      firstname: '管理者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'かんりしゃ'
+      email: 'test-user@and-period.jp'
+      createdAt: 1640962800
+      updatedAt: 1640962800
 contactsResponse:
   type: object
   properties:
@@ -81,87 +77,35 @@ contactsResponse:
       type: array
       description: お問い合わせ一覧
       items:
-        type: object
-        properties:
-          id:
-            type: string
-            description: お問い合わせID
-          title:
-            type: string
-            description: 件名
-          categoryId:
-            type: string
-            description: お問い合わせ種別ID
-          content:
-            type: string
-            description: 内容
-          username:
-            type: string
-            description: 氏名
-          email:
-            type: string
-            format: email
-            description: メールアドレス
-          phoneNumber:
-            type: string
-            description: 電話番号(国際番号 + 電話番号)
-          status:
-            $ref: './../../../openapi.yaml#/components/schemas/contactStatus'
-          note:
-            type: string
-            description: 対応時メモ
-          createdAt:
-            type: integer
-            format: int64
-            description: 登録日時 (unixtime)
-          updatedAt:
-            type: integer
-            format: int64
-            description: 更新日時 (unixtime)
-          threads:
-            type: array
-            description: 会話履歴一覧
-            items:
-              $ref: './../../../openapi.yaml#/components/schemas/v1ThreadResponse'
-        required:
-        - id
-        - title
-        - categoryId
-        - content
-        - username
-        - email
-        - phoneNumber
-        - status
-        - note
-        - createdAt
-        - updatedAt
-        - threads
-        example:
-          id: 'kSByoE6FetnPs5Byk3a9Zx'
-          title: 'お問い合わせ件名'
-          categoryId: 'kSByoE6FetnPs5Byk3a9Zx'
-          content: 'お問い合わせ内容です。'
-          username: '問合 太郎'
-          email: 'test-user@and-period.jp'
-          phoneNumber: '+819012345678'
-          status: 1
-          note: '対応者のメモです。'
-          createdAt: 1640962800
-          updatedAt: 1640962800
-          threads:
-            - id: "kSByoE6FetnPs5Byk3a9Zx"
-              contactId: "kSByoE6FetnPs5Byk3a9Zx"
-              userId: "kSByoE6FetnPs5Byk3a9Zx"
-              userType: 1
-              content: お問い合わせ内容
-              createdAt: 1580000000
-              updatedAt: 1580000000
+        $ref: './../../../openapi.yaml#/components/schemas/contact'
+    contactCategories:
+      type: array
+      description: お問い合わせ種別一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/contactCategory'
+    threads:
+      type: array
+      description: 会話履歴一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/thread'
+    users:
+      type: array
+      description: ユーザー一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/user'
+    responders:
+      type: array
+      description: 管理者一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/admin'
     total:
       type: integer
       format: int64
       description: 合計数
   required:
   - contacts
+  - contactCategories
+  - threads
   - total
   example:
     contacts:
@@ -176,31 +120,43 @@ contactsResponse:
       note: '対応者のメモです。'
       createdAt: 1640962800
       updatedAt: 1640962800
-      threads:
-      - id: "kSByoE6FetnPs5Byk3a9Zx"
-        contactId: "kSByoE6FetnPs5Byk3a9Zx"
-        userId: "kSByoE6FetnPs5Byk3a9Zx"
-        userType: 1
-        content: お問い合わせ内容
-        createdAt: 1580000000
-        updatedAt: 1580000000
+    threads:
+    - id: "kSByoE6FetnPs5Byk3a9Zx"
+      contactId: "kSByoE6FetnPs5Byk3a9Zx"
+      userId: "kSByoE6FetnPs5Byk3a9Zx"
+      userType: 1
+      content: お問い合わせ内容
+      createdAt: 1580000000
+      updatedAt: 1580000000
+    contactCategories:
+    - id: "kSByoE6FetnPs5Byk3a9Zx"
+      title: お問い合わせ種別名
+      createdAt: 1580000000
+      updatedAt: 1580000000
+    users:
     - id: 'kSByoE6FetnPs5Byk3a9Zx'
-      title: 'お問い合わせ件名'
-      categpryId: 'kSByoE6FetnPs5Byk3a9Zx'
-      content: 'お問い合わせ内容です。'
-      username: '問合 太郎'
+      lastname: '&.'
+      firstname: '購入者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'こうにゅうしゃ'
+      registered: true
       email: 'test-user@and-period.jp'
       phoneNumber: '+819012345678'
-      status: 2
-      note: '対応者のメモです。'
+      postalCode: '1000014'
+      prefecture: 'tokyo'
+      city: '千代田区'
+      addressLine1: '永田町1-7-1'
+      addressLine2: ''
       createdAt: 1640962800
       updatedAt: 1640962800
-      threads:
-      - id: "kSByoE6FetnPs5Byk3a9Zx"
-        contactId: "kSByoE6FetnPs5Byk3a9Zx"
-        userId: "kSByoE6FetnPs5Byk3a9Zx"
-        userType: 2
-        content: お問い合わせ内容
-        createdAt: 1580000000
-        updatedAt: 1580000000
-    total: 2
+    responder:
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      role: 2
+      lastname: '&.'
+      firstname: '管理者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'かんりしゃ'
+      email: 'test-user@and-period.jp'
+      createdAt: 1640962800
+      updatedAt: 1640962800
+    total: 1

--- a/docs/swagger/admin/components/schemas/v1/thread.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/thread.response.yaml
@@ -1,43 +1,40 @@
 threadResponse:
   type: object
   properties:
-    id:
-      type: string
-      description: お問い合わせ会話履歴ID
-    contactId:
-      type: string
-      description: お問い合わせID
-    userId:
-      type: string
-      description: 送信者ID
-    userType:
-      $ref: './../../../openapi.yaml#/components/schemas/contactUserType'
-    content:
-      type: string
-      description: 会話内容
-    createdAt:
-      type: integer
-      format: int64
-      description: 登録日時 (unixtime)
-    updatedAt:
-      type: integer
-      format: int64
-      description: 更新日時 (unixtime)
+    thread:
+      $ref: './../../../openapi.yaml#/components/schemas/thread'
+    user:
+      $ref: './../../../openapi.yaml#/components/schemas/user'
+    admin:
+      $ref: './../../../openapi.yaml#/components/schemas/admin'
   required:
-  - id
-  - contactId
-  - userType
-  - content
-  - createdAt
-  - updatedAt
+  - thread
   example:
-    id: "kSByoE6FetnPs5Byk3a9Zx"
-    contactId: "kSByoE6FetnPs5Byk3a9Zx"
-    userId: "kSByoE6FetnPs5Byk3a9Zx"
-    userType: 1
-    content: お問い合わせ内容
-    createdAt: 1580000000
-    updatedAt: 1580000000
+    thread:
+      id: "kSByoE6FetnPs5Byk3a9Zx"
+      contactId: "kSByoE6FetnPs5Byk3a9Zx"
+      userId: "kSByoE6FetnPs5Byk3a9Zx"
+      userType: 1
+      content: お問い合わせ内容
+      createdAt: 1580000000
+      updatedAt: 1580000000
+    user:
+      id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastname: '&.'
+      firstname: '購入者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'こうにゅうしゃ'
+      registered: true
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      postalCode: '1000014'
+      prefecture: 'tokyo'
+      city: '千代田区'
+      addressLine1: '永田町1-7-1'
+      addressLine2: ''
+      createdAt: 1640962800
+      updatedAt: 1640962800
+
 threadsResponse:
   type: object
   properties:
@@ -45,32 +42,20 @@ threadsResponse:
       type: array
       description: お問い合わせ会話履歴一覧
       items:
-        properties:
-          id:
-            type: string
-            description: お問い合わせ会話履歴ID
-          contactId:
-            type: string
-            description: お問い合わせID
-          userId:
-            type: string
-            description: 送信者ID
-          userType:
-            $ref: './../../../openapi.yaml#/components/schemas/contactUserType'
-          content:
-            type: string
-            description: 会話内容
-          createdAt:
-            type: integer
-            format: int64
-            description: 登録日時 (unixtime)
-          updatedAt:
-            type: integer
-            format: int64
-            description: 更新日時 (unixtime)
+        $ref: './../../../openapi.yaml#/components/schemas/thread'
+    users:
+      type: array
+      description: お問い合わせ会話ユーザー一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/user'
+    admins:
+      type: array
+      description: お問い合わせ会話管理者一覧
+      items:
+        $ref: './../../../openapi.yaml#/components/schemas/admin'
     total:
       type: integer
-      format: int32
+      format: int64
       description: お問い合わせ会話履歴総数
   required:
   - threads
@@ -84,4 +69,29 @@ threadsResponse:
       content: お問い合わせ内容
       createdAt: 1580000000
       updatedAt: 1580000000
-    total: 1
+    users:
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastname: '&.'
+      firstname: '購入者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'こうにゅうしゃ'
+      registered: true
+      email: 'test-user@and-period.jp'
+      phoneNumber: '+819012345678'
+      postalCode: '1000014'
+      prefecture: 'tokyo'
+      city: '千代田区'
+      addressLine1: '永田町1-7-1'
+      addressLine2: ''
+      createdAt: 1640962800
+      updatedAt: 1640962800
+    admins:
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      role: 2
+      lastname: '&.'
+      firstname: '管理者'
+      lastnameKana: 'あんどどっと'
+      firstnameKana: 'かんりしゃ'
+      email: 'test-user@and-period.jp'
+      createdAt: 1640962800
+      updatedAt: 1640962800

--- a/docs/swagger/admin/openapi.yaml
+++ b/docs/swagger/admin/openapi.yaml
@@ -268,6 +268,10 @@ components:
       $ref: './components/schemas/entity/administrator.yaml#/administrator'
     category:
       $ref: './components/schemas/entity/category.yaml#/category'
+    contactCategory:
+      $ref: './components/schemas/entity/contact-category.yaml#/contactCategory'
+    contact:
+      $ref: './components/schemas/entity/contact.yaml#/contact'
     coordinator:
       $ref: './components/schemas/entity/coordinator.yaml#/coordinator'
     live:
@@ -290,6 +294,8 @@ components:
       $ref: './components/schemas/entity/schedule.yaml#/schedule'
     shipping:
       $ref: './components/schemas/entity/shipping.yaml#/shipping'
+    thread:
+      $ref: './components/schemas/entity/thread.yaml#/thread'
     user:
       $ref: './components/schemas/entity/user.yaml#/user'
     # Request

--- a/web/admin/src/components/templates/ContactList.vue
+++ b/web/admin/src/components/templates/ContactList.vue
@@ -2,7 +2,7 @@
 import { VDataTable } from 'vuetify/lib/labs/components.mjs'
 
 import { AlertType } from '~/lib/hooks'
-import { ContactStatus, ContactsResponseContactsInner } from '~/types/api'
+import { ContactStatus, ContactsResponse } from '~/types/api'
 
 const props = defineProps({
   loading: {
@@ -26,7 +26,7 @@ const props = defineProps({
     default: () => []
   },
   contacts: {
-    type: Array<ContactsResponseContactsInner>,
+    type: Array<ContactsResponse>,
     default: () => []
   },
   tableItemsPerPage: {

--- a/web/admin/src/store/contact.ts
+++ b/web/admin/src/store/contact.ts
@@ -2,16 +2,16 @@ import { defineStore } from 'pinia'
 
 import { useCommonStore } from './common'
 import {
+  Contact,
   ContactResponse,
-  ContactsResponseContactsInner,
   UpdateContactRequest
 } from '~/types/api'
 import { apiClient } from '~/plugins/api-client'
 
 export const useContactStore = defineStore('contact', {
   state: () => ({
-    contact: {} as ContactResponse,
-    contacts: [] as Array<ContactsResponseContactsInner>,
+    contact: {} as Contact,
+    contacts: [] as Contact[],
     total: 0
   }),
 
@@ -24,7 +24,7 @@ export const useContactStore = defineStore('contact', {
      */
     async fetchContacts (limit = 20, offset = 0, orders: string[] = []): Promise<void> {
       try {
-        const res = await apiClient.contactApi().v1ListContacts(limit, offset, orders.join(','))
+        const res = await apiClient.contactApi().v1ListContacts(limit, offset)
         this.contacts = res.data.contacts
         this.total = res.data.total
       } catch (err) {
@@ -39,7 +39,7 @@ export const useContactStore = defineStore('contact', {
     async getContact (contactId: string): Promise<ContactResponse> {
       try {
         const res = await apiClient.contactApi().v1GetContact(contactId)
-        this.contact = res.data
+        this.contact = res.data.contact
         return res.data
       } catch (err) {
         return this.errorHandler(err)

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -397,6 +397,87 @@ export interface CategoryResponse {
     'category': Category;
 }
 /**
+ * お問い合わせ情報
+ * @export
+ * @interface Contact
+ */
+export interface Contact {
+    /**
+     * お問い合わせID
+     * @type {string}
+     * @memberof Contact
+     */
+    'id': string;
+    /**
+     * 件名
+     * @type {string}
+     * @memberof Contact
+     */
+    'title': string;
+    /**
+     * お問い合わせ種別ID
+     * @type {string}
+     * @memberof Contact
+     */
+    'categoryId': string;
+    /**
+     * 内容
+     * @type {string}
+     * @memberof Contact
+     */
+    'content': string;
+    /**
+     * 氏名
+     * @type {string}
+     * @memberof Contact
+     */
+    'username': string;
+    /**
+     * メールアドレス
+     * @type {string}
+     * @memberof Contact
+     */
+    'email': string;
+    /**
+     * 電話番号(国際番号 + 電話番号)
+     * @type {string}
+     * @memberof Contact
+     */
+    'phoneNumber': string;
+    /**
+     * 
+     * @type {ContactStatus}
+     * @memberof Contact
+     */
+    'status': ContactStatus;
+    /**
+     * 対応時メモ
+     * @type {string}
+     * @memberof Contact
+     */
+    'note': string;
+    /**
+     * 登録日時 (unixtime)
+     * @type {number}
+     * @memberof Contact
+     */
+    'createdAt': number;
+    /**
+     * 更新日時 (unixtime)
+     * @type {number}
+     * @memberof Contact
+     */
+    'updatedAt': number;
+    /**
+     * 会話履歴一覧
+     * @type {Array<ThreadResponse>}
+     * @memberof Contact
+     */
+    'threads': Array<ThreadResponse>;
+}
+
+
+/**
  * 
  * @export
  * @interface ContactCategoriesResponse
@@ -404,39 +485,39 @@ export interface CategoryResponse {
 export interface ContactCategoriesResponse {
     /**
      * お問い合わせ種別一覧
-     * @type {Array<ContactCategoriesResponseContactCategoriesInner>}
+     * @type {Array<ContactCategory>}
      * @memberof ContactCategoriesResponse
      */
-    'contactCategories': Array<ContactCategoriesResponseContactCategoriesInner>;
+    'contactCategories': Array<ContactCategory>;
 }
 /**
- * 
+ * お問い合わせ種別情報
  * @export
- * @interface ContactCategoriesResponseContactCategoriesInner
+ * @interface ContactCategory
  */
-export interface ContactCategoriesResponseContactCategoriesInner {
+export interface ContactCategory {
     /**
      * お問い合わせ種別ID
      * @type {string}
-     * @memberof ContactCategoriesResponseContactCategoriesInner
+     * @memberof ContactCategory
      */
     'id': string;
     /**
      * お問い合わせ種別名
      * @type {string}
-     * @memberof ContactCategoriesResponseContactCategoriesInner
+     * @memberof ContactCategory
      */
     'title': string;
     /**
      * 登録日時 (unixtime)
      * @type {number}
-     * @memberof ContactCategoriesResponseContactCategoriesInner
+     * @memberof ContactCategory
      */
     'createdAt': number;
     /**
      * 更新日時 (unixtime)
      * @type {number}
-     * @memberof ContactCategoriesResponseContactCategoriesInner
+     * @memberof ContactCategory
      */
     'updatedAt': number;
 }
@@ -447,29 +528,11 @@ export interface ContactCategoriesResponseContactCategoriesInner {
  */
 export interface ContactCategoryResponse {
     /**
-     * お問い合わせ種別ID
-     * @type {string}
+     * 
+     * @type {ContactCategory}
      * @memberof ContactCategoryResponse
      */
-    'id': string;
-    /**
-     * お問い合わせ種別名
-     * @type {string}
-     * @memberof ContactCategoryResponse
-     */
-    'title': string;
-    /**
-     * 登録日時 (unixtime)
-     * @type {number}
-     * @memberof ContactCategoryResponse
-     */
-    'createdAt': number;
-    /**
-     * 更新日時 (unixtime)
-     * @type {number}
-     * @memberof ContactCategoryResponse
-     */
-    'updatedAt': number;
+    'contactCategory': ContactCategory;
 }
 /**
  * 
@@ -478,80 +541,36 @@ export interface ContactCategoryResponse {
  */
 export interface ContactResponse {
     /**
-     * お問い合わせID
-     * @type {string}
+     * 
+     * @type {Contact}
      * @memberof ContactResponse
      */
-    'id': string;
-    /**
-     * 件名
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'title': string;
-    /**
-     * お問い合わせ種別ID
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'categoryId': string;
-    /**
-     * 内容
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'content': string;
-    /**
-     * 氏名
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'username': string;
-    /**
-     * メールアドレス
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'email': string;
-    /**
-     * 電話番号(国際番号 + 電話番号)
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'phoneNumber': string;
+    'contact': Contact;
     /**
      * 
-     * @type {ContactStatus}
+     * @type {ContactCategory}
      * @memberof ContactResponse
      */
-    'status': ContactStatus;
-    /**
-     * 対応時メモ
-     * @type {string}
-     * @memberof ContactResponse
-     */
-    'note': string;
-    /**
-     * 登録日時 (unixtime)
-     * @type {number}
-     * @memberof ContactResponse
-     */
-    'createdAt': number;
-    /**
-     * 更新日時 (unixtime)
-     * @type {number}
-     * @memberof ContactResponse
-     */
-    'updatedAt': number;
+    'contactCategory': ContactCategory;
     /**
      * 会話履歴一覧
-     * @type {Array<ThreadResponse1>}
+     * @type {Array<Thread>}
      * @memberof ContactResponse
      */
-    'threads': Array<ThreadResponse1>;
+    'threads': Array<Thread>;
+    /**
+     * 
+     * @type {User}
+     * @memberof ContactResponse
+     */
+    'user'?: User;
+    /**
+     * 
+     * @type {Admin}
+     * @memberof ContactResponse
+     */
+    'responder'?: Admin;
 }
-
-
 /**
  * お問い合わせ対応状況
  * @export
@@ -620,10 +639,34 @@ export type ContactUserType = typeof ContactUserType[keyof typeof ContactUserTyp
 export interface ContactsResponse {
     /**
      * お問い合わせ一覧
-     * @type {Array<ContactsResponseContactsInner>}
+     * @type {Array<Contact>}
      * @memberof ContactsResponse
      */
-    'contacts': Array<ContactsResponseContactsInner>;
+    'contacts': Array<Contact>;
+    /**
+     * お問い合わせ種別一覧
+     * @type {Array<ContactCategory>}
+     * @memberof ContactsResponse
+     */
+    'contactCategories': Array<ContactCategory>;
+    /**
+     * 会話履歴一覧
+     * @type {Array<Thread>}
+     * @memberof ContactsResponse
+     */
+    'threads': Array<Thread>;
+    /**
+     * ユーザー一覧
+     * @type {Array<User>}
+     * @memberof ContactsResponse
+     */
+    'users'?: Array<User>;
+    /**
+     * 管理者一覧
+     * @type {Array<Admin>}
+     * @memberof ContactsResponse
+     */
+    'responders'?: Array<Admin>;
     /**
      * 合計数
      * @type {number}
@@ -631,87 +674,6 @@ export interface ContactsResponse {
      */
     'total': number;
 }
-/**
- * 
- * @export
- * @interface ContactsResponseContactsInner
- */
-export interface ContactsResponseContactsInner {
-    /**
-     * お問い合わせID
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'id': string;
-    /**
-     * 件名
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'title': string;
-    /**
-     * お問い合わせ種別ID
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'categoryId': string;
-    /**
-     * 内容
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'content': string;
-    /**
-     * 氏名
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'username': string;
-    /**
-     * メールアドレス
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'email': string;
-    /**
-     * 電話番号(国際番号 + 電話番号)
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'phoneNumber': string;
-    /**
-     * 
-     * @type {ContactStatus}
-     * @memberof ContactsResponseContactsInner
-     */
-    'status': ContactStatus;
-    /**
-     * 対応時メモ
-     * @type {string}
-     * @memberof ContactsResponseContactsInner
-     */
-    'note': string;
-    /**
-     * 登録日時 (unixtime)
-     * @type {number}
-     * @memberof ContactsResponseContactsInner
-     */
-    'createdAt': number;
-    /**
-     * 更新日時 (unixtime)
-     * @type {number}
-     * @memberof ContactsResponseContactsInner
-     */
-    'updatedAt': number;
-    /**
-     * 会話履歴一覧
-     * @type {Array<ThreadResponse1>}
-     * @memberof ContactsResponseContactsInner
-     */
-    'threads': Array<ThreadResponse1>;
-}
-
-
 /**
  * コーディネータ情報
  * @export
@@ -4593,51 +4555,51 @@ export type StorageMethodType = typeof StorageMethodType[keyof typeof StorageMet
 
 
 /**
- * 
+ * お問い合わせ会話履歴情報
  * @export
- * @interface ThreadResponse
+ * @interface Thread
  */
-export interface ThreadResponse {
+export interface Thread {
     /**
      * お問い合わせ会話履歴ID
      * @type {string}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'id': string;
     /**
      * お問い合わせID
      * @type {string}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'contactId': string;
     /**
      * 送信者ID
      * @type {string}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'userId'?: string;
     /**
      * 
      * @type {ContactUserType}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'userType': ContactUserType;
     /**
      * 会話内容
      * @type {string}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'content': string;
     /**
      * 登録日時 (unixtime)
      * @type {number}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'createdAt': number;
     /**
      * 更新日時 (unixtime)
      * @type {number}
-     * @memberof ThreadResponse
+     * @memberof Thread
      */
     'updatedAt': number;
 }
@@ -4646,54 +4608,28 @@ export interface ThreadResponse {
 /**
  * 
  * @export
- * @interface ThreadResponse1
+ * @interface ThreadResponse
  */
-export interface ThreadResponse1 {
-    /**
-     * お問い合わせ会話履歴ID
-     * @type {string}
-     * @memberof ThreadResponse1
-     */
-    'id': string;
-    /**
-     * お問い合わせID
-     * @type {string}
-     * @memberof ThreadResponse1
-     */
-    'contactId': string;
-    /**
-     * 送信者ID
-     * @type {string}
-     * @memberof ThreadResponse1
-     */
-    'userId'?: string;
+export interface ThreadResponse {
     /**
      * 
-     * @type {ContactUserType}
-     * @memberof ThreadResponse1
+     * @type {Thread}
+     * @memberof ThreadResponse
      */
-    'userType': ContactUserType;
+    'thread': Thread;
     /**
-     * 会話内容
-     * @type {string}
-     * @memberof ThreadResponse1
+     * 
+     * @type {User}
+     * @memberof ThreadResponse
      */
-    'content': string;
+    'user'?: User;
     /**
-     * 登録日時 (unixtime)
-     * @type {number}
-     * @memberof ThreadResponse1
+     * 
+     * @type {Admin}
+     * @memberof ThreadResponse
      */
-    'createdAt': number;
-    /**
-     * 更新日時 (unixtime)
-     * @type {number}
-     * @memberof ThreadResponse1
-     */
-    'updatedAt': number;
+    'admin'?: Admin;
 }
-
-
 /**
  * 
  * @export
@@ -4702,10 +4638,22 @@ export interface ThreadResponse1 {
 export interface ThreadsResponse {
     /**
      * お問い合わせ会話履歴一覧
-     * @type {Array<ThreadsResponseThreadsInner>}
+     * @type {Array<Thread>}
      * @memberof ThreadsResponse
      */
-    'threads': Array<ThreadsResponseThreadsInner>;
+    'threads': Array<Thread>;
+    /**
+     * お問い合わせ会話ユーザー一覧
+     * @type {Array<User>}
+     * @memberof ThreadsResponse
+     */
+    'users'?: Array<User>;
+    /**
+     * お問い合わせ会話管理者一覧
+     * @type {Array<Admin>}
+     * @memberof ThreadsResponse
+     */
+    'admins'?: Array<Admin>;
     /**
      * お問い合わせ会話履歴総数
      * @type {number}
@@ -4713,57 +4661,6 @@ export interface ThreadsResponse {
      */
     'total': number;
 }
-/**
- * 
- * @export
- * @interface ThreadsResponseThreadsInner
- */
-export interface ThreadsResponseThreadsInner {
-    /**
-     * お問い合わせ会話履歴ID
-     * @type {string}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'id'?: string;
-    /**
-     * お問い合わせID
-     * @type {string}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'contactId'?: string;
-    /**
-     * 送信者ID
-     * @type {string}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'userId'?: string;
-    /**
-     * 
-     * @type {ContactUserType}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'userType'?: ContactUserType;
-    /**
-     * 会話内容
-     * @type {string}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'content'?: string;
-    /**
-     * 登録日時 (unixtime)
-     * @type {number}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'createdAt'?: number;
-    /**
-     * 更新日時 (unixtime)
-     * @type {number}
-     * @memberof ThreadsResponseThreadsInner
-     */
-    'updatedAt'?: number;
-}
-
-
 /**
  * 
  * @export
@@ -14659,7 +14556,7 @@ export const ThreadApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async v1CreateThread(body: CreateThreadRequest, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ThreadResponse1>> {
+        async v1CreateThread(body: CreateThreadRequest, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ThreadResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.v1CreateThread(body, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -14681,7 +14578,7 @@ export const ThreadApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async v1GetThread(threadId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ThreadResponse1>> {
+        async v1GetThread(threadId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ThreadResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.v1GetThread(threadId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -14727,7 +14624,7 @@ export const ThreadApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        v1CreateThread(body: CreateThreadRequest, options?: any): AxiosPromise<ThreadResponse1> {
+        v1CreateThread(body: CreateThreadRequest, options?: any): AxiosPromise<ThreadResponse> {
             return localVarFp.v1CreateThread(body, options).then((request) => request(axios, basePath));
         },
         /**
@@ -14747,7 +14644,7 @@ export const ThreadApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        v1GetThread(threadId: string, options?: any): AxiosPromise<ThreadResponse1> {
+        v1GetThread(threadId: string, options?: any): AxiosPromise<ThreadResponse> {
             return localVarFp.v1GetThread(threadId, options).then((request) => request(axios, basePath));
         },
         /**


### PR DESCRIPTION
## やったこと
- api
  - 単体のresponse更新
  - 単体のresponseを返すhandlerを更新
- swagger
  - entity作成
  - contactのresponse更新

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->
- [x] api
  - [x] 単体のresponse
  - [x] 複数のresponse
  - [x] 単体のresponse返すhandler
  - [x] 複数のresponse返すhandler
  - [x] 複数のresponse生成用のメソッド
- [x] swagger
  - [x] entity
    - [x] contact
    - [x] contact-category
    - [x] thread
  - [x] openapi
  - [x] response
    - [x] contact
    - [x] contact-category
    - [x] thread
 
## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
