### PR TITLE
feat(gateway): アーカイブ一覧APIに日時情報を追加

### DIFF
--- a/api/internal/gateway/user/v1/response/live.go
+++ b/api/internal/gateway/user/v1/response/live.go
@@ -38,6 +38,8 @@ type ArchiveSummary struct {
 	ScheduleID    string   `json:"scheduleId"`    // 開催スケジュールID
 	CoordinatorID string   `json:"coordinatorId"` // コーディネータID
 	Title         string   `json:"title"`         // タイトル
+	StartAt       int64    `json:"startAt"`       // 開催開始日時
+	EndAt         int64    `json:"endAt"`         // 開催終了日時
 	ThumbnailURL  string   `json:"thumbnailUrl"`  // サムネイルURL
 	Thumbnails    []*Image `json:"thumbnails"`    // サムネイル一覧(リサイズ済み)
 }

--- a/api/internal/gateway/user/v1/service/archive_summary.go
+++ b/api/internal/gateway/user/v1/service/archive_summary.go
@@ -18,6 +18,8 @@ func NewArchiveSummary(schedule *entity.Schedule) *ArchiveSummary {
 			ScheduleID:    schedule.ID,
 			CoordinatorID: schedule.CoordinatorID,
 			Title:         schedule.Title,
+			StartAt:       schedule.StartAt.Unix(),
+			EndAt:         schedule.EndAt.Unix(),
 			ThumbnailURL:  schedule.ThumbnailURL,
 			Thumbnails:    NewImages(schedule.Thumbnails).Response(),
 		},

