### PR TITLE
fix(media): YouTube配信の登録処理を修正

### DIFF
--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -74,10 +74,12 @@ type UploadBroadcastArchiveParams struct {
 }
 
 type UpsertYoutubeBroadcastParams struct {
-	YoutubeAccount   string
-	YoutubeStreamURL string
-	YoutubeStreamKey string
-	YoutubeBackupURL string
+	YoutubeAccount     string
+	YoutubeBroadcastID string
+	YoutubeStreamID    string
+	YoutubeStreamURL   string
+	YoutubeStreamKey   string
+	YoutubeBackupURL   string
 }
 
 type BroadcastComment interface {

--- a/api/internal/media/database/mysql/broadcast.go
+++ b/api/internal/media/database/mysql/broadcast.go
@@ -128,6 +128,8 @@ func (b *broadcast) Update(ctx context.Context, broadcastID string, params *data
 	}
 	if params.UpsertYoutubeBroadcastParams != nil {
 		updates["youtube_account"] = params.YoutubeAccount
+		updates["youtube_broadcast_id"] = params.YoutubeBroadcastID
+		updates["youtube_stream_id"] = params.YoutubeStreamID
 		updates["youtube_stream_key"] = params.YoutubeStreamKey
 		updates["youtube_stream_url"] = params.YoutubeStreamURL
 		updates["youtube_backup_url"] = params.YoutubeBackupURL

--- a/api/internal/media/database/mysql/broadcast_test.go
+++ b/api/internal/media/database/mysql/broadcast_test.go
@@ -418,10 +418,12 @@ func TestBroadcast_Update(t *testing.T) {
 				params: &database.UpdateBroadcastParams{
 					Status: entity.BroadcastStatusActive,
 					UpsertYoutubeBroadcastParams: &database.UpsertYoutubeBroadcastParams{
-						YoutubeAccount:   "test@example.com",
-						YoutubeStreamURL: "rtmp://a.rtmp.youtube.com/live2",
-						YoutubeStreamKey: "stream-key",
-						YoutubeBackupURL: "rtmp://b.rtmp.youtube.com/live2?backup=1",
+						YoutubeAccount:     "test@example.com",
+						YoutubeBroadcastID: "broadcast-id",
+						YoutubeStreamID:    "stream-id",
+						YoutubeStreamURL:   "rtmp://a.rtmp.youtube.com/live2",
+						YoutubeStreamKey:   "stream-key",
+						YoutubeBackupURL:   "rtmp://b.rtmp.youtube.com/live2?backup=1",
 					},
 				},
 			},

--- a/api/internal/media/entity/broadcast.go
+++ b/api/internal/media/entity/broadcast.go
@@ -53,6 +53,8 @@ type Broadcast struct {
 	MediaLiveMP4InputName     string          `gorm:"default:null"`         // MediaLiveインプット名(MP4)
 	MediaStoreContainerArn    string          `gorm:"default:null"`         // MediaStoreコンテナARN
 	YoutubeAccount            string          `gorm:"default:null"`         // YouTubeアカウント
+	YoutubeBroadcastID        string          `gorm:"default:null"`         // YouTube配信ID
+	YoutubeStreamID           string          `gorm:"default:null"`         // YouTubeストリームID
 	YoutubeStreamURL          string          `gorm:"default:null"`         // YouTube配信URL
 	YoutubeStreamKey          string          `gorm:"default:null"`         // YouTubeストリームキー
 	YoutubeBackupURL          string          `gorm:"default:null"`         // YouTubeバックアップURL

--- a/api/pkg/youtube/client.go
+++ b/api/pkg/youtube/client.go
@@ -36,8 +36,11 @@ type Auth interface {
 }
 
 type Service interface {
+	GetLiveBroadcast(ctx context.Context, broadcastID string) (*youtube.LiveBroadcast, error)                   // ライブ配信情報取得
 	CreateLiveBroadcast(ctx context.Context, params *CreateLiveBroadcastParams) (*youtube.LiveBroadcast, error) // ライブ配信作成
+	BindLiveBroadcast(ctx context.Context, broadcastID, streamID string) error                                  // ライブ配信とライブストリームを紐付け
 	GetLiveStream(ctx context.Context, streamID string) (*youtube.LiveStream, error)                            // ライブ配信先設定取得
+	CreateLiveStream(ctx context.Context, params *CreateLiveStreamParams) (*youtube.LiveStream, error)          // ライブストリーム作成
 }
 
 type Params struct {

--- a/infra/mysql/schema/2024051601-media-add-column.sql
+++ b/infra/mysql/schema/2024051601-media-add-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_broadcast_id` VARCHAR(256) NULL DEFAULT NULL;
+ALTER TABLE `media`.`broadcasts` ADD COLUMN `youtube_stream_id` VARCHAR(256) NULL DEFAULT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - YouTubeライブ配信機能の強化：YouTubeライブ配信とストリームの作成、管理が可能に。

- **バグ修正**
  - 配信データの更新にYouTube関連の新しいフィールドを追加。

- **データベース**
  - `broadcasts`テーブルに新しいカラム`youtube_broadcast_id`と`youtube_stream_id`を追加。

- **API**
  - 新しいAPIメソッドを追加：`GetLiveBroadcast`、`BindLiveBroadcast`、`CreateLiveStream`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->