### PR TITLE
fix(store): 注文履歴ステータスの追加

### DIFF
--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -91,6 +91,7 @@ type Order interface {
 	Create(ctx context.Context, order *entity.Order) error
 	UpdatePayment(ctx context.Context, orderID string, params *UpdateOrderPaymentParams) error
 	UpdateFulfillment(ctx context.Context, orderID, fulfillmentID string, params *UpdateOrderFulfillmentParams) error
+	UpdateRefund(ctx context.Context, orderID string, params *UpdateOrderRefundParams) error
 	Draft(ctx context.Context, orderID string, params *DraftOrderParams) error
 	Complete(ctx context.Context, orderID string, params *CompleteOrderParams) error
 	Aggregate(ctx context.Context, params *AggregateOrdersParams) (entity.AggregatedOrders, error)
@@ -105,12 +106,9 @@ type ListOrdersParams struct {
 }
 
 type UpdateOrderPaymentParams struct {
-	Status       entity.PaymentStatus
-	PaymentID    string
-	RefundType   entity.RefundType
-	RefundTotal  int64
-	RefundReason string
-	IssuedAt     time.Time
+	Status    entity.PaymentStatus
+	PaymentID string
+	IssuedAt  time.Time
 }
 
 type UpdateOrderFulfillmentParams struct {
@@ -118,6 +116,14 @@ type UpdateOrderFulfillmentParams struct {
 	ShippingCarrier entity.ShippingCarrier
 	TrackingNumber  string
 	ShippedAt       time.Time
+}
+
+type UpdateOrderRefundParams struct {
+	Status       entity.PaymentStatus
+	RefundType   entity.RefundType
+	RefundTotal  int64
+	RefundReason string
+	IssuedAt     time.Time
 }
 
 type DraftOrderParams struct {

--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -89,11 +89,10 @@ type Order interface {
 	Get(ctx context.Context, orderID string, fields ...string) (*entity.Order, error)
 	GetByTransactionID(ctx context.Context, userID, transactionID string) (*entity.Order, error)
 	Create(ctx context.Context, order *entity.Order) error
-	UpdatePaymentStatus(ctx context.Context, orderID string, params *UpdateOrderPaymentParams) error
-	UpdateFulfillment(ctx context.Context, fulfillmentID string, params *UpdateOrderFulfillmentParams) error
+	UpdatePayment(ctx context.Context, orderID string, params *UpdateOrderPaymentParams) error
+	UpdateFulfillment(ctx context.Context, orderID, fulfillmentID string, params *UpdateOrderFulfillmentParams) error
 	Draft(ctx context.Context, orderID string, params *DraftOrderParams) error
 	Complete(ctx context.Context, orderID string, params *CompleteOrderParams) error
-	Refund(ctx context.Context, orderID string, params *RefundOrderParams) error
 	Aggregate(ctx context.Context, params *AggregateOrdersParams) (entity.AggregatedOrders, error)
 	AggregateByPromotion(ctx context.Context, params *AggregateOrdersByPromotionParams) (entity.AggregatedOrderPromotions, error)
 }
@@ -106,22 +105,8 @@ type ListOrdersParams struct {
 }
 
 type UpdateOrderPaymentParams struct {
-	Status    entity.PaymentStatus
-	PaymentID string
-	IssuedAt  time.Time
-}
-
-type DraftOrderParams struct {
-	ShippingMessage string
-}
-
-type CompleteOrderParams struct {
-	ShippingMessage string
-	CompletedAt     time.Time
-}
-
-type RefundOrderParams struct {
 	Status       entity.PaymentStatus
+	PaymentID    string
 	RefundType   entity.RefundType
 	RefundTotal  int64
 	RefundReason string
@@ -133,6 +118,15 @@ type UpdateOrderFulfillmentParams struct {
 	ShippingCarrier entity.ShippingCarrier
 	TrackingNumber  string
 	ShippedAt       time.Time
+}
+
+type DraftOrderParams struct {
+	ShippingMessage string
+}
+
+type CompleteOrderParams struct {
+	ShippingMessage string
+	CompletedAt     time.Time
 }
 
 type AggregateOrdersParams struct {

--- a/api/internal/store/database/mysql/order.go
+++ b/api/internal/store/database/mysql/order.go
@@ -177,7 +177,7 @@ func (o *order) UpdatePayment(ctx context.Context, orderID string, params *datab
 			updates["payment_id"] = params.PaymentID
 		}
 
-		stmt := o.db.DB.WithContext(ctx).
+		stmt := tx.WithContext(ctx).
 			Table(orderPaymentTable).
 			Where("order_id = ?", orderID)
 		if err := stmt.Updates(updates).Error; err != nil {

--- a/api/internal/store/database/mysql/order.go
+++ b/api/internal/store/database/mysql/order.go
@@ -137,7 +137,7 @@ func (o *order) Create(ctx context.Context, order *entity.Order) error {
 	return dbError(err)
 }
 
-func (o *order) UpdatePaymentStatus(ctx context.Context, orderID string, params *database.UpdateOrderPaymentParams) error {
+func (o *order) UpdatePayment(ctx context.Context, orderID string, params *database.UpdateOrderPaymentParams) error {
 	err := o.db.Transaction(ctx, func(tx *gorm.DB) error {
 		order, err := o.get(ctx, tx, orderID)
 		if err != nil {
@@ -160,11 +160,18 @@ func (o *order) UpdatePaymentStatus(ctx context.Context, orderID string, params 
 			updates["paid_at"] = params.IssuedAt
 		case entity.PaymentStatusCaptured:
 			updates["captured_at"] = params.IssuedAt
-		case entity.PaymentStatusCanceled:
-			updates["canceled_at"] = params.IssuedAt
-			updates["refund_type"] = entity.RefundTypeCanceled
 		case entity.PaymentStatusFailed:
 			updates["failed_at"] = params.IssuedAt
+		case entity.PaymentStatusCanceled:
+			updates["refund_type"] = params.RefundType
+			updates["refund_total"] = params.RefundTotal
+			updates["refund_reason"] = params.RefundReason
+			updates["canceled_at"] = params.IssuedAt
+		case entity.PaymentStatusRefunded:
+			updates["refund_type"] = params.RefundType
+			updates["refund_total"] = params.RefundTotal
+			updates["refund_reason"] = params.RefundReason
+			updates["refunded_at"] = params.IssuedAt
 		}
 		if params.PaymentID != "" {
 			updates["payment_id"] = params.PaymentID
@@ -173,31 +180,46 @@ func (o *order) UpdatePaymentStatus(ctx context.Context, orderID string, params 
 		stmt := o.db.DB.WithContext(ctx).
 			Table(orderPaymentTable).
 			Where("order_id = ?", orderID)
-
-		return stmt.Updates(updates).Error
+		if err := stmt.Updates(updates).Error; err != nil {
+			return err
+		}
+		return o.updateStatus(ctx, tx, order.ID)
 	})
 	return dbError(err)
 }
 
-func (o *order) UpdateFulfillment(ctx context.Context, fulfillmentID string, params *database.UpdateOrderFulfillmentParams) error {
-	updates := map[string]interface{}{
-		"status":     params.Status,
-		"updated_at": o.now(),
-	}
-	switch params.Status {
-	case entity.FulfillmentStatusFulfilled:
-		updates["shipping_carrier"] = params.ShippingCarrier
-		updates["tracking_number"] = params.TrackingNumber
-		updates["shipped_at"] = params.ShippedAt
-	case entity.FulfillmentStatusUnfulfilled:
-		updates["shipping_carrier"] = entity.ShippingCarrierUnknown
-		updates["tracking_number"] = nil
-		updates["shipped_at"] = nil
-	}
-	err := o.db.DB.WithContext(ctx).
-		Table(orderFulfillmentTable).
-		Where("id = ?", fulfillmentID).
-		Updates(updates).Error
+func (o *order) UpdateFulfillment(ctx context.Context, orderID, fulfillmentID string, params *database.UpdateOrderFulfillmentParams) error {
+	err := o.db.Transaction(ctx, func(tx *gorm.DB) error {
+		order, err := o.get(ctx, tx, orderID)
+		if err != nil {
+			return err
+		}
+		if order.IsCompleted() {
+			return fmt.Errorf("mysql: this order is already completed: %w", database.ErrFailedPrecondition)
+		}
+
+		updates := map[string]interface{}{
+			"status":     params.Status,
+			"updated_at": o.now(),
+		}
+		switch params.Status {
+		case entity.FulfillmentStatusFulfilled:
+			updates["shipping_carrier"] = params.ShippingCarrier
+			updates["tracking_number"] = params.TrackingNumber
+			updates["shipped_at"] = params.ShippedAt
+		case entity.FulfillmentStatusUnfulfilled:
+			updates["shipping_carrier"] = entity.ShippingCarrierUnknown
+			updates["tracking_number"] = nil
+			updates["shipped_at"] = nil
+		}
+		stmt := tx.WithContext(ctx).
+			Table(orderFulfillmentTable).
+			Where("id = ?", fulfillmentID)
+		if err := stmt.Updates(updates).Error; err != nil {
+			return err
+		}
+		return o.updateStatus(ctx, tx, order.ID)
+	})
 	return dbError(err)
 }
 
@@ -217,33 +239,13 @@ func (o *order) Complete(ctx context.Context, orderID string, params *database.C
 	now := o.now()
 	updates := map[string]interface{}{
 		"shipping_message": params.ShippingMessage,
+		"status":           entity.OrderStatusCompleted,
 		"completed_at":     now,
 		"updated_at":       now,
 	}
 	err := o.db.DB.WithContext(ctx).
 		Table(orderTable).
 		Where("id = ?", orderID).
-		Updates(updates).Error
-	return dbError(err)
-}
-
-func (o *order) Refund(ctx context.Context, orderID string, params *database.RefundOrderParams) error {
-	updates := map[string]interface{}{
-		"status":        params.Status,
-		"refund_type":   params.RefundType,
-		"refund_total":  params.RefundTotal,
-		"refund_reason": params.RefundReason,
-		"updated_at":    o.now(),
-	}
-	switch params.Status {
-	case entity.PaymentStatusCanceled:
-		updates["canceled_at"] = params.IssuedAt
-	case entity.PaymentStatusRefunded:
-		updates["refunded_at"] = params.IssuedAt
-	}
-	err := o.db.DB.WithContext(ctx).
-		Table(orderPaymentTable).
-		Where("order_id = ?", orderID).
 		Updates(updates).Error
 	return dbError(err)
 }
@@ -343,4 +345,44 @@ func (o *order) fill(ctx context.Context, tx *gorm.DB, orders ...*entity.Order) 
 
 	entity.Orders(orders).Fill(payments.MapByOrderID(), fulfillments.GroupByOrderID(), items.GroupByOrderID())
 	return nil
+}
+
+func (o *order) updateStatus(ctx context.Context, tx *gorm.DB, orderID string) error {
+	var (
+		order        *entity.Order
+		payment      *entity.OrderPayment
+		fulfillments entity.OrderFulfillments
+	)
+
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		stmt := o.db.Statement(ectx, tx, orderTable).Where("id = ?", orderID)
+		return stmt.First(&order).Error
+	})
+	eg.Go(func() error {
+		stmt := o.db.Statement(ectx, tx, orderPaymentTable).Where("order_id = ?", orderID)
+		return stmt.First(&payment).Error
+	})
+	eg.Go(func() error {
+		stmt := o.db.Statement(ectx, tx, orderFulfillmentTable).Where("order_id = ?", orderID)
+		return stmt.Find(&fulfillments).Error
+	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	order.Fill(payment, fulfillments, entity.OrderItems{}) // 商品詳細は不要なため取得しない
+
+	status := order.OrderStatus()
+	if order.Status == status {
+		return nil // DBに登録されているステータスと差異がないため更新は不要
+	}
+
+	updates := map[string]interface{}{
+		"status":     status,
+		"updated_at": o.now(),
+	}
+	stmt := tx.WithContext(ctx).
+		Table(orderTable).
+		Where("id = ?", orderID)
+	return stmt.Updates(updates).Error
 }

--- a/api/internal/store/database/mysql/order.go
+++ b/api/internal/store/database/mysql/order.go
@@ -214,6 +214,7 @@ func (o *order) UpdateFulfillment(ctx context.Context, orderID, fulfillmentID st
 		}
 		stmt := tx.WithContext(ctx).
 			Table(orderFulfillmentTable).
+			Where("order_id = ?", orderID).
 			Where("id = ?", fulfillmentID)
 		if err := stmt.Updates(updates).Error; err != nil {
 			return err

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -672,23 +672,6 @@ func TestOrder_UpdatePayment(t *testing.T) {
 			},
 		},
 		{
-			name: "success canceled",
-			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
-			},
-			args: args{
-				orderID: "order-id",
-				params: &database.UpdateOrderPaymentParams{
-					Status:    entity.PaymentStatusCanceled,
-					PaymentID: "payment-id",
-					IssuedAt:  now(),
-				},
-			},
-			want: want{
-				err: nil,
-			},
-		},
-		{
 			name: "success failed",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
@@ -699,44 +682,6 @@ func TestOrder_UpdatePayment(t *testing.T) {
 					Status:    entity.PaymentStatusFailed,
 					PaymentID: "",
 					IssuedAt:  now(),
-				},
-			},
-			want: want{
-				err: nil,
-			},
-		},
-		{
-			name: "success canceled",
-			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
-			},
-			args: args{
-				orderID: "order-id",
-				params: &database.UpdateOrderPaymentParams{
-					Status:       entity.PaymentStatusCanceled,
-					RefundType:   entity.RefundTypeCanceled,
-					RefundTotal:  1980,
-					RefundReason: "テストです。",
-					IssuedAt:     now(),
-				},
-			},
-			want: want{
-				err: nil,
-			},
-		},
-		{
-			name: "success refunded",
-			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
-			},
-			args: args{
-				orderID: "order-id",
-				params: &database.UpdateOrderPaymentParams{
-					Status:       entity.PaymentStatusRefunded,
-					RefundType:   entity.RefundTypeRefunded,
-					RefundTotal:  1980,
-					RefundReason: "テストです。",
-					IssuedAt:     now(),
 				},
 			},
 			want: want{
@@ -766,7 +711,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 			args: args{
 				orderID: "order-id",
 				params: &database.UpdateOrderPaymentParams{
-					Status:    entity.PaymentStatusRefunded,
+					Status:    entity.PaymentStatusAuthorized,
 					PaymentID: "",
 					IssuedAt:  now(),
 				},
@@ -959,19 +904,176 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 				err: database.ErrFailedPrecondition,
 			},
 		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			require.NoError(t, err)
+
+			tt.setup(ctx, t, db)
+
+			db := &order{db: db, now: now}
+			err = db.UpdateFulfillment(ctx, tt.args.orderID, tt.args.fulfillmentID, tt.args.params)
+			assert.ErrorIs(t, err, tt.want.err)
+		})
+	}
+}
+
+func TestOrder_UpdateRefund(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	categories := make(entity.Categories, 2)
+	categories[0] = testCategory("category-id01", "野菜", now())
+	categories[1] = testCategory("category-id02", "果物", now())
+	err = db.DB.Create(&categories).Error
+	require.NoError(t, err)
+	productTypes := make(entity.ProductTypes, 2)
+	productTypes[0] = testProductType("type-id01", "category-id01", "野菜", now())
+	productTypes[1] = testProductType("type-id02", "category-id02", "果物", now())
+	err = db.DB.Create(&productTypes).Error
+	require.NoError(t, err)
+	products := make(entity.Products, 2)
+	products[0] = testProduct("product-id01", "type-id01", "category-id01", "coordinator-id", "producer-id", []string{}, 1, now())
+	products[1] = testProduct("product-id02", "type-id02", "category-id02", "coordinator-id", "producer-id", []string{}, 2, now())
+	err = db.DB.Create(&products).Error
+	require.NoError(t, err)
+	for i := range products {
+		err = db.DB.Create(&products[i].ProductRevision).Error
+		require.NoError(t, err)
+	}
+	schedule := testSchedule("schedule-id", "coordinator-id", now())
+	err = db.DB.Create(&schedule).Error
+	require.NoError(t, err)
+
+	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
+		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		err := db.DB.Create(&order).Error
+		require.NoError(t, err)
+
+		payment := testOrderPayment(orderID, 1, "transaction-id", "payment-id", now)
+		payment.Status = status
+		err = db.DB.Create(&payment).Error
+		require.NoError(t, err)
+
+		fulfillments := make(entity.OrderFulfillments, 1)
+		fulfillments[0] = testOrderFulfillment("fulfillment-id", orderID, 1, 1, now)
+		err = db.DB.Create(&fulfillments).Error
+		require.NoError(t, err)
+
+		items := make(entity.OrderItems, 2)
+		items[0] = testOrderItem("fulfillment-id", 1, orderID, now)
+		items[1] = testOrderItem("fulfillment-id", 2, orderID, now)
+		err = db.DB.Create(&items).Error
+		require.NoError(t, err)
+	}
+
+	type args struct {
+		orderID string
+		params  *database.UpdateOrderRefundParams
+	}
+	type want struct {
+		err error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name: "success canceled",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
+				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
+			},
+			args: args{
+				orderID: "order-id",
+				params: &database.UpdateOrderRefundParams{
+					Status:       entity.PaymentStatusCanceled,
+					RefundType:   entity.RefundTypeCanceled,
+					RefundTotal:  1980,
+					RefundReason: "テストです。",
+					IssuedAt:     now(),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		{
+			name: "success refunded",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
+				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
+			},
+			args: args{
+				orderID: "order-id",
+				params: &database.UpdateOrderRefundParams{
+					Status:       entity.PaymentStatusRefunded,
+					RefundType:   entity.RefundTypeRefunded,
+					RefundTotal:  1980,
+					RefundReason: "テストです。",
+					IssuedAt:     now(),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		{
+			name:  "not found",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				orderID: "order-id",
+				params: &database.UpdateOrderRefundParams{
+					Status:   entity.PaymentStatusRefunded,
+					IssuedAt: now(),
+				},
+			},
+			want: want{
+				err: database.ErrNotFound,
+			},
+		},
+		{
+			name: "already completed",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
+				create(t, "order-id", entity.PaymentStatusCaptured, now().AddDate(0, 0, -1))
+			},
+			args: args{
+				orderID: "order-id",
+				params: &database.UpdateOrderRefundParams{
+					Status:   entity.PaymentStatusRefunded,
+					IssuedAt: now(),
+				},
+			},
+			want: want{
+				err: database.ErrFailedPrecondition,
+			},
+		},
 		{
 			name: "not latest data",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				create(t, "order-id", entity.PaymentStatusAuthorized, now().AddDate(0, 0, 1))
 			},
 			args: args{
-				orderID:       "order-id",
-				fulfillmentID: "fulfillment-id",
-				params: &database.UpdateOrderFulfillmentParams{
-					Status:          entity.FulfillmentStatusFulfilled,
-					ShippingCarrier: entity.ShippingCarrierYamato,
-					TrackingNumber:  "tracking-number",
-					ShippedAt:       now(),
+				orderID: "order-id",
+				params: &database.UpdateOrderRefundParams{
+					Status:   entity.PaymentStatusCaptured,
+					IssuedAt: now(),
 				},
 			},
 			want: want{
@@ -992,7 +1094,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 			tt.setup(ctx, t, db)
 
 			db := &order{db: db, now: now}
-			err = db.UpdateFulfillment(ctx, tt.args.orderID, tt.args.fulfillmentID, tt.args.params)
+			err = db.UpdateRefund(ctx, tt.args.orderID, tt.args.params)
 			assert.ErrorIs(t, err, tt.want.err)
 		})
 	}

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -1049,22 +1049,6 @@ func TestOrder_UpdateRefund(t *testing.T) {
 			},
 		},
 		{
-			name: "already completed",
-			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusCaptured, now().AddDate(0, 0, -1))
-			},
-			args: args{
-				orderID: "order-id",
-				params: &database.UpdateOrderRefundParams{
-					Status:   entity.PaymentStatusRefunded,
-					IssuedAt: now(),
-				},
-			},
-			want: want{
-				err: database.ErrFailedPrecondition,
-			},
-		},
-		{
 			name: "not latest data",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				create(t, "order-id", entity.PaymentStatusAuthorized, now().AddDate(0, 0, 1))

--- a/api/internal/store/entity/order.go
+++ b/api/internal/store/entity/order.go
@@ -8,6 +8,21 @@ import (
 	"gorm.io/gorm"
 )
 
+// OrderStatus - 注文ステータス
+type OrderStatus int32
+
+const (
+	OrderStatusUnknown   OrderStatus = 0
+	OrderStatusUnpaid    OrderStatus = 1 // 支払い待ち
+	OrderStatusWaiting   OrderStatus = 2 // 受注待ち
+	OrderStatusPreparing OrderStatus = 3 // 発送準備中
+	OrderStatusShipped   OrderStatus = 4 // 発送完了
+	OrderStatusCompleted OrderStatus = 5 // 完了
+	OrderStatusCanceled  OrderStatus = 6 // キャンセル
+	OrderStatusRefunded  OrderStatus = 7 // 返金
+	OrderStatusFailed    OrderStatus = 8 // 失敗
+)
+
 // Order - 注文履歴情報
 type Order struct {
 	OrderPayment      `gorm:"-"`
@@ -18,6 +33,7 @@ type Order struct {
 	CoordinatorID     string         `gorm:""`                     // 注文受付担当者ID
 	PromotionID       string         `gorm:"default:null"`         // プロモーションID
 	ManagementID      int64          `gorm:""`                     // 管理番号
+	Status            OrderStatus    `gorm:""`                     // 注文ステータス
 	ShippingMessage   string         `gorm:"default:null"`         // 発送時のメッセージ
 	CreatedAt         time.Time      `gorm:"<-:create"`            // 登録日時
 	UpdatedAt         time.Time      `gorm:""`                     // 更新日時
@@ -96,6 +112,7 @@ func NewOrder(params *NewOrderParams) (*Order, error) {
 		UserID:            params.Customer.ID,
 		CoordinatorID:     params.CoordinatorID,
 		PromotionID:       promotionID,
+		Status:            OrderStatusUnpaid, // 初期ステータスは「支払い待ち」で登録
 		ShippingMessage:   "ご注文ありがとうございます！商品到着まで今しばらくお待ち下さい。",
 	}, nil
 }
@@ -106,6 +123,35 @@ func (o *Order) Fill(payment *OrderPayment, fulfillments OrderFulfillments, item
 	o.OrderItems = items
 }
 
+func (o *Order) OrderStatus() OrderStatus {
+	if o == nil {
+		return OrderStatusUnknown
+	}
+	switch o.OrderPayment.Status {
+	case PaymentStatusPending:
+		return OrderStatusUnpaid
+	case PaymentStatusAuthorized:
+		return OrderStatusWaiting
+	case PaymentStatusCaptured:
+		if !o.OrderFulfillments.Fulfilled() {
+			return OrderStatusPreparing
+		}
+		if o.CompletedAt.IsZero() {
+			return OrderStatusShipped
+		}
+		return OrderStatusCompleted
+	case PaymentStatusCanceled:
+		return OrderStatusCanceled
+	case PaymentStatusRefunded:
+		return OrderStatusRefunded
+	case PaymentStatusFailed:
+		return OrderStatusFailed
+	default:
+		return OrderStatusUnknown
+	}
+}
+
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Completed() bool {
 	if o == nil {
 		return false
@@ -118,6 +164,7 @@ func (o *Order) Completed() bool {
 		o.OrderPayment.Status == PaymentStatusFailed
 }
 
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Capturable() bool {
 	if o == nil {
 		return false
@@ -125,6 +172,7 @@ func (o *Order) Capturable() bool {
 	return o.OrderPayment.Status == PaymentStatusAuthorized
 }
 
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Preservable() bool {
 	if o == nil {
 		return false
@@ -132,6 +180,7 @@ func (o *Order) Preservable() bool {
 	return o.OrderPayment.Status == PaymentStatusCaptured && o.CompletedAt.IsZero()
 }
 
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Completable() bool {
 	if o == nil {
 		return false
@@ -142,6 +191,7 @@ func (o *Order) Completable() bool {
 	return o.OrderPayment.Status == PaymentStatusCaptured && o.CompletedAt.IsZero()
 }
 
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Cancelable() bool {
 	if o == nil {
 		return false
@@ -149,6 +199,7 @@ func (o *Order) Cancelable() bool {
 	return o.OrderPayment.Status == PaymentStatusPending || o.OrderPayment.Status == PaymentStatusAuthorized
 }
 
+// TODO: Order.Statusを利用して書き換える
 func (o *Order) Refundable() bool {
 	if o == nil {
 		return false

--- a/api/internal/store/entity/order.go
+++ b/api/internal/store/entity/order.go
@@ -123,31 +123,36 @@ func (o *Order) Fill(payment *OrderPayment, fulfillments OrderFulfillments, item
 	o.OrderItems = items
 }
 
-func (o *Order) OrderStatus() OrderStatus {
-	if o == nil {
-		return OrderStatusUnknown
-	}
-	switch o.OrderPayment.Status {
+func (o *Order) SetPaymentStatus(status PaymentStatus) {
+	switch status {
 	case PaymentStatusPending:
-		return OrderStatusUnpaid
+		o.Status = OrderStatusUnpaid
 	case PaymentStatusAuthorized:
-		return OrderStatusWaiting
+		o.Status = OrderStatusWaiting
 	case PaymentStatusCaptured:
-		if !o.OrderFulfillments.Fulfilled() {
-			return OrderStatusPreparing
-		}
-		if o.CompletedAt.IsZero() {
-			return OrderStatusShipped
-		}
-		return OrderStatusCompleted
+		o.Status = OrderStatusPreparing
 	case PaymentStatusCanceled:
-		return OrderStatusCanceled
+		o.Status = OrderStatusCanceled
 	case PaymentStatusRefunded:
-		return OrderStatusRefunded
+		o.Status = OrderStatusRefunded
 	case PaymentStatusFailed:
-		return OrderStatusFailed
+		o.Status = OrderStatusFailed
 	default:
-		return OrderStatusUnknown
+		o.Status = OrderStatusUnknown
+	}
+}
+
+func (o *Order) SetFulfillmentStatus(fulfillmentID string, status FulfillmentStatus) {
+	for _, f := range o.OrderFulfillments {
+		if f.ID == fulfillmentID {
+			f.Status = status
+			break
+		}
+	}
+	if o.OrderFulfillments.Fulfilled() {
+		o.Status = OrderStatusShipped
+	} else {
+		o.Status = OrderStatusPreparing
 	}
 }
 

--- a/api/internal/store/service/checkout.go
+++ b/api/internal/store/service/checkout.go
@@ -174,7 +174,7 @@ func (s *service) NotifyPaymentCompleted(ctx context.Context, in *store.NotifyPa
 		PaymentID: in.PaymentID,
 		IssuedAt:  in.IssuedAt,
 	}
-	err := s.db.Order.UpdatePaymentStatus(ctx, in.OrderID, params)
+	err := s.db.Order.UpdatePayment(ctx, in.OrderID, params)
 	if errors.Is(err, database.ErrFailedPrecondition) {
 		s.logger.Warn("Order is already updated",
 			zap.String("orderId", in.OrderID), zap.Int32("status", int32(in.Status)), zap.Time("issuedAt", in.IssuedAt))
@@ -197,14 +197,19 @@ func (s *service) NotifyPaymentRefunded(ctx context.Context, in *store.NotifyPay
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
-	params := &database.RefundOrderParams{
+	params := &database.UpdateOrderPaymentParams{
 		Status:       in.Status,
 		RefundType:   in.Type,
 		RefundTotal:  in.Total,
 		RefundReason: in.Reason,
 		IssuedAt:     in.IssuedAt,
 	}
-	err := s.db.Order.Refund(ctx, in.OrderID, params)
+	err := s.db.Order.UpdatePayment(ctx, in.OrderID, params)
+	if errors.Is(err, database.ErrFailedPrecondition) {
+		s.logger.Warn("Order is already updated",
+			zap.String("orderId", in.OrderID), zap.Int32("status", int32(in.Status)), zap.Time("issuedAt", in.IssuedAt))
+		return nil
+	}
 	return internalError(err)
 }
 

--- a/api/internal/store/service/checkout.go
+++ b/api/internal/store/service/checkout.go
@@ -197,14 +197,14 @@ func (s *service) NotifyPaymentRefunded(ctx context.Context, in *store.NotifyPay
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
-	params := &database.UpdateOrderPaymentParams{
+	params := &database.UpdateOrderRefundParams{
 		Status:       in.Status,
 		RefundType:   in.Type,
 		RefundTotal:  in.Total,
 		RefundReason: in.Reason,
 		IssuedAt:     in.IssuedAt,
 	}
-	err := s.db.Order.UpdatePayment(ctx, in.OrderID, params)
+	err := s.db.Order.UpdateRefund(ctx, in.OrderID, params)
 	if errors.Is(err, database.ErrFailedPrecondition) {
 		s.logger.Warn("Order is already updated",
 			zap.String("orderId", in.OrderID), zap.Int32("status", int32(in.Status)), zap.Time("issuedAt", in.IssuedAt))

--- a/api/internal/store/service/checkout_test.go
+++ b/api/internal/store/service/checkout_test.go
@@ -1033,7 +1033,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 func TestNotifyPaymentRefunded(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	params := &database.UpdateOrderPaymentParams{
+	params := &database.UpdateOrderRefundParams{
 		Status:       entity.PaymentStatusRefunded,
 		RefundType:   entity.RefundTypeRefunded,
 		RefundTotal:  1980,
@@ -1049,7 +1049,7 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 		{
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdateRefund(ctx, "order-id", params).Return(nil)
 			},
 			input: &store.NotifyPaymentRefundedInput{
 				OrderID:  "order-id",
@@ -1070,7 +1070,7 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 		{
 			name: "failed to update payment status",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(assert.AnError)
+				mocks.db.Order.EXPECT().UpdateRefund(ctx, "order-id", params).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentRefundedInput{
 				OrderID:  "order-id",
@@ -1085,7 +1085,7 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 		{
 			name: "already updated",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
+				mocks.db.Order.EXPECT().UpdateRefund(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
 			},
 			input: &store.NotifyPaymentRefundedInput{
 				OrderID:  "order-id",

--- a/api/internal/store/service/checkout_test.go
+++ b/api/internal/store/service/checkout_test.go
@@ -31,6 +31,7 @@ func TestGetCheckoutState(t *testing.T) {
 			UserID:          "user-id",
 			PromotionID:     "",
 			CoordinatorID:   "coordinator-id",
+			Status:          entity.OrderStatusUnpaid,
 			ShippingMessage: "ご注文ありがとうございます！商品到着まで今しばらくお待ち下さい。",
 			CreatedAt:       now,
 			UpdatedAt:       now,
@@ -796,6 +797,7 @@ func checkoutmocks(
 		UserID:          "user-id",
 		CoordinatorID:   "coordinator-id",
 		PromotionID:     "promotion-id",
+		Status:          entity.OrderStatusUnpaid,
 		ShippingMessage: "ご注文ありがとうございます！商品到着まで今しばらくお待ち下さい。",
 	}
 
@@ -943,7 +945,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 		{
 			name: "success authorized",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePaymentStatus(ctx, "order-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(nil)
 				mocks.messenger.EXPECT().NotifyOrderAuthorized(ctx, in).Return(nil)
 			},
 			input: &store.NotifyPaymentCompletedInput{
@@ -962,7 +964,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 					PaymentID: "payment-id",
 					IssuedAt:  now,
 				}
-				mocks.db.Order.EXPECT().UpdatePaymentStatus(ctx, "order-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(nil)
 			},
 			input: &store.NotifyPaymentCompletedInput{
 				OrderID:   "order-id",
@@ -981,7 +983,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 		{
 			name: "failed to update payment status",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePaymentStatus(ctx, "order-id", params).Return(assert.AnError)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentCompletedInput{
 				OrderID:   "order-id",
@@ -994,7 +996,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 		{
 			name: "already updated",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePaymentStatus(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
 			},
 			input: &store.NotifyPaymentCompletedInput{
 				OrderID:   "order-id",
@@ -1007,7 +1009,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 		{
 			name: "failed to notify order authorized",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().UpdatePaymentStatus(ctx, "order-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(nil)
 				mocks.messenger.EXPECT().NotifyOrderAuthorized(ctx, in).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentCompletedInput{
@@ -1031,7 +1033,7 @@ func TestNotifyPaymentCompleted(t *testing.T) {
 func TestNotifyPaymentRefunded(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	params := &database.RefundOrderParams{
+	params := &database.UpdateOrderPaymentParams{
 		Status:       entity.PaymentStatusRefunded,
 		RefundType:   entity.RefundTypeRefunded,
 		RefundTotal:  1980,
@@ -1047,7 +1049,7 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 		{
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().Refund(ctx, "order-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(nil)
 			},
 			input: &store.NotifyPaymentRefundedInput{
 				OrderID:  "order-id",
@@ -1068,7 +1070,7 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 		{
 			name: "failed to update payment status",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().Refund(ctx, "order-id", params).Return(assert.AnError)
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentRefundedInput{
 				OrderID:  "order-id",
@@ -1079,6 +1081,21 @@ func TestNotifyPaymentRefunded(t *testing.T) {
 				IssuedAt: now,
 			},
 			expect: exception.ErrInternal,
+		},
+		{
+			name: "already updated",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Order.EXPECT().UpdatePayment(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
+			},
+			input: &store.NotifyPaymentRefundedInput{
+				OrderID:  "order-id",
+				Status:   entity.PaymentStatusRefunded,
+				Type:     entity.RefundTypeRefunded,
+				Total:    1980,
+				Reason:   "在庫不足のため。",
+				IssuedAt: now,
+			},
+			expect: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -1292,6 +1309,7 @@ func TestCheckout(t *testing.T) {
 			UserID:          "user-id",
 			CoordinatorID:   "coordinator-id",
 			PromotionID:     "promotion-id",
+			Status:          entity.OrderStatusUnpaid,
 			ShippingMessage: "ご注文ありがとうございます！商品到着まで今しばらくお待ち下さい。",
 		}
 	}

--- a/api/internal/store/service/order.go
+++ b/api/internal/store/service/order.go
@@ -175,7 +175,7 @@ func (s *service) UpdateOrderFulfillment(ctx context.Context, in *store.UpdateOr
 		TrackingNumber:  in.TrackingNumber,
 		ShippedAt:       s.now(),
 	}
-	err = s.db.Order.UpdateFulfillment(ctx, in.FulfillmentID, params)
+	err = s.db.Order.UpdateFulfillment(ctx, in.OrderID, in.FulfillmentID, params)
 	return internalError(err)
 }
 

--- a/api/internal/store/service/order_test.go
+++ b/api/internal/store/service/order_test.go
@@ -1104,7 +1104,7 @@ func TestUpdateOrderFulfillment(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
-				mocks.db.Order.EXPECT().UpdateFulfillment(ctx, "fulfillment-id", params).Return(nil)
+				mocks.db.Order.EXPECT().UpdateFulfillment(ctx, "order-id", "fulfillment-id", params).Return(nil)
 			},
 			input: &store.UpdateOrderFulfillmentInput{
 				OrderID:         "order-id",
@@ -1151,7 +1151,7 @@ func TestUpdateOrderFulfillment(t *testing.T) {
 			name: "failed to update fulfillment",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
-				mocks.db.Order.EXPECT().UpdateFulfillment(ctx, "fulfillment-id", params).Return(assert.AnError)
+				mocks.db.Order.EXPECT().UpdateFulfillment(ctx, "order-id", "fulfillment-id", params).Return(assert.AnError)
 			},
 			input: &store.UpdateOrderFulfillmentInput{
 				OrderID:         "order-id",

--- a/infra/mysql/schema/2024020501-stores-add-column.sql
+++ b/infra/mysql/schema/2024020501-stores-add-column.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `stores`.`orders` ADD COLUMN `status` INT DEFAULT NULL;
+ALTER TABLE `stores`.`orders` ADD COLUMN `status` INT NOT NULL;

--- a/infra/mysql/schema/2024020501-stores-add-column.sql
+++ b/infra/mysql/schema/2024020501-stores-add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `stores`.`orders` ADD COLUMN `status` INT DEFAULT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 注文のステータス、支払い、および返金情報の更新機能を強化しました。
	- 注文の履行状況を更新するための新しいパラメータを追加しました。

- **バグ修正**
	- 注文の返金処理を削除し、新しい返金更新メソッドに置き換えました。

- **リファクタ**
	- 支払いステータスの更新メソッド名を変更しました。

- **データベースの変更**
	- `stores.orders`テーブルに新しい`status`列を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->