### PR TITLE
fix(messenger): ライブ配信開始通知の時間調整

### DIFF
--- a/api/internal/messenger/service/reserve.go
+++ b/api/internal/messenger/service/reserve.go
@@ -16,7 +16,7 @@ import (
 func (s *service) ReserveStartLive(ctx context.Context, in *messenger.ReserveStartLiveInput) error {
 	const (
 		messageType = entity.ScheduleTypeStartLive
-		duration    = time.Hour // ライブ配信開始の１時間前通知
+		duration    = 10 * time.Minute // ライブ配信開始の10分前通知
 	)
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)

--- a/api/internal/messenger/service/reserve_test.go
+++ b/api/internal/messenger/service/reserve_test.go
@@ -31,7 +31,7 @@ func TestReserveStartLive(t *testing.T) {
 		MessageID:   "schedule-id",
 		Status:      entity.ScheduleStatusWaiting,
 		Count:       0,
-		SentAt:      now,
+		SentAt:      now.Add(time.Hour - (10 * time.Minute)),
 		Deadline:    now.Add(time.Hour),
 	}
 	tests := []struct {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
### リリースノート

このアップデートでは、ライブ配信の開始通知時間に関する重要な変更が行われました。これにより、ユーザー体験が向上します。

- **Refactor**: ライブ配信の開始通知時間を1時間前から10分前に変更しました。これにより、ユーザーはライブ配信の開始直前に効果的なリマインドを受け取ることができ、予定の調整が容易になります。

この変更は、ユーザーがライブ配信を見逃すことなく参加できるようにするためのものです。よりタイムリーな通知により、ユーザーのエンゲージメントと満足度が向上することを期待しています。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->