### PR TITLE
チャンネル作成時に重複を回避する処理を追加

### DIFF
--- a/infra/serverless/functions/getExistsChannelIndex/handler.js
+++ b/infra/serverless/functions/getExistsChannelIndex/handler.js
@@ -1,0 +1,8 @@
+exports.getExistsChannelIndex = async (event) => {
+  console.log(event);
+  const channelNames = event.ChannelNames;
+  const channelName = event.ChannelName;
+  const index = channelNames.indexOf(channelName);
+
+  return index;
+}

--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -57,6 +57,7 @@ resources:
                     - mediaLive:DescribeInput
                     - mediaLive:DeleteInput
                     - mediaLive:DescribeChannel
+                    - mediaLive:ListChannels
                     - mediaLive:CreateChannel
                     - mediaLive:DeleteChannel
                     - mediaStore:CreateContainer
@@ -260,8 +261,54 @@ stepFunctions:
               MediaLiveChannelId.$: $[0][0].ChannelResult.Channel.Id
               MediaStoreContainerArn.$: $[0][2].ContainerResult.Container.Arn
             Branches:
-              - StartAt: CreateChannel
+              - StartAt: ListChannels
                 States:
+                  ListChannels:
+                    Type: Task
+                    Comment: ライブ配信 - チャンネル一覧を取得
+                    InputPath: $
+                    ResultPath: $[0].ListChannelsResult
+                    Resource: arn:aws:states:::aws-sdk:medialive:listChannels
+                    Parameters:
+                      MaxResults: 100
+                    Next: ExtractChannelNames
+                  ExtractChannelNames:
+                    Type: Pass
+                    Comment: ライブ配信 - チャンネル一覧からチャンネル名を抽出
+                    InputPath: $
+                    ResultPath: $[0].ExtractChannelNamesResult
+                    Parameters:
+                      ChannelNames.$: $[0].ListChannelsResult.Channels[*].Name
+                    Next: CheckAnyChannelExists
+                  CheckAnyChannelExists:
+                    Type: Choice
+                    Comment: チャンネル一覧に、チャンネルが一つでもあるか確認
+                    InputPath: $
+                    Choices:
+                      - Variable: $[0].ExtractChannelNamesResult.ChannelNames
+                        IsPresent: true
+                        Next: CompareChannelNames
+                    Default: CreateChannel
+                  CompareChannelNames:
+                    Type: Pass
+                    Comment: ライブ配信 - チャンネル名一覧を比較
+                    InputPath: $
+                    ResultPath: $[0].CompareChannelNamesResult.ChannelExists
+                    Parameters:
+                      ChannelExists.$: States.ArrayContains($[0].ExtractChannelNamesResult.ChannelNames, $[0].ChannelInput.Name)
+                    Next: CheckSpecifyChannelExists
+                  CheckSpecifyChannelExists:
+                    Type: Choice
+                    Comment: チャンネル一覧に、特定のNameを持つチャンネルがあるか確認
+                    InputPath: $
+                    Choices:
+                      - Variable: $[0].CompareChannelNamesResult.ChannelExists
+                        BooleanEquals: true
+                        Next: SkipCreateChannel
+                    Default: CreateChannel
+                  SkipCreateChannel:
+                    Type: Succeed
+                    Comment: チャンネルが存在する場合は終了
                   CreateChannel:
                     Type: Task
                     Comment: ライブ配信 - チャンネルを作成

--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -135,6 +135,11 @@ functions:
     handler: functions/calculateMP4StartTime/handler.calculateMP4StartTime
     memorySize: 128
     timeout: 10
+  getExistsChannelIndex:
+    role: lambdaRole
+    handler: functions/getExistsChannelIndex/handler.getExistsChannelIndex
+    memorySize: 128
+    timeout: 10
   disableDistribution:
     role: lambdaRole
     handler: functions/disableDistribution/handler.disableDistribution
@@ -293,7 +298,7 @@ stepFunctions:
                     Type: Pass
                     Comment: ライブ配信 - チャンネル名一覧を比較
                     InputPath: $
-                    ResultPath: $[0].CompareChannelNamesResult.ChannelExists
+                    ResultPath: $[0].CompareChannelNamesResult
                     Parameters:
                       ChannelExists.$: States.ArrayContains($[0].ExtractChannelNamesResult.ChannelNames, $[0].ChannelInput.Name)
                     Next: CheckSpecifyChannelExists
@@ -304,8 +309,27 @@ stepFunctions:
                     Choices:
                       - Variable: $[0].CompareChannelNamesResult.ChannelExists
                         BooleanEquals: true
-                        Next: SkipCreateChannel
+                        Next: GetExistsChannelIndex
                     Default: CreateChannel
+                  GetExistsChannelIndex:
+                    Type: Task
+                    Comment: ライブ配信 - チャンネル一覧から特定のNameを持つチャンネルのインデックスを取得
+                    InputPath: $
+                    ResultPath: $[0].GetExistsChannelIndexResult
+                    Resource:
+                      Fn::GetAtt: [getExistsChannelIndex, Arn]
+                    Parameters:
+                      ChannelNames.$: $[0].ExtractChannelNamesResult.ChannelNames
+                      ChannelName.$: $[0].ChannelInput.Name
+                    Next: PassChannelInfo
+                  PassChannelInfo:
+                    Type: Pass
+                    Comment: ライブ配信 - チャンネル一覧から特定のNameを持つチャンネルの情報を抽出してDB保存用に格納する
+                    InputPath: $
+                    ResultPath: $[0].ChannelResult
+                    Parameters:
+                      Channel.$: States.ArrayGetItem($[0].ListChannelsResult.Channels, $[0].GetExistsChannelIndexResult)
+                    Next: SkipCreateChannel
                   SkipCreateChannel:
                     Type: Succeed
                     Comment: チャンネルが存在する場合は終了


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- 既存のチャンネル一覧を取得
- 一つもチャンネルがない場合チャンネル作成
- Inputのチャンネル名と一致するチャンネルがあれば情報を抽出して作成をスキップ
- 一致するチャンネルがなければチャンネル作成

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->
<img width="251" alt="スクリーンショット 2023-12-05 4 52 49" src="https://github.com/and-period/furumaru/assets/76773825/2ed42631-8363-4771-88c6-86325c5f5017">


## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
