### PR TITLE
feat: add DeleteMediaLiveResourcesFunction

### DIFF
--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -55,8 +55,11 @@ resources:
                 - Effect: Allow
                   Action:
                     - mediaLive:CreateInput
+                    - mediaLive:DescribeInput
+                    - mediaLive:DeleteInput
+                    - mediaLive:DescribeChannel
                     - mediaLive:CreateChannel
-                    - mediaLive:BatchUpdateSchedule
+                    - mediaLive:DeleteChannel
                     - mediaStore:CreateContainer
                     - mediaStore:DescribeContainer
                     - mediaStore:PutContainerPolicy
@@ -455,6 +458,77 @@ stepFunctions:
             ResultPath: $.RegisterResoursesInfoResult
             Resource: arn:aws:lambda:ap-northeast-1:386661535629:function:furumaru-broadcast-create-updater-stg
             End: True
+    deleteMediaLiveMachine:
+      name: deleteMediaLiveResoursesFunction-${self:provider.stage}
+      role:
+        Fn::GetAtt: [defaultRole, Arn]
+      definition:
+        StartAt: DescribeChannel
+        States:
+          DescribeChannel:
+            Type: Task
+            Comment: MediaLiveのチャンネルを取得
+            InputPath: $
+            ResultPath: $.DescribeChannelResult
+            Resource: arn:aws:states:::aws-sdk:medialive:describeChannel
+            Parameters:
+              ChannelId.$: $.ChannelId
+            Next: DeleteChannel
+          DeleteChannel:
+            Type: Task
+            Comment: MediaLiveのチャンネルを削除
+            InputPath: $
+            ResultPath: $.DeleteChannelResult
+            Resource: arn:aws:states:::aws-sdk:medialive:deleteChannel
+            Parameters:
+              ChannelId.$: $.ChannelId
+            Next: DeleteInputMap
+          DeleteInputMap:
+            Type: Map
+            Comment: MediaLiveのInputを削除
+            InputPath: $
+            ItemsPath: $.DescribeChannelResult.InputAttachments
+            ResultPath: $.DeleteInputMapResult
+            End: true
+            ItemSelector:
+              InputId.$: $$.Map.Item.Value.InputId
+            MaxConcurrency: 5
+            ItemProcessor:
+              ProcessorConfig:
+                Mode: INLINE
+              StartAt: DescribeInput
+              States:
+                DescribeInput:
+                  Type: Task
+                  Comment: MediaLiveのInputを取得
+                  InputPath: $
+                  ResultPath: $.DescribeInputResult
+                  Resource: arn:aws:states:::aws-sdk:medialive:describeInput
+                  Parameters:
+                    InputId.$: $.InputId
+                  Next: WaitDettached
+                WaitDettached:
+                  Type: Wait
+                  Seconds: 1
+                  Next: CheckInputDetached
+                CheckInputDetached:
+                  Type: Choice
+                  InputPath: $
+                  Choices:
+                    - Variable: $.DescribeInputResult.State
+                      StringEquals: "DETACHED"
+                      Next: DeleteInput
+                  Default: DescribeInput
+                DeleteInput:
+                  Type: Task
+                  Resource: arn:aws:states:::aws-sdk:medialive:deleteInput
+                  InputPath: $
+                  Parameters:
+                    InputId.$: $.InputId
+                  End: true
+
+
+
 
 plugins:
   - serverless-step-functions

--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -527,8 +527,5 @@ stepFunctions:
                     InputId.$: $.InputId
                   End: true
 
-
-
-
 plugins:
   - serverless-step-functions


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
MediaLiveのチャンネルを削除
アタッチされていた入力のStateがDetachedになったのを確認して入力の削除を並列実行
StepFunctionsに渡す入力値はChannelIdのみ

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->
![stepfunctions_graph (2)](https://github.com/and-period/furumaru/assets/76773825/70bc031b-a237-4e9f-8dcc-239bf8be088f)


## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
