### PR TITLE
Release for v1.11.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.11.15](https://github.com/and-period/furumaru/compare/v1.11.14...v1.11.15) - 2024-05-22
+- Add: added privacy in admin page by @hamachans in https://github.com/and-period/furumaru/pull/2222
+- fix: fixed markdwon by @hamachans in https://github.com/and-period/furumaru/pull/2226
+- feat(serverless): originAccessControlの削除処理を追加 by @sea-kai in https://github.com/and-period/furumaru/pull/2224
+
 ## [v1.11.14](https://github.com/and-period/furumaru/compare/v1.11.13...v1.11.14) - 2024-05-19
 - fix(media): YouTube配信の登録処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2208
 - fix(media): YouTube配信とストリーム設定の関連付け処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2210


### PR DESCRIPTION
This pull request is for the next release as v1.11.15 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.15 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.14" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Add: added privacy in admin page by @hamachans in https://github.com/and-period/furumaru/pull/2222
* fix: fixed markdwon by @hamachans in https://github.com/and-period/furumaru/pull/2226
* feat(serverless): originAccessControlの削除処理を追加 by @sea-kai in https://github.com/and-period/furumaru/pull/2224


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.14...v1.11.15