### PR TITLE
Release for v1.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.3](https://github.com/and-period/furumaru/compare/v1.11.2...v1.11.3) - 2024-04-19
+- Revert "fix(workflow): リリースタグ作成ジョブでPATを使わないように (#2161)" by @taba2424 in https://github.com/and-period/furumaru/pull/2163
+
 ## [v1.11.2](https://github.com/and-period/furumaru/compare/v1.11.1...v1.11.2) - 2024-04-19
 - fix(workflow): リリースタグ作成ジョブでPATを使わないように by @taba2424 in https://github.com/and-period/furumaru/pull/2161
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Revert "fix(workflow): リリースタグ作成ジョブでPATを使わないように (#2161)" by @taba2424 in https://github.com/and-period/furumaru/pull/2163


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.2...v1.11.3