### PR TITLE
fix(media): StepFunctionsへ渡すRTMPプッシュの情報を修正

### DIFF
--- a/api/internal/media/broadcast/scheduler/const.go
+++ b/api/internal/media/broadcast/scheduler/const.go
@@ -39,8 +39,6 @@ type CreateRtmpOutputPayload struct {
 	Name      string `json:"Name"`
 	StreamURL string `json:"StreamUrl"`
 	StreamKey string `json:"StreamKey"`
-	BackupURL string `json:"BackupUrl"`
-	BackupKey string `json:"BackupKey"`
 }
 
 // CreateArchivePayload - 配信リソース(MediaLive アーカイブグループ)


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能変更**
  - YouTubeストリーミング用のRTMP出力ペイロードの生成方法を改善しました。
  - MediaLiveストリーミング用のRTMP出力ペイロードの作成を簡素化しました。

- **リファクタリング**
  - `BackupURL`および`BackupKey`フィールドを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->