### PR TITLE
ヘッダーの伸縮時の挙動を修正

### DIFF
--- a/web/user/.eslintrc.cjs
+++ b/web/user/.eslintrc.cjs
@@ -4,17 +4,27 @@ module.exports = {
   extends: [
     '@nuxtjs/eslint-config-typescript',
     'plugin:tailwindcss/recommended',
-    'prettier'
+    'prettier',
   ],
   rules: {
     '@typescript-eslint/no-unused-vars': 'off',
     'no-unused-vars': [
-      'error', {
+      'error',
+      {
         args: 'none',
         varsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',
-        destructuredArrayIgnorePattern: '^_'
-      }
-    ]
-  }
+        destructuredArrayIgnorePattern: '^_',
+      },
+    ],
+  },
+  overrides: [
+    {
+      files: ['src/pages/**', 'src/layouts/**'],
+      rules: {
+        'vue/no-multiple-template-root': 'off',
+        'vue/multi-word-component-names': 'off',
+      },
+    },
+  ],
 }

--- a/web/user/src/layouts/default.vue
+++ b/web/user/src/layouts/default.vue
@@ -120,26 +120,26 @@ const handleClickBuyButton = () => {
 </script>
 
 <template>
+  <div class="sticky top-0 z-[60]">
+    <the-app-header
+      :home-path="localePath('/')"
+      :is-authenticated="isAuthenticated"
+      :is-scrolled="isScrolled"
+      :authenticated-account-menu-item="authenticatedMenuItems"
+      :no-authenticated-account-menu-item="noAuthenticatedMenuItems"
+      :menu-items="navbarMenuList"
+      :notification-title="ht('notificationTitle')"
+      :no-notification-item-text="ht('noNotificationItemText')"
+      :notification-items="notifications"
+      :cart-is-empty="cartIsEmpty"
+      :cart-items="cartItems"
+      :cart-menu-message="cartMenuMessage"
+      :sp-menu-items="spModeMenuItems"
+      :footer-menu-items="footerMenuList"
+      @click:buy-button="handleClickBuyButton"
+    />
+  </div>
   <div class="flex min-h-screen flex-col bg-base">
-    <div class="sticky top-0 z-[60]">
-      <the-app-header
-        :home-path="localePath('/')"
-        :is-authenticated="isAuthenticated"
-        :is-scrolled="isScrolled"
-        :authenticated-account-menu-item="authenticatedMenuItems"
-        :no-authenticated-account-menu-item="noAuthenticatedMenuItems"
-        :menu-items="navbarMenuList"
-        :notification-title="ht('notificationTitle')"
-        :no-notification-item-text="ht('noNotificationItemText')"
-        :notification-items="notifications"
-        :cart-is-empty="cartIsEmpty"
-        :cart-items="cartItems"
-        :cart-menu-message="cartMenuMessage"
-        :sp-menu-items="spModeMenuItems"
-        :footer-menu-items="footerMenuList"
-        @click:buy-button="handleClickBuyButton"
-      />
-    </div>
     <main class="grow overflow-hidden">
       <div class="mx-auto pb-16">
         <slot />


### PR DESCRIPTION
## やったこと

- ヘッダーの伸縮時にコンテンツエリアの要素の高さが安定しない挙動があったので修正した。

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
