### PR TITLE
fix(admin): 配信スケジュールが更新できない場合のバリデーション追加

### DIFF
--- a/web/admin/src/components/organisms/ScheduleShow.vue
+++ b/web/admin/src/components/organisms/ScheduleShow.vue
@@ -11,6 +11,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  updatable: {
+    type: Boolean,
+    default: false
+  },
   formData: {
     type: Object as PropType<UpdateScheduleRequest>,
     default: (): UpdateScheduleRequest => ({
@@ -169,11 +173,13 @@ const onSubmit = async (): Promise<void> => {
           <v-card-text>
             <v-text-field
               v-model="formDataValidate.title.$model"
+              :readonly="!updatable"
               :error-messages="getErrorMessage(formDataValidate.title.$errors)"
               label="タイトル"
             />
             <v-textarea
               v-model="formDataValidate.description.$model"
+              :readonly="!updatable"
               :error-message="getErrorMessage(formDataValidate.description.$errors)"
               label="詳細"
               maxlength="2000"
@@ -234,6 +240,7 @@ const onSubmit = async (): Promise<void> => {
           <div class="d-flex flex-column flex-md-row justify-center">
             <v-text-field
               v-model="startTimeDataValidate.date.$model"
+              :readonly="!updatable"
               :error-messages="getErrorMessage(startTimeDataValidate.date.$errors)"
               type="date"
               variant="outlined"
@@ -243,6 +250,7 @@ const onSubmit = async (): Promise<void> => {
             />
             <v-text-field
               v-model="startTimeDataValidate.time.$model"
+              :readonly="!updatable"
               :error-messages="getErrorMessage(startTimeDataValidate.time.$errors)"
               type="time"
               variant="outlined"
@@ -256,6 +264,7 @@ const onSubmit = async (): Promise<void> => {
           <div class="d-flex flex-column flex-md-row justify-center">
             <v-text-field
               v-model="endTimeDataValidate.date.$model"
+              :readonly="!updatable"
               :error-messages="getErrorMessage(endTimeDataValidate.date.$errors)"
               type="date"
               variant="outlined"
@@ -265,6 +274,7 @@ const onSubmit = async (): Promise<void> => {
             />
             <v-text-field
               v-model="endTimeDataValidate.time.$model"
+              :readonly="!updatable"
               :error-messages="getErrorMessage(endTimeDataValidate.time.$errors)"
               type="time"
               variant="outlined"
@@ -277,7 +287,14 @@ const onSubmit = async (): Promise<void> => {
     </v-col>
   </v-row>
 
-  <v-btn block :loading="loading" variant="outlined" color="primary" @click="onSubmit">
+  <v-btn
+    v-if="updatable"
+    block
+    :loading="loading"
+    variant="outlined"
+    color="primary"
+    @click="onSubmit"
+  >
     更新
   </v-btn>
 </template>

--- a/web/admin/src/components/templates/ScheduleEdit.vue
+++ b/web/admin/src/components/templates/ScheduleEdit.vue
@@ -10,6 +10,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  updatable: {
+    type: Boolean,
+    default: false
+  },
   isAlert: {
     type: Boolean,
     default: false
@@ -351,6 +355,7 @@ const onSubmitUploadArchiveMp4 = (): void => {
       <organisms-schedule-show
         v-model:form-data="scheduleFormDataValue"
         :loading="loading"
+        :updatable="updatable"
         :schedule="schedule"
         :coordinators="coordinators"
         :thumbnail-upload-status="thumbnailUploadStatus"

--- a/web/admin/src/pages/schedules/[id]/index.vue
+++ b/web/admin/src/pages/schedules/[id]/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import dayjs from 'dayjs'
+import dayjs, { unix } from 'dayjs'
 import { storeToRefs } from 'pinia'
 import { useAlert } from '~/lib/hooks'
 import { useBroadcastStore, useCommonStore, useCoordinatorStore, useLiveStore, useProducerStore, useProductStore, useScheduleStore } from '~/store'
@@ -107,6 +107,11 @@ const fetchState = useAsyncData(async (): Promise<void> => {
 
 const isLoading = (): boolean => {
   return fetchState?.pending?.value || loading.value
+}
+
+const updatable = (): boolean => {
+  const startAt = unix(schedule.value.startAt)
+  return dayjs().isBefore(startAt)
 }
 
 const handleSearchProducer = async (name: string): Promise<void> => {
@@ -440,7 +445,7 @@ try {
 </script>
 
 <template>
-  <templates-schedule-show
+  <templates-schedule-edit
     v-model:selected-tab-item="selector"
     v-model:create-live-dialog="createLiveDialog"
     v-model:update-live-dialog="updateLiveDialog"
@@ -452,6 +457,7 @@ try {
     v-model:update-live-form-data="updateLiveFormData"
     v-model:mp4-form-data="mp4FormData"
     :loading="isLoading()"
+    :updatable="updatable()"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート

### New Feature
- **スケジュールの編集可能性**: `ScheduleShow.vue`と`ScheduleEdit.vue`に新しい`updatable`プロパティを追加しました。これにより、特定の条件下でスケジュールの編集が可能かどうかをユーザーが容易に判断できるようになります。入力フィールドは読み取り専用としてマークされ、更新ボタンは条件に応じて表示されるか非表示になります。
- **時間に基づく更新制御**: スケジュールページ(`schedules/[id]/index.vue`)において、現在時刻が指定時刻より前かどうかをチェックする新しいロジックを導入しました。これにより、ユーザーはスケジュールがまだ更新可能かどうかを明確に知ることができます。

このアップデートにより、ユーザーはスケジュール管理の柔軟性と利便性を高めることができます。また、システムはより直感的に操作可能となり、ユーザーエクスペリエンスが向上します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->