### PR TITLE
fix(store): ライブ配信への商品紐づけ数制限を削除

### DIFF
--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -410,7 +410,7 @@ type GetLiveInput struct {
 type CreateLiveInput struct {
 	ScheduleID string    `validate:"required"`
 	ProducerID string    `validate:"required"`
-	ProductIDs []string  `validate:"min=0,max=16,unique"`
+	ProductIDs []string  `validate:"unique"`
 	Comment    string    `validate:"required,max=2000"`
 	StartAt    time.Time `validate:"required"`
 	EndAt      time.Time `validate:"required,gtfield=StartAt"`
@@ -418,7 +418,7 @@ type CreateLiveInput struct {
 
 type UpdateLiveInput struct {
 	LiveID     string    `validate:"required"`
-	ProductIDs []string  `validate:"min=0,max=16,unique"`
+	ProductIDs []string  `validate:"unique"`
 	Comment    string    `validate:"required,max=2000"`
 	StartAt    time.Time `validate:"required"`
 	EndAt      time.Time `validate:"required,gtfield=StartAt"`


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

### リリースノート

このアップデートでは、製品管理機能に関する重要な改善が行われました。これらの変更は、ユーザーがより効率的に製品情報を管理できるようにすることを目的としています。

- **Refactor**: `CreateLiveInput`および`UpdateLiveInput`構造体における`ProductIDs`フィールドのバリデーションルールが更新されました。以前の`min=0,max=16`の制限を取り除き、代わりに製品IDの一意性を保証するための`unique`バリデーションが導入されました。この変更により、ユーザーはより柔軟に製品IDを扱うことができるようになり、同時にデータの整合性も保たれます。

このアップデートを通じて、私たちはユーザーの皆様がよりスムーズに製品情報を管理し、ビジネスの成長を支援できるよう努めてまいります。ご不明な点やご提案がございましたら、お気軽にお問い合わせください。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->