### PR TITLE
feat(media): ファイル参照時にCDN経由にできるように

### DIFF
--- a/api/internal/media/cmd/uploader/registry.go
+++ b/api/internal/media/cmd/uploader/registry.go
@@ -82,7 +82,7 @@ func (a *app) inject(ctx context.Context) error {
 		Tmp:       params.tmpStorage,
 		Cache:     params.cache,
 	}
-	a.uploader = uploader.NewUploader(uploaderParams, uploader.WithLogger(params.logger))
+	a.uploader = uploader.NewUploader(uploaderParams, uploader.WithLogger(params.logger), uploader.WithCacheDomain(a.CDNDomain))
 	a.logger = params.logger
 	a.waitGroup = params.waitGroup
 	return nil

--- a/api/internal/media/cmd/uploader/uploader.go
+++ b/api/internal/media/cmd/uploader/uploader.go
@@ -29,6 +29,7 @@ type app struct {
 	AWSRegion        string `envconfig:"AWS_REGION" default:"ap-northeast-1"`
 	S3Bucket         string `envconfig:"S3_BUCKET" default:""`
 	S3TmpBucket      string `envconfig:"S3_TMP_BUCKET" default:""`
+	CDNDomain        string `envconfig:"CDN_DOMAIN" default:""`
 }
 
 //nolint:revive


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: ファイル参照時にCDN経由でアクセスできるようになりました。`uploader.NewUploader`の呼び出しに新しいオプション`uploader.WithCacheDomain`が追加され、`app`構造体に`CDNDomain`フィールドが追加されました。これにより、CDNドメインを指定してファイル参照時にCDN経由でアクセスできます。
- Test: `generateUploadURL`関数のテストケースが追加され、期待される結果が更新されました。また、新しいフィールド`expect`が導入され、テスト結果の一部を無視するために使用されます。

以上の変更は、ファイル参照時のパフォーマンスと信頼性を向上させるためのものです。ユーザーはCDN経由でファイルにアクセスできるようになり、テストのカバレッジも向上します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->