### PR TITLE
feat(docs): リサイズ済みサムネイル情報をDeprecatedに

### DIFF
--- a/docs/swagger/admin/components/schemas/entity/coordinator.yaml
+++ b/docs/swagger/admin/components/schemas/entity/coordinator.yaml
@@ -60,6 +60,7 @@ coordinator:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:
@@ -77,6 +78,7 @@ coordinator:
     headers:
       type: array
       description: リサイズ済みヘッダー画像URL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/admin/components/schemas/entity/live-comment.yaml
+++ b/docs/swagger/admin/components/schemas/entity/live-comment.yaml
@@ -19,6 +19,7 @@ liveComment:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/admin/components/schemas/entity/producer.yaml
+++ b/docs/swagger/admin/components/schemas/entity/producer.yaml
@@ -54,6 +54,7 @@ producer:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:
@@ -71,6 +72,7 @@ producer:
     headers:
       type: array
       description: リサイズ済みヘッダー画像URL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/admin/components/schemas/entity/product-type.yaml
+++ b/docs/swagger/admin/components/schemas/entity/product-type.yaml
@@ -14,6 +14,7 @@ productType:
     icons:
       type: array
       description: リサイズ済みアイコンURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/admin/components/schemas/entity/product.yaml
+++ b/docs/swagger/admin/components/schemas/entity/product.yaml
@@ -48,6 +48,7 @@ product:
           images:
             type: array
             description: リサイズ済み画像URL一覧
+            deprecated: true
             items:
               type: object
               properties:

--- a/docs/swagger/admin/components/schemas/entity/schedule.yaml
+++ b/docs/swagger/admin/components/schemas/entity/schedule.yaml
@@ -22,6 +22,7 @@ schedule:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/admin/components/schemas/entity/user.yaml
+++ b/docs/swagger/admin/components/schemas/entity/user.yaml
@@ -40,6 +40,7 @@ user:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/user/components/schemas/entity/common.yaml
+++ b/docs/swagger/user/components/schemas/entity/common.yaml
@@ -4,6 +4,7 @@ thumbnail:
     url:
       type: string
       description: リサイズ済みサムネイルURL
+      deprecated: true
     size:
       $ref: './../../../openapi.yaml#/components/schemas/imageSize'
   required:

--- a/docs/swagger/user/components/schemas/entity/coordinator.yaml
+++ b/docs/swagger/user/components/schemas/entity/coordinator.yaml
@@ -31,6 +31,7 @@ coordinator:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     headerUrl:
@@ -39,6 +40,7 @@ coordinator:
     headers:
       type: array
       description: リサイズ済みヘッダー画像URL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/user/components/schemas/entity/live-comment.yaml
+++ b/docs/swagger/user/components/schemas/entity/live-comment.yaml
@@ -16,6 +16,7 @@ liveComment:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/user/components/schemas/entity/live.yaml
+++ b/docs/swagger/user/components/schemas/entity/live.yaml
@@ -60,6 +60,7 @@ liveSummary:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     startAt:
@@ -137,6 +138,7 @@ liveProduct:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
   required:
@@ -178,6 +180,7 @@ archiveSummary:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
   required:

--- a/docs/swagger/user/components/schemas/entity/producer.yaml
+++ b/docs/swagger/user/components/schemas/entity/producer.yaml
@@ -20,6 +20,7 @@ producer:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     headerUrl:
@@ -28,6 +29,7 @@ producer:
     headers:
       type: array
       description: リサイズ済みヘッダー画像URL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/user/components/schemas/entity/product-type.yaml
+++ b/docs/swagger/user/components/schemas/entity/product-type.yaml
@@ -14,6 +14,7 @@ productType:
     icons:
       type: array
       description: リサイズ済みアイコンURL一覧
+      deprecated: true
       items:
         type: object
         properties:

--- a/docs/swagger/user/components/schemas/entity/product.yaml
+++ b/docs/swagger/user/components/schemas/entity/product.yaml
@@ -37,6 +37,7 @@ product:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     media:
@@ -53,6 +54,7 @@ product:
           images:
             type: array
             description: リサイズ済み画像URL一覧
+            deprecated: true
             items:
               type: object
               properties:

