### PR TITLE
ローカルの開発サーバをhttpsで立ち上げるための設定の追加

### DIFF
--- a/web/user/.gitignore
+++ b/web/user/.gitignore
@@ -1,3 +1,7 @@
+# Certificate
+localhost-key.pem
+localhost.pem
+
 # locale
 **/locales/*.js
 

--- a/web/user/package.json
+++ b/web/user/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxt dev",
+    "predev": "./predev.sh",
+    "dev": "nuxt dev --https --ssl-cert ./localhost.pem --ssl-key ./localhost-key.pem",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/web/user/predev.sh
+++ b/web/user/predev.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if ! (type mkcert > /dev/null 2>&1); then
+    echo "Installing mkcert..."
+    brew install mkcert
+fi
+
+if [ ! -e "localhost.pem" ] && [ ! -e "localhost-key.pem" ]; then
+    echo "Generating a Certificate..."
+    mkcert -install
+    mkcert localhost
+fi


### PR DESCRIPTION
## やったこと

NPMスクリプトに`predev`コマンドを用意し、[mkcert](https://github.com/FiloSottile/mkcert)を使って自己証明書を生成し、その証明書を使ってhttpsでローカルの開発サーバを立ち上げるように設定を変更した。

マージ後の初回の`yarn dev`時にライブラリのインストールで自己証明書の生成が入るので、rootパスワードといろいろと設定ウィンドウが出るかもだけど、そのセットアップをすれば問題なく動作します。

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
