### PR TITLE
fix(store): 注文ステータスの検証ロジックを修正

### DIFF
--- a/api/internal/store/database/mysql/order.go
+++ b/api/internal/store/database/mysql/order.go
@@ -146,7 +146,7 @@ func (o *order) UpdatePayment(ctx context.Context, orderID string, params *datab
 		if err != nil {
 			return err
 		}
-		if order.IsCompleted() {
+		if order.Completed() {
 			return fmt.Errorf("mysql: this order is already completed: %w", database.ErrFailedPrecondition)
 		}
 		updatedAt := order.OrderPayment.UpdatedAt.Truncate(time.Second)
@@ -189,7 +189,7 @@ func (o *order) UpdateFulfillment(ctx context.Context, orderID, fulfillmentID st
 		if err != nil {
 			return err
 		}
-		if order.IsCompleted() {
+		if order.Completed() {
 			return fmt.Errorf("mysql: this order is already completed: %w", database.ErrFailedPrecondition)
 		}
 

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -706,7 +706,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "already completed",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusCompleted, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID: "order-id",

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -602,13 +602,13 @@ func TestOrder_UpdatePayment(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
-	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
+	create := func(t *testing.T, orderID string, status entity.OrderStatus, now time.Time) {
 		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order.Status = status
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
 
 		payment := testOrderPayment(orderID, 1, "transaction-id", "payment-id", now)
-		payment.Status = status
 		err = db.DB.Create(&payment).Error
 		require.NoError(t, err)
 
@@ -640,7 +640,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "success authorized",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID: "order-id",
@@ -657,7 +657,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "success captured",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusAuthorized, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID: "order-id",
@@ -674,7 +674,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "success failed",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID: "order-id",
@@ -706,7 +706,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "already completed",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusCaptured, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID: "order-id",
@@ -723,7 +723,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 		{
 			name: "not latest data",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusAuthorized, now().AddDate(0, 0, 1))
+				create(t, "order-id", entity.OrderStatusUnpaid, now().AddDate(0, 0, 1))
 			},
 			args: args{
 				orderID: "order-id",
@@ -794,13 +794,13 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
-	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
+	create := func(t *testing.T, orderID string, status entity.OrderStatus, now time.Time) {
 		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order.Status = status
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
 
 		payment := testOrderPayment(orderID, 1, "transaction-id", "payment-id", now)
-		payment.Status = status
 		err = db.DB.Create(&payment).Error
 		require.NoError(t, err)
 
@@ -833,7 +833,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 		{
 			name: "success fulfilled",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusPending, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusPreparing, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID:       "order-id",
@@ -852,7 +852,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 		{
 			name: "success uunfulfilled",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusAuthorized, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusPreparing, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID:       "order-id",
@@ -888,7 +888,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 		{
 			name: "already completed",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				create(t, "order-id", entity.PaymentStatusCaptured, now().AddDate(0, 0, -1))
+				create(t, "order-id", entity.OrderStatusCompleted, now().AddDate(0, 0, -1))
 			},
 			args: args{
 				orderID:       "order-id",

--- a/api/internal/store/entity/order.go
+++ b/api/internal/store/entity/order.go
@@ -156,17 +156,16 @@ func (o *Order) SetFulfillmentStatus(fulfillmentID string, status FulfillmentSta
 	}
 }
 
-// TODO: Order.Statusを利用して書き換える
 func (o *Order) Completed() bool {
 	if o == nil {
 		return false
 	}
-	if !o.CompletedAt.IsZero() {
+	switch o.Status {
+	case OrderStatusCompleted, OrderStatusCanceled, OrderStatusRefunded, OrderStatusFailed:
 		return true
+	default:
+		return false
 	}
-	return o.OrderPayment.Status == PaymentStatusCanceled ||
-		o.OrderPayment.Status == PaymentStatusRefunded ||
-		o.OrderPayment.Status == PaymentStatusFailed
 }
 
 // TODO: Order.Statusを利用して書き換える

--- a/api/internal/store/entity/order_test.go
+++ b/api/internal/store/entity/order_test.go
@@ -376,6 +376,68 @@ func TestOrder_SetFulfillmentStatus(t *testing.T) {
 	}
 }
 
+func TestOrder_Completed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		order  *Order
+		expect bool
+	}{
+		{
+			name:   "unpaid",
+			order:  &Order{Status: OrderStatusUnpaid},
+			expect: false,
+		},
+		{
+			name:   "waiting",
+			order:  &Order{Status: OrderStatusWaiting},
+			expect: false,
+		},
+		{
+			name:   "preparing",
+			order:  &Order{Status: OrderStatusPreparing},
+			expect: false,
+		},
+		{
+			name:   "shipped",
+			order:  &Order{Status: OrderStatusShipped},
+			expect: false,
+		},
+		{
+			name:   "completed",
+			order:  &Order{Status: OrderStatusCompleted},
+			expect: true,
+		},
+		{
+			name:   "canceled",
+			order:  &Order{Status: OrderStatusCanceled},
+			expect: true,
+		},
+		{
+			name:   "refunded",
+			order:  &Order{Status: OrderStatusRefunded},
+			expect: true,
+		},
+		{
+			name:   "failed",
+			order:  &Order{Status: OrderStatusFailed},
+			expect: true,
+		},
+		{
+			name:   "nil",
+			order:  nil,
+			expect: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.order.Completed())
+		})
+	}
+}
+
 func TestOrder_EnableAction(t *testing.T) {
 	t.Parallel()
 	type want struct {

--- a/api/internal/store/service/order_test.go
+++ b/api/internal/store/service/order_test.go
@@ -1136,7 +1136,7 @@ func TestUpdateOrderFulfillment(t *testing.T) {
 		{
 			name: "failed to completed",
 			setup: func(ctx context.Context, mocks *mocks) {
-				order := &entity.Order{CompletedAt: now}
+				order := &entity.Order{Status: entity.OrderStatusCompleted}
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
 			},
 			input: &store.UpdateOrderFulfillmentInput{


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 注文の完了状態を判断するロジックを改善しました。`CompletedAt`フィールドの代わりに`Status`フィールドを使用して、注文が完了したかどうかを判断します。

- **バグ修正**
	- `UpdatePayment`と`UpdateFulfillment`機能内での`IsCompleted()`メソッドの呼び出しを`Completed()`に置き換えました。

- **テスト**
	- 注文の状態に基づいて注文が完了しているかどうかをテストする新しいテスト機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->