### PR TITLE
Fix: we can select only mp4 file

### DIFF
--- a/web/admin/src/components/molecules/VideoSelectForm.vue
+++ b/web/admin/src/components/molecules/VideoSelectForm.vue
@@ -12,7 +12,7 @@ const props = defineProps({
   },
   accept: {
     type: Array<String>,
-    default: (): string[] => ['video/*']
+    default: (): string[] => ['video/mp4']
   },
   error: {
     type: Boolean,


### PR DESCRIPTION
## やったこと
https://calmato.atlassian.net/browse/FA-94
mp4以外を選択すると、アップロード失敗していたので、mp4のみ選択できるようにした

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
