### PR TITLE
feat(media): youtube配信先のバックアップURL追加

### DIFF
--- a/api/internal/media/broadcast/scheduler/const.go
+++ b/api/internal/media/broadcast/scheduler/const.go
@@ -39,6 +39,8 @@ type CreateRtmpOutputPayload struct {
 	Name      string `json:"Name"`
 	StreamURL string `json:"StreamUrl"`
 	StreamKey string `json:"StreamKey"`
+	BackupURL string `json:"BackupUrl"`
+	BackupKey string `json:"BackupKey"`
 }
 
 // CreateArchivePayload - 配信リソース(MediaLive アーカイブグループ)

--- a/api/internal/media/broadcast/scheduler/starter.go
+++ b/api/internal/media/broadcast/scheduler/starter.go
@@ -202,11 +202,16 @@ func (s *starter) createChannel(ctx context.Context, target time.Time) error {
 			}
 			rtmpOutputs := make([]*CreateRtmpOutputPayload, 0, 1) // youtube への配信のみ
 			if broadcast.YoutubeStreamURL != "" && broadcast.YoutubeStreamKey != "" {
-				rtmpOutputs = append(rtmpOutputs, &CreateRtmpOutputPayload{
+				payload := &CreateRtmpOutputPayload{
 					Name:      "youtube",
 					StreamURL: broadcast.YoutubeStreamURL,
 					StreamKey: broadcast.YoutubeStreamKey,
-				})
+				}
+				if broadcast.YoutubeBackupURL != "" {
+					payload.BackupURL = broadcast.YoutubeBackupURL
+					payload.BackupKey = broadcast.YoutubeStreamKey
+				}
+				rtmpOutputs = append(rtmpOutputs, payload)
 			}
 			payload := &CreatePayload{
 				ScheduleID: broadcast.ScheduleID,

--- a/api/internal/media/entity/broadcast.go
+++ b/api/internal/media/entity/broadcast.go
@@ -54,6 +54,7 @@ type Broadcast struct {
 	MediaStoreContainerArn    string          `gorm:"default:null"`         // MediaStoreコンテナARN
 	YoutubeStreamURL          string          `gorm:"default:null"`         // YouTube配信URL
 	YoutubeStreamKey          string          `gorm:"default:null"`         // YouTubeストリームキー
+	YoutubeBackupURL          string          `gorm:"default:null"`         // YouTubeバックアップURL
 	CreatedAt                 time.Time       `gorm:"<-:create"`            // 登録日時
 	UpdatedAt                 time.Time       `gorm:""`                     // 更新日時
 }

--- a/infra/mysql/schema/2024050801-media-add-column.sql
+++ b/infra/mysql/schema/2024050801-media-add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_backup_url` TEXT NULL DEFAULT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 放送スケジューラーにバックアップURLとバックアップキーのフィールドを追加しました。
	- 放送データにYouTubeのバックアップURLフィールドを追加しました。

- **データベース変更**
	- メディアデータベースの放送テーブルに新しいカラム「youtube_backup_url」を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->