--- a/docs/swagger/user/components/schemas/entity/schedule.yaml
+++ b/docs/swagger/user/components/schemas/entity/schedule.yaml
@@ -22,6 +22,7 @@ schedule:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     distributionUrl:

--- a/docs/swagger/user/components/schemas/entity/top.yaml
+++ b/docs/swagger/user/components/schemas/entity/top.yaml
@@ -19,6 +19,7 @@ topLive:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
     startAt:
@@ -55,6 +56,7 @@ topLive:
           thumbnails:
             type: array
             description: リサイズ済みサムネイルURL一覧
+            deprecated: true
             items:
               $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
         required:
@@ -121,6 +123,7 @@ topArchive:
     thumbnails:
       type: array
       description: リサイズ済みサムネイルURL一覧
+      deprecated: true
       items:
         $ref: './../../../openapi.yaml#/components/schemas/thumbnail'
   required:

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -1034,6 +1034,7 @@ export interface Coordinator {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<CoordinatorThumbnailsInner>}
      * @memberof Coordinator
+     * @deprecated
      */
     'thumbnails': Array<CoordinatorThumbnailsInner>;
     /**
@@ -1046,6 +1047,7 @@ export interface Coordinator {
      * リサイズ済みヘッダー画像URL一覧
      * @type {Array<CoordinatorHeadersInner>}
      * @memberof Coordinator
+     * @deprecated
      */
     'headers': Array<CoordinatorHeadersInner>;
     /**
@@ -2321,6 +2323,7 @@ export interface LiveComment {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<CoordinatorThumbnailsInner>}
      * @memberof LiveComment
+     * @deprecated
      */
     'thumbnails': Array<CoordinatorThumbnailsInner>;
     /**
@@ -3807,6 +3810,7 @@ export interface Producer {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<CoordinatorThumbnailsInner>}
      * @memberof Producer
+     * @deprecated
      */
     'thumbnails': Array<CoordinatorThumbnailsInner>;
     /**
@@ -3819,6 +3823,7 @@ export interface Producer {
      * リサイズ済みヘッダー画像URL一覧
      * @type {Array<CoordinatorHeadersInner>}
      * @memberof Producer
+     * @deprecated
      */
     'headers': Array<CoordinatorHeadersInner>;
     /**
@@ -4127,6 +4132,7 @@ export interface ProductMediaInner {
      * リサイズ済み画像URL一覧
      * @type {Array<ProductMediaInnerImagesInner>}
      * @memberof ProductMediaInner
+     * @deprecated
      */
     'images': Array<ProductMediaInnerImagesInner>;
 }
