### PR TITLE
Admin側のHTMLのエディタを取り除く

### DIFF
--- a/web/admin/src/components/organisms/LiveList.vue
+++ b/web/admin/src/components/organisms/LiveList.vue
@@ -432,18 +432,12 @@ const onSubmitDelete = (): void => {
             />
           </template>
         </v-autocomplete>
-        <p class="text-subtitle-2 text-grey py-2">
-          概要
-        </p>
-        <client-only>
-          <tiptap-editor
-            v-model="createFormDataValidate.comment.$model"
-            :error-message="
-              getErrorMessage(createFormDataValidate.comment.$errors)
-            "
-            class="mb-4"
-          />
-        </client-only>
+        <v-textarea
+          v-model="createFormDataValidate.comment.$model"
+          :error-message="getErrorMessage(createFormDataValidate.comment.$errors)"
+          label="概要"
+          maxlength="2000"
+        />
       </v-card-text>
       <v-card-actions>
         <v-spacer />
@@ -562,18 +556,12 @@ const onSubmitDelete = (): void => {
             />
           </template>
         </v-autocomplete>
-        <p class="text-subtitle-2 text-grey py-2">
-          概要
-        </p>
-        <client-only>
-          <tiptap-editor
-            v-model="updateFormDataValidate.comment.$model"
-            :error-message="
-              getErrorMessage(updateFormDataValidate.comment.$errors)
-            "
-            class="mb-4"
-          />
-        </client-only>
+        <v-textarea
+          v-model="updateFormDataValidate.comment.$model"
+          :error-message="getErrorMessage(updateFormDataValidate.comment.$errors)"
+          label="概要"
+          maxlength="2000"
+        />
       </v-card-text>
       <v-card-actions>
         <v-spacer />

--- a/web/admin/src/components/organisms/ScheduleShow.vue
+++ b/web/admin/src/components/organisms/ScheduleShow.vue
@@ -164,16 +164,12 @@ const onSubmit = async (): Promise<void> => {
               :error-messages="getErrorMessage(formDataValidate.title.$errors)"
               label="タイトル"
             />
-            <p class="text-subtitle-2 text-grey py-2">
-              詳細
-            </p>
-            <client-only>
-              <tiptap-editor
-                v-model="formDataValidate.description.$model"
-                :error-message="getErrorMessage(formDataValidate.description.$errors)"
-                class="mb-4"
-              />
-            </client-only>
+            <v-textarea
+              v-model="formDataValidate.description.$model"
+              :error-message="getErrorMessage(formDataValidate.description.$errors)"
+              label="詳細"
+              maxlength="2000"
+            />
             <v-row>
               <v-col cols="12" sm="12" md="4">
                 <molecules-image-select-form

--- a/web/admin/src/components/templates/ProductEdit.vue
+++ b/web/admin/src/components/templates/ProductEdit.vue
@@ -334,16 +334,12 @@ const onSubmit = async (): Promise<void> => {
             />
           </v-card-text>
 
-          <v-card-subtitle>商品説明</v-card-subtitle>
-          <v-card-text>
-            <client-only>
-              <tiptap-editor
-                v-model="formDataValidate.description.$model"
-                :error-message="getErrorMessage(formDataValidate.description.$errors)"
-                class="mb-4"
-              />
-            </client-only>
-          </v-card-text>
+          <v-textarea
+            v-model="formDataValidate.description.$model"
+            :error-message="getErrorMessage(formDataValidate.description.$errors)"
+            label="商品説明"
+            maxlength="2000"
+          />
 
           <v-card-subtitle>商品画像登録</v-card-subtitle>
           <v-card-text>

--- a/web/admin/src/components/templates/ProductEdit.vue
+++ b/web/admin/src/components/templates/ProductEdit.vue
@@ -332,14 +332,13 @@ const onSubmit = async (): Promise<void> => {
               label="商品名"
               outlined
             />
+            <v-textarea
+              v-model="formDataValidate.description.$model"
+              :error-message="getErrorMessage(formDataValidate.description.$errors)"
+              label="商品説明"
+              maxlength="2000"
+            />
           </v-card-text>
-
-          <v-textarea
-            v-model="formDataValidate.description.$model"
-            :error-message="getErrorMessage(formDataValidate.description.$errors)"
-            label="商品説明"
-            maxlength="2000"
-          />
 
           <v-card-subtitle>商品画像登録</v-card-subtitle>
           <v-card-text>

--- a/web/admin/src/components/templates/ProductNew.vue
+++ b/web/admin/src/components/templates/ProductNew.vue
@@ -288,13 +288,13 @@ const onSubmit = async (): Promise<void> => {
               label="商品名"
               outlined
             />
+            <v-textarea
+              v-model="formDataValidate.description.$model"
+              :error-message="getErrorMessage(formDataValidate.description.$errors)"
+              label="商品説明"
+              maxlength="2000"
+            />
           </v-card-text>
-          <v-textarea
-            v-model="formDataValidate.description.$model"
-            :error-message="getErrorMessage(formDataValidate.description.$errors)"
-            label="商品説明"
-            maxlength="2000"
-          />
 
           <v-card-subtitle>商品画像登録</v-card-subtitle>
           <v-card-text>

--- a/web/admin/src/components/templates/ProductNew.vue
+++ b/web/admin/src/components/templates/ProductNew.vue
@@ -289,17 +289,12 @@ const onSubmit = async (): Promise<void> => {
               outlined
             />
           </v-card-text>
-
-          <v-card-subtitle>商品説明</v-card-subtitle>
-          <v-card-text>
-            <client-only>
-              <tiptap-editor
-                v-model="formDataValidate.description.$model"
-                :error-message="getErrorMessage(formDataValidate.description.$errors)"
-                class="mb-4"
-              />
-            </client-only>
-          </v-card-text>
+          <v-textarea
+            v-model="formDataValidate.description.$model"
+            :error-message="getErrorMessage(formDataValidate.description.$errors)"
+            label="商品説明"
+            maxlength="2000"
+          />
 
           <v-card-subtitle>商品画像登録</v-card-subtitle>
           <v-card-text>

--- a/web/admin/src/components/templates/ScheduleNew.vue
+++ b/web/admin/src/components/templates/ScheduleNew.vue
@@ -187,17 +187,13 @@ const onSubmit = async (): Promise<void> => {
             density="compact"
             @update:model-value="onChangeEndAt"
           />
-        </div>
-        <p class="text-subtitle-2 text-grey py-2">
-          詳細
-        </p>
-        <client-only>
-          <tiptap-editor
+          <v-textarea
             v-model="formDataValidate.description.$model"
             :error-message="getErrorMessage(formDataValidate.description.$errors)"
-            class="mb-4"
+            label="詳細"
+            maxlength="2000"
           />
-        </client-only>
+        </div>
         <v-row>
           <v-col cols="12" sm="12" md="4">
             <molecules-image-select-form

--- a/web/admin/src/components/templates/ScheduleNew.vue
+++ b/web/admin/src/components/templates/ScheduleNew.vue
@@ -187,13 +187,13 @@ const onSubmit = async (): Promise<void> => {
             density="compact"
             @update:model-value="onChangeEndAt"
           />
-          <v-textarea
-            v-model="formDataValidate.description.$model"
-            :error-message="getErrorMessage(formDataValidate.description.$errors)"
-            label="詳細"
-            maxlength="2000"
-          />
         </div>
+        <v-textarea
+          v-model="formDataValidate.description.$model"
+          :error-message="getErrorMessage(formDataValidate.description.$errors)"
+          label="詳細"
+          maxlength="2000"
+        />
         <v-row>
           <v-col cols="12" sm="12" md="4">
             <molecules-image-select-form


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- Admin側のHTMLエディタをtextareaに変更
  - 商品説明
  - 配信スケジュール
  - 配信詳細

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->
<img width="761" alt="スクリーンショット 2024-01-09 1 07 02" src="https://github.com/and-period/furumaru/assets/76773825/b65ce839-d6f8-45e7-aaaa-771c6ca1f7c1">
<img width="771" alt="スクリーンショット 2024-01-09 1 02 13" src="https://github.com/and-period/furumaru/assets/76773825/385cd8ce-d949-48a2-8459-1fc60a7f4a54">
<img width="752" alt="スクリーンショット 2024-01-09 1 01 48" src="https://github.com/and-period/furumaru/assets/76773825/1a226dd3-1807-4ceb-b063-8691134a6c7a">
<img width="1162" alt="スクリーンショット 2024-01-09 1 01 39" src="https://github.com/and-period/furumaru/assets/76773825/743fb048-1de4-47ce-8d41-e649ffe4b157">



## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->



## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
