### PR TITLE
feat(media): Cache-Contrlを設定するように

### DIFF
--- a/api/internal/media/cmd/uploader/registry.go
+++ b/api/internal/media/cmd/uploader/registry.go
@@ -82,7 +82,12 @@ func (a *app) inject(ctx context.Context) error {
 		Tmp:       params.tmpStorage,
 		Cache:     params.cache,
 	}
-	a.uploader = uploader.NewUploader(uploaderParams, uploader.WithLogger(params.logger), uploader.WithCacheURL(a.CDNURL))
+	uploaderOpts := []uploader.Option{
+		uploader.WithLogger(params.logger),
+		uploader.WithStorageURL(a.CDNURL),
+		uploader.WithCacheTTL(a.CDNCacheTTL),
+	}
+	a.uploader = uploader.NewUploader(uploaderParams, uploaderOpts...)
 	a.logger = params.logger
 	a.waitGroup = params.waitGroup
 	return nil

--- a/api/internal/media/cmd/uploader/uploader.go
+++ b/api/internal/media/cmd/uploader/uploader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/and-period/furumaru/api/internal/media/uploader"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -18,18 +19,19 @@ type app struct {
 	logger           *zap.Logger
 	waitGroup        *sync.WaitGroup
 	uploader         uploader.Uploader
-	AppName          string `default:"media-uploader" envconfig:"APP_NAME"`
-	Environment      string `default:"none"           envconfig:"ENV"`
-	RunMethod        string `default:"lambda"         envconfig:"RUN_METHOD"`
-	RunType          string `default:""               envconfig:"RUN_TYPE"`
-	LogPath          string `default:""               envconfig:"LOG_PATH"`
-	LogLevel         string `default:"info"           envconfig:"LOG_LEVEL"`
-	SentryDsn        string `default:""               envconfig:"SENTRY_DSN"`
-	SentrySecretName string `default:""               envconfig:"SENTRY_SECRET_NAME"`
-	AWSRegion        string `default:"ap-northeast-1" envconfig:"AWS_REGION"`
-	S3Bucket         string `default:""               envconfig:"S3_BUCKET"`
-	S3TmpBucket      string `default:""               envconfig:"S3_TMP_BUCKET"`
-	CDNURL           string `default:""               envconfig:"CDN_URL"`
+	AppName          string        `default:"media-uploader" envconfig:"APP_NAME"`
+	Environment      string        `default:"none"           envconfig:"ENV"`
+	RunMethod        string        `default:"lambda"         envconfig:"RUN_METHOD"`
+	RunType          string        `default:""               envconfig:"RUN_TYPE"`
+	LogPath          string        `default:""               envconfig:"LOG_PATH"`
+	LogLevel         string        `default:"info"           envconfig:"LOG_LEVEL"`
+	SentryDsn        string        `default:""               envconfig:"SENTRY_DSN"`
+	SentrySecretName string        `default:""               envconfig:"SENTRY_SECRET_NAME"`
+	AWSRegion        string        `default:"ap-northeast-1" envconfig:"AWS_REGION"`
+	S3Bucket         string        `default:""               envconfig:"S3_BUCKET"`
+	S3TmpBucket      string        `default:""               envconfig:"S3_TMP_BUCKET"`
+	CDNURL           string        `default:""               envconfig:"CDN_URL"`
+	CDNCacheTTL      time.Duration `default:"5m"             envconfig:"CDN_CACHE_TTL"`
 }
 
 //nolint:revive

--- a/api/pkg/storage/client.go
+++ b/api/pkg/storage/client.go
@@ -53,7 +53,7 @@ type Bucket interface {
 	// S3 Bucketへオブジェクトをアップロード
 	Upload(ctx context.Context, path string, body io.Reader) (string, error)
 	// S3 Bucketへ他バケットからオブジェクトをコピーする
-	Copy(ctx context.Context, srcBucket, srcKey, dstKey string) (string, error)
+	Copy(ctx context.Context, srcBucket, srcKey, dstKey string, metadata map[string]string) (string, error)
 	// S3 Bucket URLが自身のバケット用URLかの判定
 	IsMyHost(url string) bool
 }
@@ -245,12 +245,13 @@ func (b *bucket) Upload(ctx context.Context, path string, body io.Reader) (strin
 	return b.GenerateObjectURL(path)
 }
 
-func (b *bucket) Copy(ctx context.Context, srcBucket, srcKey, dstKey string) (string, error) {
+func (b *bucket) Copy(ctx context.Context, srcBucket, srcKey, dstKey string, metadata map[string]string) (string, error) {
 	source := strings.Join([]string{srcBucket, srcKey}, "/")
 	in := &s3.CopyObjectInput{
 		Bucket:     b.name,
 		Key:        aws.String(dstKey),
 		CopySource: aws.String(source),
+		Metadata:   metadata,
 	}
 	_, err := b.s3.CopyObject(ctx, in)
 	if err != nil {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### New Feature

- **キャッシュ管理の向上**: アップロードされたメディアファイルのキャッシュ制御が強化されました。新しい`ttl`（Time to Live）フィールドにより、デフォルトで5分間のキャッシュ期間が設定されています。これにより、ウェブサイトやアプリケーションのパフォーマンスが向上します。
- **メタデータのカスタマイズ**: ファイルコピー時にオブジェクトのメタデータを指定できる新機能が追加されました。これにより、開発者はファイルのコピー操作をより細かく制御できるようになります。

これらの変更により、開発者はメディアファイルの管理と配信をより効率的に行えるようになり、エンドユーザーの体験も向上することが期待されます。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->