### PR TITLE
feat(media): youtube配信用の情報をDB管理できるように

### DIFF
--- a/api/.golangci.yaml
+++ b/api/.golangci.yaml
@@ -41,7 +41,6 @@ linters:
   - promlinter
   - protogetter
   - reassign
-  - revive
   - rowserrcheck
   - sloglint
   - sqlclosecheck

--- a/api/internal/media/broadcast/scheduler/const.go
+++ b/api/internal/media/broadcast/scheduler/const.go
@@ -9,11 +9,12 @@ const (
 
 // CreatePayload - 配信リソース作成リクエスト
 type CreatePayload struct {
-	ScheduleID   string                `json:"ScheduleId"`
-	ChannelInput *CreateChannelPayload `json:"ChannelInput"`
-	MP4Input     *CreateMp4Payload     `json:"MP4Input"`
-	RtmpInput    *CreateRtmpPayload    `json:"RtmpInput"`
-	ArchiveInput *CreateArchivePayload `json:"ArchiveInput"`
+	ScheduleID  string                     `json:"ScheduleId"`
+	Channel     *CreateChannelPayload      `json:"ChannelInput"`
+	MP4Input    *CreateMp4InputPayload     `json:"MP4Input"`
+	RtmpInput   *CreateRtmpInputPayload    `json:"RtmpInput"`
+	RtmpOutputs []*CreateRtmpOutputPayload `json:"RtmpOutputs"`
+	Archive     *CreateArchivePayload      `json:"ArchiveInput"`
 }
 
 // CreateChannelPayload - 配信リソース(MediaLive チャンネル)
@@ -23,14 +24,21 @@ type CreateChannelPayload struct {
 	InputLossImageSlateURI string `json:"InputLossImageSlateUri"`
 }
 
-// CreateMp4Payload - 配信リソース(MediaLive MP4インプット)
-type CreateMp4Payload struct {
+// CreateMp4InputPayload - 配信リソース(MediaLive MP4インプット)
+type CreateMp4InputPayload struct {
 	InputURL string `json:"InputUrl"`
 }
 
-// CreateRtmpPayload - 配信リソース(MediaLive プッシュRTMPインプット)
-type CreateRtmpPayload struct {
+// CreateRtmpInputPayload - 配信リソース(MediaLive プッシュRTMPインプット)
+type CreateRtmpInputPayload struct {
 	StreamName string `json:"StreamName"`
+}
+
+// CreateRtmpOutputPayload - 配信リソース(MediaLive プッシュRTMPアウトプット)
+type CreateRtmpOutputPayload struct {
+	Name      string `json:"Name"`
+	StreamURL string `json:"StreamUrl"`
+	StreamKey string `json:"StreamKey"`
 }
 
 // CreateArchivePayload - 配信リソース(MediaLive アーカイブグループ)

--- a/api/internal/media/entity/broadcast.go
+++ b/api/internal/media/entity/broadcast.go
@@ -52,6 +52,8 @@ type Broadcast struct {
 	MediaLiveMP4InputArn      string          `gorm:"default:null"`         // MediaLiveインプットARN(MP4)
 	MediaLiveMP4InputName     string          `gorm:"default:null"`         // MediaLiveインプット名(MP4)
 	MediaStoreContainerArn    string          `gorm:"default:null"`         // MediaStoreコンテナARN
+	YoutubeStreamURL          string          `gorm:"default:null"`         // YouTube配信URL
+	YoutubeStreamKey          string          `gorm:"default:null"`         // YouTubeストリームキー
 	CreatedAt                 time.Time       `gorm:"<-:create"`            // 登録日時
 	UpdatedAt                 time.Time       `gorm:""`                     // 更新日時
 }

--- a/infra/mysql/schema/2024050701-media-add-column.sql
+++ b/infra/mysql/schema/2024050701-media-add-column.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_stream_url` TEXT NULL DEFAULT NULL;
+ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_stream_key` VARCHAR(256) NULL DEFAULT NULL;

--- a/infra/mysql/schema/2024050701-media-add-column.sql
+++ b/infra/mysql/schema/2024050701-media-add-column.sql
@@ -1,3 +1,2 @@
-
 ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_stream_url` TEXT NULL DEFAULT NULL;
 ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_stream_key` VARCHAR(256) NULL DEFAULT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
このあとStepFunctions側で、youtubeへの配信用のMediaLive Outputグループ(RTMP Push)を追加するフローを作成できるようにしたいです。
そのため、まずはDBでyoutube配信先情報を保持できるようにします。

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - YouTubeストリーミング用のRTMP出力を作成する機能が追加されました。
  - ブロードキャスト構造にYouTubeのストリームURLとキーのフィールドが追加されました。

- **バグ修正**
  - チャンネル作成、MP4入力、RTMP入力、アーカイブ入力に関連するフィールドの名称変更と構造の調整が行われました。

- **データベース更新**
  - `broadcasts`テーブルに`youtube_stream_url`（TEXT型）と`youtube_stream_key`（VARCHAR(256)型）の新しいカラムが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->