### PR TITLE
Release for v1.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.11](https://github.com/and-period/furumaru/compare/v1.11.10...v1.11.11) - 2024-04-29
+- Fix: fixed guest puchse by @hamachans in https://github.com/and-period/furumaru/pull/2180
+
 ## [v1.11.10](https://github.com/and-period/furumaru/compare/v1.11.9...v1.11.10) - 2024-04-23
 - fix(func): オリジンレスポンスの処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2176
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.11 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.11 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.10" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix: fixed guest puchse by @hamachans in https://github.com/and-period/furumaru/pull/2180


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.10...v1.11.11
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート v1.11.11

このバージョンのアップデートでは、ユーザー体験を向上させるための重要な修正が行われました。私たちは常に製品の品質向上に努めており、今回の更新もその一環です。以下に主な変更点をまとめました。

- Bug fix:
  - ゲストユーザーによる購入プロセスの問題を修正しました。これにより、登録せずに商品を購入する際のユーザー体験が向上します。

この修正は、皆様からの貴重なフィードバックに基づいて実施されました。今後ともご意見をお聞かせください。皆様のサポートに心から感謝申し上げます。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->