### PR TITLE
fix(serverless): RTMPOutputが空の際の挙動を修正

### DIFF
--- a/infra/serverless/functions/createChannelWithRTMPOutputs/handler.js
+++ b/infra/serverless/functions/createChannelWithRTMPOutputs/handler.js
@@ -56,8 +56,8 @@ module.exports.createChannelWithRTMPOutputs = async (event) => {
         }
       );
     });
+    settings.EncoderSettings.OutputGroups.push(RTMPOutputGroup);
   }
-  settings.EncoderSettings.OutputGroups.push(RTMPOutputGroup);
   console.log(settings);
   try {
     const data = await medialive.createChannel(settings).promise();


### PR DESCRIPTION
## やったこと
- RTMPOutputsが空の際に、OutputGroupsに空の配列を追加してしまう挙動を修正
<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->


## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考
実行結果
https://ap-northeast-1.console.aws.amazon.com/states/home?region=ap-northeast-1#/v2/executions/details/arn:aws:states:ap-northeast-1:386661535629:execution:mediaLiveStepFunction-stg:db9d62cf-33f8-4ff8-8304-97c01f74f35e
<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - RTMP出力グループを条件付きで追加する機能を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->