### PR TITLE
fix: アーカイブに表示するコンテンツが少ない場合にレイアウトが崩れる問題に対応

### DIFF
--- a/web/user/src/pages/index.vue
+++ b/web/user/src/pages/index.vue
@@ -156,7 +156,7 @@ useSeoMeta({
               :title="archive.title"
               :img-src="archive.thumbnailUrl"
               :width="368"
-              class="cursor-pointer md:min-w-[368px]"
+              class="cursor-pointer md:min-w-[368px] md:max-w-[368px]"
               @click="handleClickLiveItem(archive.scheduleId)"
             />
           </div>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

![localhost_3000_ (1)](https://github.com/and-period/furumaru/assets/27722351/0b7b7f6f-3598-44e8-93ac-7bbc7f8759ae)


<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