@@ -4321,6 +4327,7 @@ export interface ProductType {
      * リサイズ済みアイコンURL一覧
      * @type {Array<ProductTypeIconsInner>}
      * @memberof ProductType
+     * @deprecated
      */
     'icons': Array<ProductTypeIconsInner>;
     /**
@@ -4742,6 +4749,7 @@ export interface Schedule {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<CoordinatorThumbnailsInner>}
      * @memberof Schedule
+     * @deprecated
      */
     'thumbnails': Array<CoordinatorThumbnailsInner>;
     /**
@@ -6404,6 +6412,7 @@ export interface User {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<CoordinatorThumbnailsInner>}
      * @memberof User
+     * @deprecated
      */
     'thumbnails': Array<CoordinatorThumbnailsInner>;
     /**

--- a/web/user/src/types/api/models/ArchiveSummary.ts
+++ b/web/user/src/types/api/models/ArchiveSummary.ts
@@ -54,6 +54,7 @@ export interface ArchiveSummary {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof ArchiveSummary
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
 }

--- a/web/user/src/types/api/models/Coordinator.ts
+++ b/web/user/src/types/api/models/Coordinator.ts
@@ -84,6 +84,7 @@ export interface Coordinator {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof Coordinator
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
     /**
@@ -96,6 +97,7 @@ export interface Coordinator {
      * リサイズ済みヘッダー画像URL一覧
      * @type {Array<CoordinatorHeadersInner>}
      * @memberof Coordinator
+     * @deprecated
      */
     headers: Array<CoordinatorHeadersInner>;
     /**

--- a/web/user/src/types/api/models/LiveComment.ts
+++ b/web/user/src/types/api/models/LiveComment.ts
@@ -54,6 +54,7 @@ export interface LiveComment {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<LiveCommentThumbnailsInner>}
      * @memberof LiveComment
+     * @deprecated
      */
     thumbnails: Array<LiveCommentThumbnailsInner>;
     /**

--- a/web/user/src/types/api/models/LiveProduct.ts
+++ b/web/user/src/types/api/models/LiveProduct.ts
@@ -60,6 +60,7 @@ export interface LiveProduct {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof LiveProduct
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
 }

--- a/web/user/src/types/api/models/LiveSummary.ts
+++ b/web/user/src/types/api/models/LiveSummary.ts
@@ -72,6 +72,7 @@ export interface LiveSummary {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof LiveSummary
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
     /**

--- a/web/user/src/types/api/models/Producer.ts
+++ b/web/user/src/types/api/models/Producer.ts
@@ -66,6 +66,7 @@ export interface Producer {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof Producer
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
     /**
@@ -78,6 +79,7 @@ export interface Producer {
      * リサイズ済みヘッダー画像URL一覧
      * @type {Array<CoordinatorHeadersInner>}
      * @memberof Producer
+     * @deprecated
      */
     headers: Array<CoordinatorHeadersInner>;
     /**

--- a/web/user/src/types/api/models/Product.ts
+++ b/web/user/src/types/api/models/Product.ts
@@ -114,6 +114,7 @@ export interface Product {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof Product
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
     /**

--- a/web/user/src/types/api/models/ProductMediaInner.ts
+++ b/web/user/src/types/api/models/ProductMediaInner.ts
@@ -42,6 +42,7 @@ export interface ProductMediaInner {
      * リサイズ済み画像URL一覧
      * @type {Array<ProductMediaInnerImagesInner>}
      * @memberof ProductMediaInner
+     * @deprecated
      */
     images: Array<ProductMediaInnerImagesInner>;
 }

--- a/web/user/src/types/api/models/ProductType.ts
+++ b/web/user/src/types/api/models/ProductType.ts
@@ -48,6 +48,7 @@ export interface ProductType {
      * リサイズ済みアイコンURL一覧
      * @type {Array<ProductTypeIconsInner>}
      * @memberof ProductType
+     * @deprecated
      */
     icons: Array<ProductTypeIconsInner>;
     /**

--- a/web/user/src/types/api/models/Schedule.ts
+++ b/web/user/src/types/api/models/Schedule.ts
@@ -72,6 +72,7 @@ export interface Schedule {
      * リサイズ済みサムネイルURL一覧
      * @type {Array<Thumbnail>}
      * @memberof Schedule
+     * @deprecated
      */
     thumbnails: Array<Thumbnail>;
     /**

--- a/web/user/src/types/api/models/Thumbnail.ts
+++ b/web/user/src/types/api/models/Thumbnail.ts
@@ -30,6 +30,7 @@ export interface Thumbnail {
      * リサイズ済みサムネイルURL
      * @type {string}
      * @memberof Thumbnail
+     * @deprecated
      */
     url: string;
     /**


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート

このアップデートでは、APIのスキーマ定義におけるいくつかの重要な変更が行われました。これらの変更は、より効率的で現代的なデータ構造への移行を目指しています。エンドユーザーにとって直接的な新機能の追加はありませんが、バックエンドの改善により将来的により良いサービス提供が可能になります。

### Documentation
- **非推奨フィールドのマーク**: リサイズ済みの画像URL一覧、サムネイル、ヘッダー画像のフィールドに`deprecated: true`を設定しました。これにより、これらのフィールドが将来的に削除されることを示しています。開発者は、これらのフィールドの使用を避け、代替手段を検討する必要があります。

### Refactor
- **スキーマの更新**: `liveSummary`, `liveProduct`, `archiveSummary`のスキーマに変更が加えられました。これらの変更は、データの表現をより明確にし、APIの利用を容易にすることを目的としています。

これらの変更は、APIの将来の拡張性とメンテナンス性を向上させるためのものです。ご理解とご協力をお願いいたします。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->