### PR TITLE
feat:ライブ配信中にタイムラインに表示される商品から商品詳細画面に遷移できるようにする

### DIFF
--- a/web/user/src/components/molecules/TheLiveTimelineItem.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineItem.vue
@@ -15,6 +15,7 @@ interface Props {
 const props = defineProps<Props>()
 
 interface Emits {
+  (e: 'click:item', id: string): void
   (e: 'click:addCart', name: string, id: string, quantity: number): void
 }
 
@@ -23,6 +24,10 @@ const emits = defineEmits<Emits>()
 const startAtString = computed(() => {
   return unix(props.startAt).format('HH:mm')
 })
+
+const handleClickItem = (prodictId: string) => {
+  emits('click:item', prodictId)
+}
 
 const handleClickAddCart = (name: string, id: string, quantity: number) => {
   emits('click:addCart', name, id, quantity)
@@ -59,7 +64,9 @@ const handleClickAddCart = (name: string, id: string, quantity: number) => {
         </div>
         <div
           class="w-[150px] overflow-auto break-words text-[12px] font-medium tracking-[1.2px]"
-        >{{ comment }}</div>
+        >
+          {{ comment }}
+        </div>
       </div>
 
       <div
@@ -69,6 +76,7 @@ const handleClickAddCart = (name: string, id: string, quantity: number) => {
           v-for="item in items"
           :key="item.id"
           :product="item"
+          @click:item="handleClickItem"
           @click:add-cart="handleClickAddCart"
         />
       </div>

--- a/web/user/src/components/molecules/TheLiveTimelineProduct.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineProduct.vue
@@ -9,6 +9,7 @@ interface Props {
 const props = defineProps<Props>()
 
 interface Emits {
+  (e: 'click:item', id: string): void
   (e: 'click:addCart', name: string, id: string, quantity: number): void
 }
 
@@ -32,6 +33,10 @@ const thumbnailUrl = computed<string>(() => {
 const handleClickAddCart = () => {
   emits('click:addCart', props.product.name, props.product.id, formData.value)
 }
+
+const handleClickItemTitle = () => {
+  emits('click:item', props.product.id)
+}
 </script>
 
 <template>
@@ -40,7 +45,10 @@ const handleClickAddCart = () => {
       <img :src="thumbnailUrl" class="h-20 w-20" />
     </template>
     <div class="flex flex-col justify-between">
-      <div class="text-[12px] tracking-[1.2px]">
+      <div
+        class="text-[12px] tracking-[1.2px] hover:cursor-pointer hover:underline"
+        @click="handleClickItemTitle"
+      >
         {{ product.name }}
       </div>
       <div>
@@ -69,7 +77,7 @@ const handleClickAddCart = () => {
           </div>
           <button
             class="flex h-full bg-main px-4 py-1 text-white"
-            @click="handleClickAddCart"
+            @click.stop="handleClickAddCart"
           >
             カゴに入れる
           </button>

--- a/web/user/src/components/organisms/TheLiveTimeline.vue
+++ b/web/user/src/components/organisms/TheLiveTimeline.vue
@@ -8,10 +8,15 @@ interface Props {
 defineProps<Props>()
 
 interface Emits {
+  (e: 'click:item', id: string): void
   (e: 'click:addCart', name: string, id: string, quantity: number): void
 }
 
 const emits = defineEmits<Emits>()
+
+const handleClickItem = (prodictId: string) => {
+  emits('click:item', prodictId)
+}
 
 const handleClickAddCart = (name: string, id: string, quantity: number) => {
   emits('click:addCart', name, id, quantity)
@@ -29,6 +34,7 @@ const handleClickAddCart = (name: string, id: string, quantity: number) => {
         :username="liveTimeline.producer?.username"
         :comment="liveTimeline.comment"
         :items="liveTimeline.products"
+        @click:item="handleClickItem"
         @click:add-cart="handleClickAddCart"
       />
     </ol>

--- a/web/user/src/pages/live/[...id].vue
+++ b/web/user/src/pages/live/[...id].vue
@@ -13,6 +13,7 @@ const { addCart } = shoppingCartStore
 
 const snackbarItems = ref<Snackbar[]>([])
 
+const router = useRouter()
 const route = useRoute()
 
 const isLoading = ref<boolean>(false)
@@ -62,6 +63,10 @@ const isArchive = computed<boolean>(() => {
     return false
   }
 })
+
+const handleClickItem = (prodictId: string) => {
+  router.push(`/items/${prodictId}`)
+}
 
 const handleClickAddCart = (name: string, id: string, quantity: number) => {
   addCart({ productId: id, quantity })
@@ -113,6 +118,7 @@ useSeoMeta({
           <the-live-timeline
             class="mt-4"
             :items="liveTimeLineItems"
+            @click:item="handleClickItem"
             @click:add-cart="handleClickAddCart"
           />
         </client-only>


### PR DESCRIPTION
## やったこと

- ライブ配信中にタイムラインに表示される商品の商品名から商品詳細画面に遷移できるようにした

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
