### PR TITLE
Release for v1.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.10](https://github.com/and-period/furumaru/compare/v1.11.9...v1.11.10) - 2024-04-23
+- fix(func): オリジンレスポンスの処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2176
+
 ## [v1.11.9](https://github.com/and-period/furumaru/compare/v1.11.8...v1.11.9) - 2024-04-23
 
 ## [v1.11.8](https://github.com/and-period/furumaru/compare/v1.11.7...v1.11.8) - 2024-04-19


### PR DESCRIPTION
This pull request is for the next release as v1.11.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(func): オリジンレスポンスの処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2176


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.9...v1.11.10
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート v1.11.10

このリリースでは、ユーザー体験を向上させるための重要なバグ修正が行われました。皆様のフィードバックをもとに、より快適にご利用いただけるよう努めてまいります。

### Bug fix
- オリジンレスポンスの処理を修正しました: 一部の状況下で不適切なレスポンスが返される問題を解決しました。この修正により、アプリケーションの安定性と信頼性が向上します。

私たちは常に製品の改善に取り組んでおり、ユーザーの皆様からの貴重なご意見を歓迎しています。今後ともどうぞよろしくお願いいたします。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->