### PR TITLE
feat(user): 通知設定一覧取得処理の実装

### DIFF
--- a/api/internal/gateway/user/v1/service/auth_user.go
+++ b/api/internal/gateway/user/v1/service/auth_user.go
@@ -25,7 +25,7 @@ func NewAuthUser(user *entity.User, notification *entity.UserNotification) *Auth
 		},
 	}
 	if notification != nil {
-		res.NotificationEnabled = !notification.EmailDisabled
+		res.NotificationEnabled = !notification.Disabled
 	}
 	return res
 }

--- a/api/internal/gateway/user/v1/service/auth_user_test.go
+++ b/api/internal/gateway/user/v1/service/auth_user_test.go
@@ -47,10 +47,10 @@ func TestAuthUser(t *testing.T) {
 				},
 			},
 			notification: &entity.UserNotification{
-				UserID:        "user-id",
-				EmailDisabled: false,
-				CreatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
-				UpdatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UserID:    "user-id",
+				Disabled:  false,
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
 			},
 			expect: &AuthUser{
 				AuthUser: response.AuthUser{

--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -235,6 +235,7 @@ type ListUsersParams struct {
 }
 
 type UserNotification interface {
+	MultiGet(ctx context.Context, userIDs []string, fields ...string) (entity.UserNotifications, error)
 	Get(ctx context.Context, userID string, fields ...string) (*entity.UserNotification, error)
 	Upsert(ctx context.Context, notification *entity.UserNotification) error
 }

--- a/api/internal/user/database/mysql/user_notification.go
+++ b/api/internal/user/database/mysql/user_notification.go
@@ -27,6 +27,15 @@ func newUserNotification(db *mysql.Client) database.UserNotification {
 	}
 }
 
+func (n *userNotification) MultiGet(ctx context.Context, userIDs []string, fields ...string) (entity.UserNotifications, error) {
+	var notifications entity.UserNotifications
+
+	stmt := n.db.Statement(ctx, n.db.DB, userNotificationTable, fields...).Where("user_id IN (?)", userIDs)
+
+	err := stmt.Find(&notifications).Error
+	return notifications, dbError(err)
+}
+
 func (n *userNotification) Get(ctx context.Context, userID string, fields ...string) (*entity.UserNotification, error) {
 	notification, err := n.get(ctx, n.db.DB, userID, fields...)
 	return notification, dbError(err)
@@ -37,8 +46,8 @@ func (n *userNotification) Upsert(ctx context.Context, notification *entity.User
 	notification.CreatedAt, notification.UpdatedAt = now, now
 
 	updates := map[string]interface{}{
-		"email_disabled": notification.EmailDisabled,
-		"updated_at":     now,
+		"disabled":   notification.Disabled,
+		"updated_at": now,
 	}
 	clauses := clause.OnConflict{
 		Columns:   []clause.Column{{Name: "user_id"}},

--- a/api/internal/user/database/mysql/user_notification_test.go
+++ b/api/internal/user/database/mysql/user_notification_test.go
@@ -16,6 +16,74 @@ func TestUserNotification(t *testing.T) {
 	assert.NotNil(t, newUserNotification(nil))
 }
 
+func TestUserNotification_MultiGet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	users := make(entity.Users, 2)
+	users[0] = testUser("user-id01", "test-user01@example.com", "090-0000-0001", now())
+	users[1] = testUser("user-id02", "test-user02@example.com", "090-0000-0002", now())
+	err = db.DB.WithContext(ctx).Create(&users).Error
+	require.NoError(t, err)
+	notifications := make(entity.UserNotifications, 2)
+	notifications[0] = testUserNotification("user-id01", now())
+	notifications[1] = testUserNotification("user-id02", now())
+	err = db.DB.WithContext(ctx).Create(&notifications).Error
+	require.NoError(t, err)
+
+	type args struct {
+		userIDs []string
+	}
+	type want struct {
+		notifications entity.UserNotifications
+		err           error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				userIDs: []string{"user-id01", "user-id02"},
+			},
+			want: want{
+				notifications: notifications,
+				err:           nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &userNotification{db: db, now: now}
+			actual, err := db.MultiGet(ctx, tt.args.userIDs)
+			assert.ErrorIs(t, err, tt.want.err)
+			assert.ElementsMatch(t, tt.want.notifications, actual)
+		})
+	}
+}
+
 func TestUserNotification_Get(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -99,9 +167,9 @@ func TestUserNotification_Get(t *testing.T) {
 
 func testUserNotification(userID string, now time.Time) *entity.UserNotification {
 	return &entity.UserNotification{
-		UserID:        userID,
-		EmailDisabled: false,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		UserID:    userID,
+		Disabled:  false,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 }

--- a/api/internal/user/entity/user_notification.go
+++ b/api/internal/user/entity/user_notification.go
@@ -1,18 +1,37 @@
 package entity
 
-import "time"
+import (
+	"time"
+)
 
 // UserNotification - ユーザーの通知設定
 type UserNotification struct {
-	UserID        string    `gorm:"primaryKey;<-:create"` // ユーザーID
-	EmailDisabled bool      `gorm:""`                     // メール通知の停止
-	CreatedAt     time.Time `gorm:"<-:create"`            // 登録日時
-	UpdatedAt     time.Time `gorm:""`                     // 更新日時
+	UserID    string    `gorm:"primaryKey;<-:create"` // ユーザーID
+	Disabled  bool      `gorm:""`                     // 通知の停止
+	CreatedAt time.Time `gorm:"<-:create"`            // 登録日時
+	UpdatedAt time.Time `gorm:""`                     // 更新日時
 }
+
+type UserNotifications []*UserNotification
 
 func NewUserNotification(userID string) *UserNotification {
 	return &UserNotification{
-		UserID:        userID,
-		EmailDisabled: false,
+		UserID:   userID,
+		Disabled: false,
 	}
+}
+
+func (n *UserNotification) Enabled() bool {
+	if n == nil {
+		return true
+	}
+	return !n.Disabled
+}
+
+func (ns UserNotifications) MapByUserID() map[string]*UserNotification {
+	res := make(map[string]*UserNotification, len(ns))
+	for _, n := range ns {
+		res[n.UserID] = n
+	}
+	return res
 }

--- a/api/internal/user/entity/user_notification_test.go
+++ b/api/internal/user/entity/user_notification_test.go
@@ -1,0 +1,104 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserNotification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		userID string
+		expect *UserNotification
+	}{
+		{
+			name:   "success",
+			userID: "user-id",
+			expect: &UserNotification{
+				UserID:   "user-id",
+				Disabled: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewUserNotification(tt.userID)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestUserNotification_Enabled(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		notification *UserNotification
+		expect       bool
+	}{
+		{
+			name: "success enabled",
+			notification: &UserNotification{
+				UserID:   "user-id",
+				Disabled: false,
+			},
+			expect: true,
+		},
+		{
+			name: "success disabled",
+			notification: &UserNotification{
+				UserID:   "user-id",
+				Disabled: true,
+			},
+			expect: false,
+		},
+		{
+			name:         "success nil",
+			notification: nil,
+			expect:       true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.notification.Enabled())
+		})
+	}
+}
+
+func TestUserNotifications_MapByUserID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		notifications UserNotifications
+		expect        map[string]*UserNotification
+	}{
+		{
+			name: "success",
+			notifications: UserNotifications{
+				{
+					UserID:   "user-id",
+					Disabled: false,
+				},
+			},
+			expect: map[string]*UserNotification{
+				"user-id": {
+					UserID:   "user-id",
+					Disabled: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.notifications.MapByUserID()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/user/input.go
+++ b/api/internal/user/input.go
@@ -323,6 +323,14 @@ type GetUserInput struct {
 	UserID string `validate:"required"`
 }
 
+type DeleteUserInput struct {
+	UserID string `validate:"required"`
+}
+
+type MultiGetUserNotificationsInput struct {
+	UserIDs []string `validate:"dive,required"`
+}
+
 type GetUserNotificationInput struct {
 	UserID string `validate:"required"`
 }
@@ -330,10 +338,6 @@ type GetUserNotificationInput struct {
 type UpdateUserNotificationInput struct {
 	UserID  string `validate:"required"`
 	Enabled bool   `validate:""`
-}
-
-type DeleteUserInput struct {
-	UserID string `validate:"required"`
 }
 
 type CreateMemberInput struct {

--- a/api/internal/user/service.go
+++ b/api/internal/user/service.go
@@ -54,17 +54,19 @@ type Service interface {
 	UpdateProducerHeaders(ctx context.Context, in *UpdateProducerHeadersInput) error             // ヘッダー画像(リサイズ済み)更新
 	DeleteProducer(ctx context.Context, in *DeleteProducerInput) error                           // 退会
 	// 購入者
-	SignInUser(ctx context.Context, in *SignInUserInput) (*entity.UserAuth, error)                           // サインイン
-	SignOutUser(ctx context.Context, in *SignOutUserInput) error                                             // サインアウト
-	GetUserAuth(ctx context.Context, in *GetUserAuthInput) (*entity.UserAuth, error)                         // 認証情報取得
-	RefreshUserToken(ctx context.Context, in *RefreshUserTokenInput) (*entity.UserAuth, error)               // アクセストークン更新
-	ListUsers(ctx context.Context, in *ListUsersInput) (entity.Users, int64, error)                          // 一覧取得
-	MultiGetUsers(ctx context.Context, in *MultiGetUsersInput) (entity.Users, error)                         // 一覧取得(ID指定)
-	MultiGetUserDevices(ctx context.Context, in *MultiGetUserDevicesInput) ([]string, error)                 // デバイストークン一覧取得
-	GetUser(ctx context.Context, in *GetUserInput) (*entity.User, error)                                     // １件取得
-	GetUserNotification(ctx context.Context, in *GetUserNotificationInput) (*entity.UserNotification, error) // 通知設定の取得
-	UpdateUserNotification(ctx context.Context, in *UpdateUserNotificationInput) error                       // 通知の有効化設定更新
-	DeleteUser(ctx context.Context, in *DeleteUserInput) error                                               // 退会
+	SignInUser(ctx context.Context, in *SignInUserInput) (*entity.UserAuth, error)             // サインイン
+	SignOutUser(ctx context.Context, in *SignOutUserInput) error                               // サインアウト
+	GetUserAuth(ctx context.Context, in *GetUserAuthInput) (*entity.UserAuth, error)           // 認証情報取得
+	RefreshUserToken(ctx context.Context, in *RefreshUserTokenInput) (*entity.UserAuth, error) // アクセストークン更新
+	ListUsers(ctx context.Context, in *ListUsersInput) (entity.Users, int64, error)            // 一覧取得
+	MultiGetUsers(ctx context.Context, in *MultiGetUsersInput) (entity.Users, error)           // 一覧取得(ID指定)
+	MultiGetUserDevices(ctx context.Context, in *MultiGetUserDevicesInput) ([]string, error)   // デバイストークン一覧取得
+	GetUser(ctx context.Context, in *GetUserInput) (*entity.User, error)                       // １件取得
+	DeleteUser(ctx context.Context, in *DeleteUserInput) error                                 // 退会
+	// 購入者通知設定
+	MultiGetUserNotifications(ctx context.Context, in *MultiGetUserNotificationsInput) (entity.UserNotifications, error) // 一覧取得(ID指定)
+	GetUserNotification(ctx context.Context, in *GetUserNotificationInput) (*entity.UserNotification, error)             // １件取得
+	UpdateUserNotification(ctx context.Context, in *UpdateUserNotificationInput) error                                   // 更新
 	// 会員
 	CreateMember(ctx context.Context, in *CreateMemberInput) (string, error)                         // 登録 (メールアドレス/SMS認証)
 	VerifyMember(ctx context.Context, in *VerifyMemberInput) error                                   // 登録後の確認 (メールアドレス/SMS認証)

--- a/api/internal/user/service/user_notification.go
+++ b/api/internal/user/service/user_notification.go
@@ -7,6 +7,16 @@ import (
 	"github.com/and-period/furumaru/api/internal/user/entity"
 )
 
+func (s *service) MultiGetUserNotifications(
+	ctx context.Context, in *user.MultiGetUserNotificationsInput,
+) (entity.UserNotifications, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, internalError(err)
+	}
+	notifications, err := s.db.UserNotification.MultiGet(ctx, in.UserIDs)
+	return notifications, internalError(err)
+}
+
 func (s *service) GetUserNotification(ctx context.Context, in *user.GetUserNotificationInput) (*entity.UserNotification, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return nil, internalError(err)
@@ -23,7 +33,7 @@ func (s *service) UpdateUserNotification(ctx context.Context, in *user.UpdateUse
 	if err != nil {
 		return internalError(err)
 	}
-	notification.EmailDisabled = !in.Enabled
+	notification.Disabled = !in.Enabled
 	err = s.db.UserNotification.Upsert(ctx, notification)
 	return internalError(err)
 }

--- a/infra/mysql/schema/2024032201-users-change-culumn-user-notifications.sql
+++ b/infra/mysql/schema/2024032201-users-change-culumn-user-notifications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users`.`user_notifications` CHANGE COLUMN `email_disabled` `disabled` TINYINT NOT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、最近のアップデートに関するリリースノートです。このアップデートでは、ユーザー通知設定の管理と効率性を向上させるための新機能と改善が行われました。

- **New Feature**:
  - 複数のユーザー通知設定を一度に取得できる`MultiGetUserNotifications`機能が追加されました。これにより、アプリケーションのパフォーマンスが向上し、ユーザー体験が改善されます。
  - ユーザー通知設定の更新機能が強化され、より柔軟な設定変更が可能になりました。

- **Refactor**:
  - 通知設定の内部表現が更新され、`EmailDisabled`フィールドがより汎用的な`Disabled`フィールドに置き換えられました。これにより、将来的な拡張性が高まります。

これらの変更により、ユーザーは自身の通知設定をより簡単に管理し、カスタマイズできるようになります。また、開発チームはシステムのメンテナンス性と拡張性を向上させることができました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->