--- a/api/internal/gateway/user/v1/service/archive_summary_test.go
+++ b/api/internal/gateway/user/v1/service/archive_summary_test.go
@@ -47,6 +47,8 @@ func TestArchiveSummary(t *testing.T) {
 					ScheduleID:    "schedule-id",
 					CoordinatorID: "coordinator-id",
 					Title:         "スケジュールタイトル",
+					StartAt:       1638284400,
+					EndAt:         1643641200,
 					ThumbnailURL:  "https://example.com/thumbnail.png",
 					Thumbnails: []*response.Image{
 						{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -81,6 +83,8 @@ func TestArchiveSummary_Response(t *testing.T) {
 					ScheduleID:    "schedule-id",
 					CoordinatorID: "coordinator-id",
 					Title:         "スケジュールタイトル",
+					StartAt:       1638284400,
+					EndAt:         1643641200,
 					ThumbnailURL:  "https://example.com/thumbnail.png",
 					Thumbnails: []*response.Image{
 						{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -93,6 +97,8 @@ func TestArchiveSummary_Response(t *testing.T) {
 				ScheduleID:    "schedule-id",
 				CoordinatorID: "coordinator-id",
 				Title:         "スケジュールタイトル",
+				StartAt:       1638284400,
+				EndAt:         1643641200,
 				ThumbnailURL:  "https://example.com/thumbnail.png",
 				Thumbnails: []*response.Image{
 					{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -151,6 +157,8 @@ func TestArchiveSummaries(t *testing.T) {
 						ScheduleID:    "schedule-id",
 						CoordinatorID: "coordinator-id",
 						Title:         "スケジュールタイトル",
+						StartAt:       1638284400,
+						EndAt:         1643641200,
 						ThumbnailURL:  "https://example.com/thumbnail.png",
 						Thumbnails: []*response.Image{
 							{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -187,6 +195,8 @@ func TestArchiveSummaries_CoordinatorIDs(t *testing.T) {
 						ScheduleID:    "schedule-id",
 						CoordinatorID: "coordinator-id",
 						Title:         "スケジュールタイトル",
+						StartAt:       1638284400,
+						EndAt:         1643641200,
 						ThumbnailURL:  "https://example.com/thumbnail.png",
 						Thumbnails: []*response.Image{
 							{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -223,6 +233,8 @@ func TestArchiveSummaries_Response(t *testing.T) {
 						ScheduleID:    "schedule-id",
 						CoordinatorID: "coordinator-id",
 						Title:         "スケジュールタイトル",
+						StartAt:       1638284400,
+						EndAt:         1643641200,
 						ThumbnailURL:  "https://example.com/thumbnail.png",
 						Thumbnails: []*response.Image{
 							{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},
@@ -237,6 +249,8 @@ func TestArchiveSummaries_Response(t *testing.T) {
 					ScheduleID:    "schedule-id",
 					CoordinatorID: "coordinator-id",
 					Title:         "スケジュールタイトル",
+					StartAt:       1638284400,
+					EndAt:         1643641200,
 					ThumbnailURL:  "https://example.com/thumbnail.png",
 					Thumbnails: []*response.Image{
 						{URL: "https://example.com/thumbnail_240.png", Size: int32(ImageSizeSmall)},

--- a/docs/swagger/user/components/schemas/entity/live.yaml
+++ b/docs/swagger/user/components/schemas/entity/live.yaml
@@ -174,6 +174,14 @@ archiveSummary:
     title:
       type: string
       description: タイトル
+    startAt:
+      type: integer
+      format: int64
+      description: マルシェ開始日時 (unixtime)
+    endAt:
+      type: integer
+      format: int64
+      description: マルシェ終了日時 (unixtime)
     thumbnailUrl:
       type: string
       description: サムネイルURL
@@ -187,12 +195,16 @@ archiveSummary:
   - scheduleId
   - coordinatorId
   - title
+  - startAt
+  - endAt
   - thumbnailUrl
   - thumbnails
   example:
     scheduleId: 'kSByoE6FetnPs5Byk3a9Zx'
     coordinatorId: 'kSByoE6FetnPs5Byk3a9Zx'
     title: '&.マルシェ'
+    startAt: 1640962800
+    endAt: 1640962800
     thumbnailUrl: 'https://example.com/thumbnail.png'
     thumbnails:
     - url: 'https://example.com/thumbnail_240.png'

--- a/web/user/src/types/api/models/ArchiveSummary.ts
+++ b/web/user/src/types/api/models/ArchiveSummary.ts
@@ -45,6 +45,18 @@ export interface ArchiveSummary {
      */
     title: string;
     /**
+     * マルシェ開始日時 (unixtime)
+     * @type {number}
+     * @memberof ArchiveSummary
+     */
+    startAt: number;
+    /**
+     * マルシェ終了日時 (unixtime)
+     * @type {number}
+     * @memberof ArchiveSummary
+     */
+    endAt: number;
+    /**
      * サムネイルURL
      * @type {string}
      * @memberof ArchiveSummary
@@ -67,6 +79,8 @@ export function instanceOfArchiveSummary(value: object): boolean {
     isInstance = isInstance && "scheduleId" in value;
     isInstance = isInstance && "coordinatorId" in value;
     isInstance = isInstance && "title" in value;
+    isInstance = isInstance && "startAt" in value;
+    isInstance = isInstance && "endAt" in value;
     isInstance = isInstance && "thumbnailUrl" in value;
     isInstance = isInstance && "thumbnails" in value;
 
@@ -86,6 +100,8 @@ export function ArchiveSummaryFromJSONTyped(json: any, ignoreDiscriminator: bool
         'scheduleId': json['scheduleId'],
         'coordinatorId': json['coordinatorId'],
         'title': json['title'],
+        'startAt': json['startAt'],
+        'endAt': json['endAt'],
         'thumbnailUrl': json['thumbnailUrl'],
         'thumbnails': ((json['thumbnails'] as Array<any>).map(ThumbnailFromJSON)),
     };
@@ -103,6 +119,8 @@ export function ArchiveSummaryToJSON(value?: ArchiveSummary | null): any {
         'scheduleId': value.scheduleId,
         'coordinatorId': value.coordinatorId,
         'title': value.title,
+        'startAt': value.startAt,
+        'endAt': value.endAt,
         'thumbnailUrl': value.thumbnailUrl,
         'thumbnails': ((value.thumbnails as Array<any>).map(ThumbnailToJSON)),
     };


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート

このアップデートでは、ユーザーがより詳細な情報を得られるように、いくつかの新機能とドキュメントの改善が行われました。

### New Feature
- **アーカイブサマリーの拡張**: アーカイブサマリーに開始日時(`StartAt`)と終了日時(`EndAt`)の情報が追加されました。これにより、ユーザーはイベントやコンテンツの利用可能期間を正確に把握できるようになります。

### Documentation
- **Swaggerドキュメント更新**: `archiveSummary`オブジェクトに`startAt`と`endAt`フィールドが追加されました。これはAPIを使用する開発者が、新しいフィールドの意味と利用方法を理解しやすくするためです。

これらの変更により、ユーザー体験が向上し、開発者がAPIをより効果的に活用できるようになります。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->