### PR TITLE
fix(store): ライブ商品の並び順を修正

### DIFF
--- a/api/internal/store/entity/live.go
+++ b/api/internal/store/entity/live.go
@@ -53,7 +53,7 @@ func NewLive(params *NewLiveParams) *Live {
 }
 
 func (l *Live) Fill(products LiveProducts) {
-	l.ProductIDs = products.ProductIDs()
+	l.ProductIDs = products.SortByCreatedAt().ProductIDs()
 	l.LiveProducts = products
 }
 

--- a/api/internal/store/entity/live_product.go
+++ b/api/internal/store/entity/live_product.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"sort"
 	"time"
 
 	"github.com/and-period/furumaru/api/pkg/set"
@@ -48,4 +49,11 @@ func (ps LiveProducts) GroupByLiveID() map[string]LiveProducts {
 		res[p.LiveID] = append(res[p.LiveID], p)
 	}
 	return res
+}
+
+func (ps LiveProducts) SortByCreatedAt() LiveProducts {
+	sort.SliceStable(ps, func(i, j int) bool {
+		return ps[i].CreatedAt.Before(ps[j].CreatedAt)
+	})
+	return ps
 }

--- a/api/internal/store/entity/live_product_test.go
+++ b/api/internal/store/entity/live_product_test.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -119,6 +120,42 @@ func TestLiveProducts_GroupByLiveID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expect, tt.products.GroupByLiveID())
+		})
+	}
+}
+
+func TestLiveProducts_SortByCreatedAt(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	tests := []struct {
+		name     string
+		products LiveProducts
+		expect   LiveProducts
+	}{
+		{
+			name: "success",
+			products: LiveProducts{
+				{ProductID: "product-id01", CreatedAt: now},
+				{ProductID: "product-id02", CreatedAt: now.Add(-time.Minute)},
+				{ProductID: "product-id03", CreatedAt: now.Add(time.Minute)},
+				{ProductID: "product-id04", CreatedAt: now.Add(time.Hour)},
+				{ProductID: "product-id05", CreatedAt: now.Add(-time.Hour)},
+			},
+			expect: LiveProducts{
+				{ProductID: "product-id05", CreatedAt: now.Add(-time.Hour)},
+				{ProductID: "product-id02", CreatedAt: now.Add(-time.Minute)},
+				{ProductID: "product-id01", CreatedAt: now},
+				{ProductID: "product-id03", CreatedAt: now.Add(time.Minute)},
+				{ProductID: "product-id04", CreatedAt: now.Add(time.Hour)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.products.SortByCreatedAt()
+			assert.Equal(t, tt.expect, actual)
 		})
 	}
 }


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

このアップデートでは、ライブ配信中の商品表示順序に関する改善が行われました。これにより、エンドユーザーの体験が向上します。

- **Refactor**: `Live`構造体の`Fill`メソッドを改良し、商品IDを作成日時でソートしてから割り当てるように変更しました。これにより、ライブ配信中の商品が作成された順に表示されるようになります。
- **New Feature**: `LiveProducts`型に`SortByCreatedAt()`メソッドを新たに追加しました。このメソッドは、商品をその`CreatedAt`フィールドの昇順でソートする機能を提供します。

これらの変更により、ライブ配信での商品表示がより直感的になり、ユーザーが最新の商品を見つけやすくなることが期待されます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->