### PR TITLE
fix(messenger): キュー管理のロジック修正

### DIFF
--- a/api/internal/messenger/database/database.go
+++ b/api/internal/messenger/database/database.go
@@ -147,9 +147,9 @@ type PushTemplate interface {
 }
 
 type ReceivedQueue interface {
-	Get(ctx context.Context, queueID string, fields ...string) (*entity.ReceivedQueue, error)
-	Create(ctx context.Context, queue *entity.ReceivedQueue) error
-	UpdateDone(ctx context.Context, queueID string, done bool) error
+	Get(ctx context.Context, queueID string, typ entity.NotifyType, fields ...string) (*entity.ReceivedQueue, error)
+	MultiCreate(ctx context.Context, queues ...*entity.ReceivedQueue) error
+	UpdateDone(ctx context.Context, queueID string, typ entity.NotifyType, done bool) error
 }
 
 type ReportTemplate interface {

--- a/api/internal/messenger/entity/received_queue.go
+++ b/api/internal/messenger/entity/received_queue.go
@@ -7,10 +7,22 @@ import (
 	"gorm.io/datatypes"
 )
 
+// NotifyType - 通知種別
+type NotifyType int32
+
+const (
+	NotifyTypeUnknown NotifyType = 0
+	NotifyTypeEmail   NotifyType = 1 // メール通知
+	NotifyTypeMessage NotifyType = 2 // メッセージ通知
+	NotifyTypePush    NotifyType = 3 // プッシュ通知
+	NotifyTypeReport  NotifyType = 4 // システムレポート
+)
+
 // ReceivedQueue - 通知キュー管理
 type ReceivedQueue struct {
 	ID          string         `gorm:"primaryKey;<-:create"`         // 通知キューID
-	EventType   EventType      `gorm:""`                             // 通知種別
+	NotifyType  NotifyType     `gorm:"primaryKey;<-:create"`         // 通知種別
+	EventType   EventType      `gorm:""`                             // 実行種別
 	UserType    UserType       `gorm:""`                             // 送信先ユーザー種別
 	UserIDs     []string       `gorm:"-"`                            // 送信先ユーザーID一覧
 	UserIDsJSON datatypes.JSON `gorm:"default:null;column:user_ids"` // 送信先ユーザーID一覧(JSON)
@@ -19,14 +31,35 @@ type ReceivedQueue struct {
 	UpdatedAt   time.Time      `gorm:""`                             // 更新日時
 }
 
-func NewReceivedQueue(payload *WorkerPayload) *ReceivedQueue {
+type ReceivedQueues []*ReceivedQueue
+
+func NewReceivedQueue(payload *WorkerPayload, notifyType NotifyType) *ReceivedQueue {
 	return &ReceivedQueue{
-		ID:        payload.QueueID,
-		EventType: payload.EventType,
-		UserType:  payload.UserType,
-		UserIDs:   payload.UserIDs,
-		Done:      false,
+		ID:         payload.QueueID,
+		NotifyType: notifyType,
+		EventType:  payload.EventType,
+		UserType:   payload.UserType,
+		UserIDs:    payload.UserIDs,
+		Done:       false,
 	}
+}
+
+func NewReceivedQueues(payload *WorkerPayload) ReceivedQueues {
+	const max = 4
+	res := make(ReceivedQueues, 0, max)
+	if payload.Email != nil {
+		res = append(res, NewReceivedQueue(payload, NotifyTypeEmail))
+	}
+	if payload.Message != nil {
+		res = append(res, NewReceivedQueue(payload, NotifyTypeMessage))
+	}
+	if payload.Push != nil {
+		res = append(res, NewReceivedQueue(payload, NotifyTypePush))
+	}
+	if payload.Report != nil {
+		res = append(res, NewReceivedQueue(payload, NotifyTypeReport))
+	}
+	return res
 }
 
 func (q *ReceivedQueue) Fill() error {
@@ -44,5 +77,23 @@ func (q *ReceivedQueue) FillJSON() error {
 		return err
 	}
 	q.UserIDsJSON = datatypes.JSON(v)
+	return nil
+}
+
+func (qs ReceivedQueues) Fill() error {
+	for i := range qs {
+		if err := qs[i].Fill(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (qs ReceivedQueues) FillJSON() error {
+	for i := range qs {
+		if err := qs[i].FillJSON(); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/api/internal/messenger/entity/received_queue_test.go
+++ b/api/internal/messenger/entity/received_queue_test.go
@@ -8,12 +8,12 @@ import (
 	"gorm.io/datatypes"
 )
 
-func TestReceivedQueue(t *testing.T) {
+func TestReceivedQueues(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
 		payload *WorkerPayload
-		expect  *ReceivedQueue
+		expect  ReceivedQueues
 	}{
 		{
 			name: "success",
@@ -26,13 +26,43 @@ func TestReceivedQueue(t *testing.T) {
 					TemplateID:    EmailTemplateIDAdminRegister,
 					Substitutions: map[string]interface{}{"パスワード": "!Qaz2wsx"},
 				},
+				Message: &MessageConfig{},
+				Push:    &PushConfig{},
+				Report:  &ReportConfig{},
 			},
-			expect: &ReceivedQueue{
-				ID:        "id",
-				EventType: EventTypeRegisterAdmin,
-				UserType:  UserTypeAdmin,
-				UserIDs:   []string{"admin-id"},
-				Done:      false,
+			expect: ReceivedQueues{
+				{
+					ID:         "id",
+					NotifyType: NotifyTypeEmail,
+					EventType:  EventTypeRegisterAdmin,
+					UserType:   UserTypeAdmin,
+					UserIDs:    []string{"admin-id"},
+					Done:       false,
+				},
+				{
+					ID:         "id",
+					NotifyType: NotifyTypeMessage,
+					EventType:  EventTypeRegisterAdmin,
+					UserType:   UserTypeAdmin,
+					UserIDs:    []string{"admin-id"},
+					Done:       false,
+				},
+				{
+					ID:         "id",
+					NotifyType: NotifyTypePush,
+					EventType:  EventTypeRegisterAdmin,
+					UserType:   UserTypeAdmin,
+					UserIDs:    []string{"admin-id"},
+					Done:       false,
+				},
+				{
+					ID:         "id",
+					NotifyType: NotifyTypeReport,
+					EventType:  EventTypeRegisterAdmin,
+					UserType:   UserTypeAdmin,
+					UserIDs:    []string{"admin-id"},
+					Done:       false,
+				},
 			},
 		},
 	}
@@ -40,40 +70,44 @@ func TestReceivedQueue(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual := NewReceivedQueue(tt.payload)
+			actual := NewReceivedQueues(tt.payload)
 			assert.Equal(t, tt.expect, actual)
 		})
 	}
 }
 
-func TestReceivedQueue_Fill(t *testing.T) {
+func TestReceivedQueues_Fill(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
-		queue  *ReceivedQueue
-		expect *ReceivedQueue
+		queue  ReceivedQueues
+		expect ReceivedQueues
 		hasErr bool
 	}{
 		{
 			name: "success",
-			queue: &ReceivedQueue{
-				ID:          "id",
-				EventType:   EventTypeRegisterAdmin,
-				UserType:    UserTypeAdmin,
-				UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
-				Done:        false,
-				CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
-				UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+			queue: ReceivedQueues{
+				{
+					ID:          "id",
+					EventType:   EventTypeRegisterAdmin,
+					UserType:    UserTypeAdmin,
+					UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
+					Done:        false,
+					CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+					UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+				},
 			},
-			expect: &ReceivedQueue{
-				ID:          "id",
-				EventType:   EventTypeRegisterAdmin,
-				UserType:    UserTypeAdmin,
-				UserIDs:     []string{"admin-id"},
-				UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
-				Done:        false,
-				CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
-				UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+			expect: ReceivedQueues{
+				{
+					ID:          "id",
+					EventType:   EventTypeRegisterAdmin,
+					UserType:    UserTypeAdmin,
+					UserIDs:     []string{"admin-id"},
+					UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
+					Done:        false,
+					CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+					UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+				},
 			},
 			hasErr: false,
 		},
@@ -89,34 +123,38 @@ func TestReceivedQueue_Fill(t *testing.T) {
 	}
 }
 
-func TestReceivedQueue_FillJSON(t *testing.T) {
+func TestReceivedQueues_FillJSON(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
-		queue  *ReceivedQueue
-		expect *ReceivedQueue
+		queue  ReceivedQueues
+		expect ReceivedQueues
 		hasErr bool
 	}{
 		{
 			name: "success",
-			queue: &ReceivedQueue{
-				ID:        "id",
-				EventType: EventTypeRegisterAdmin,
-				UserType:  UserTypeAdmin,
-				UserIDs:   []string{"admin-id"},
-				Done:      false,
-				CreatedAt: jst.Date(2022, 7, 10, 18, 30, 0, 0),
-				UpdatedAt: jst.Date(2022, 7, 10, 18, 30, 0, 0),
+			queue: ReceivedQueues{
+				{
+					ID:        "id",
+					EventType: EventTypeRegisterAdmin,
+					UserType:  UserTypeAdmin,
+					UserIDs:   []string{"admin-id"},
+					Done:      false,
+					CreatedAt: jst.Date(2022, 7, 10, 18, 30, 0, 0),
+					UpdatedAt: jst.Date(2022, 7, 10, 18, 30, 0, 0),
+				},
 			},
-			expect: &ReceivedQueue{
-				ID:          "id",
-				EventType:   EventTypeRegisterAdmin,
-				UserType:    UserTypeAdmin,
-				UserIDs:     []string{"admin-id"},
-				UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
-				Done:        false,
-				CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
-				UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+			expect: ReceivedQueues{
+				{
+					ID:          "id",
+					EventType:   EventTypeRegisterAdmin,
+					UserType:    UserTypeAdmin,
+					UserIDs:     []string{"admin-id"},
+					UserIDsJSON: datatypes.JSON([]byte(`["admin-id"]`)),
+					Done:        false,
+					CreatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+					UpdatedAt:   jst.Date(2022, 7, 10, 18, 30, 0, 0),
+				},
 			},
 			hasErr: false,
 		},

--- a/api/internal/messenger/service/notify.go
+++ b/api/internal/messenger/service/notify.go
@@ -338,8 +338,8 @@ func (s *service) sendMessage(ctx context.Context, payload *entity.WorkerPayload
 	if err != nil {
 		return err
 	}
-	queue := entity.NewReceivedQueue(payload)
-	if err := s.db.ReceivedQueue.Create(ctx, queue); err != nil {
+	queues := entity.NewReceivedQueues(payload)
+	if err := s.db.ReceivedQueue.MultiCreate(ctx, queues...); err != nil {
 		return err
 	}
 	if _, err := s.producer.SendMessage(ctx, buf); err != nil {

--- a/api/internal/messenger/worker/messenger.go
+++ b/api/internal/messenger/worker/messenger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/messenger/entity"
 )
 
-func (w *worker) messenger(ctx context.Context, payload *entity.WorkerPayload) error {
+func (w *worker) createMessages(ctx context.Context, payload *entity.WorkerPayload) error {
 	template, err := w.db.MessageTemplate.Get(ctx, payload.Message.TemplateID)
 	if err != nil {
 		return err

--- a/api/internal/messenger/worker/messenger_test.go
+++ b/api/internal/messenger/worker/messenger_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMessenger(t *testing.T) {
+func TestCreateMessages(t *testing.T) {
 	t.Parallel()
 
 	now := jst.Date(2022, 7, 21, 18, 30, 0, 0)
@@ -114,7 +114,7 @@ func TestMessenger(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, testWorker(tt.setup, func(ctx context.Context, t *testing.T, worker *worker) {
-			err := worker.messenger(ctx, tt.payload)
+			err := worker.createMessages(ctx, tt.payload)
 			assert.ErrorIs(t, err, tt.expectErr)
 		}))
 	}

--- a/api/internal/messenger/worker/reporter.go
+++ b/api/internal/messenger/worker/reporter.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (w *worker) reporter(ctx context.Context, payload *entity.WorkerPayload) error {
+func (w *worker) sendReport(ctx context.Context, payload *entity.WorkerPayload) error {
 	template, err := w.db.ReportTemplate.Get(ctx, payload.Report.TemplateID)
 	if err != nil {
 		return err

--- a/api/internal/messenger/worker/reporter_test.go
+++ b/api/internal/messenger/worker/reporter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReporter(t *testing.T) {
+func TestSendReport(t *testing.T) {
 	t.Parallel()
 
 	template := &entity.ReportTemplate{
@@ -103,7 +103,7 @@ func TestReporter(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, testWorker(tt.setup, func(ctx context.Context, t *testing.T, worker *worker) {
-			err := worker.reporter(ctx, tt.payload)
+			err := worker.sendReport(ctx, tt.payload)
 			assert.ErrorIs(t, err, tt.expectErr)
 		}))
 	}

--- a/infra/mysql/schema/2024020801-messengers-alter-primary-key.sql
+++ b/infra/mysql/schema/2024020801-messengers-alter-primary-key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `messengers`.`received_queues` ADD COLUMN `notify_type` INT NOT NULL;
+ALTER TABLE `messengers`.`received_queues` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `notify_type`);


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 通知タイプに基づいて複数のキューを処理するための`MultiCreate`メソッドを追加しました。
	- 異なる通知タイプを識別する`NotifyType`列挙型を導入しました。
- **バグ修正**
	- `ReceivedQueue`の`Get`および`UpdateDone`メソッドに`NotifyType`パラメータを追加して、通知タイプに基づく処理を可能にしました。
- **リファクタ**
	- 通知処理を一般化するために、`worker`内で`execute`関数を導入しました。
	- 複数のキューに対応するために、`ReceivedQueue`を`ReceivedQueues`にリネームし、関連するテストケースを更新しました。
- **テスト**
	- `notify_test.go`と`worker_test.go`で、複数のキューを扱う新しいロジックに基づいてテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->