### PR TITLE
fix:トップページに表示するアーカイブ配信の動画のタイトルなどのフォントサイズなどを調整

### DIFF
--- a/web/user/src/components/molecules/TheArchiveItem.vue
+++ b/web/user/src/components/molecules/TheArchiveItem.vue
@@ -30,11 +30,13 @@ const handleClick = () => {
     </div>
     <div class="mt-2 flex w-full flex-col gap-2">
       <div class="flex items-center justify-between text-sm">
-        <span class="rounded border-2 border-main px-2 font-bold text-main">
+        <span
+          class="rounded border border-main px-1 text-[10px] font-bold tracking-[10%] text-main"
+        >
           アーカイブ配信
         </span>
       </div>
-      <p class="line-clamp-3 break-words">
+      <p class="line-clamp-3 break-words text-[14px] tracking-[10%]">
         {{ title }}
       </p>
     </div>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

![localhost_3000_(iPhone 12 Pro)](https://github.com/and-period/furumaru/assets/27722351/2a8f1900-1edf-409a-9ee0-a3db18f6940e)



<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Style: アーカイブされたビデオのトップページに表示されるタイトルのフォントサイズを14pxに変更し、フォントの重さと文字間隔を調整しました。これにより、ユーザーが情報をより読みやすく感じることができます。
- Style: アーカイブアイテムの境界線スタイリングを修正し、サイト全体のデザインとの一貫性を高めました。この変更は、ユーザーインターフェースの視覚的魅力を向上させることを目的としています。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->