### PR TITLE
feat(serverless): originAccessControlの削除処理を追加

### DIFF
--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -70,7 +70,9 @@ resources:
                     - cloudFront:CreateDistribution
                     - cloudFront:GetDistribution
                     - cloudFront:GetDistributionConfig
+                    - cloudFront:GetOriginAccessControl
                     - cloudFront:DeleteDistribution
+                    - cloudFront:DeleteOriginAccessControl
                     - iam:PassRole
                     - states:StartExecution
                     - states:DescribeExecution
@@ -710,10 +712,29 @@ stepFunctions:
             Type: Task
             Comment: CloudFrontのディストリビューションを削除
             InputPath: $
+            ResultPath: $.DeleteDistributionResult
             Resource: arn:aws:states:::aws-sdk:cloudfront:deleteDistribution
             Parameters:
               Id.$: $.DistributionId
               IfMatch.$: $.DistributionStatus.ETag
+            Next: GetOriginAccessControl
+          GetOriginAccessControl:
+            Type: Task
+            Comment: CloudFrontのOriginAccessControlを取得
+            InputPath: $
+            ResultPath: $.GetOriginAccessControlResult
+            Resource: arn:aws:states:::aws-sdk:cloudfront:getOriginAccessControl
+            Parameters:
+              Id.$: $.DistributionStatus.Distribution.DistributionConfig.Origins.Items[0].OriginAccessControlId
+            Next: DeleteOriginAccessControl
+          DeleteOriginAccessControl:
+            Type: Task
+            Comment: CloudFrontのOriginAccessControlを削除
+            InputPath: $
+            Resource: arn:aws:states:::aws-sdk:cloudfront:deleteOriginAccessControl
+            Parameters:
+              Id.$: $.DistributionStatus.Distribution.DistributionConfig.Origins.Items[0].OriginAccessControlId
+              IfMatch.$: $.GetOriginAccessControlResult.ETag
             Next: Finish
           Finish:
             Type: Pass


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
originAccessControlの削除処理を追加

## スクリーンショット
![スクリーンショット 2024-05-22 3 15 12](https://github.com/and-period/furumaru/assets/76773825/9a489313-f3be-4d46-8f52-6a2a09af7297)

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->


## リファレンス
挙動確認したStep Function
https://ap-northeast-1.console.aws.amazon.com/states/home?region=ap-northeast-1#/v2/executions/details/arn:aws:states:ap-northeast-1:386661535629:execution:deleteCloudFrontResoursesFunction-stg:6cb83c29-131e-42ee-b30e-8978aca424d4

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->
