### PR TITLE
Release for v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.1](https://github.com/and-period/furumaru/compare/v1.11.0...v1.11.1) - 2024-04-19
+- fix(workflow): リリースタグ作成ジョブでPATを使うように by @taba2424 in https://github.com/and-period/furumaru/pull/2159
+
 ## [v1.10.4](https://github.com/and-period/furumaru/compare/v1.10.3...v1.10.4) - 2024-04-19
 - chore(deps): bump the dependencies group in /api with 11 updates by @dependabot in https://github.com/and-period/furumaru/pull/2152
 - chore(deps): bump the dependencies group in /web/admin with 52 updates by @dependabot in https://github.com/and-period/furumaru/pull/2151


### PR DESCRIPTION
This pull request is for the next release as v1.11.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(workflow): リリースタグ作成ジョブでPATを使うように by @taba2424 in https://github.com/and-period/furumaru/pull/2159


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.0...v1.11.1