### PR TITLE
Release for v1.11.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.11.17](https://github.com/and-period/furumaru/compare/v1.11.16...v1.11.17) - 2024-05-25
+- fix(media): YouTubeとの連携処理を見直し by @taba2424 in https://github.com/and-period/furumaru/pull/2229
+- fix(admin): Google認証後の処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2231
+- feat(admin): YouTube視聴URLの追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2232
+- fix(admin): 権限管理周りの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2233
+- fix(serverless): RTMPOutputが空の際の挙動を修正 by @sea-kai in https://github.com/and-period/furumaru/pull/2227
+- fix(gateway): コーディネータがユーザー一覧を取得するときの挙動を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2234
+
 ## [v1.11.16](https://github.com/and-period/furumaru/compare/v1.11.15...v1.11.16) - 2024-05-23
 
 ## [v1.11.15](https://github.com/and-period/furumaru/compare/v1.11.14...v1.11.15) - 2024-05-22


### PR DESCRIPTION
This pull request is for the next release as v1.11.17 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.17 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.16" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(media): YouTubeとの連携処理を見直し by @taba2424 in https://github.com/and-period/furumaru/pull/2229
* fix(admin): Google認証後の処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2231
* feat(admin): YouTube視聴URLの追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2232
* fix(admin): 権限管理周りの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2233
* fix(serverless): RTMPOutputが空の際の挙動を修正 by @sea-kai in https://github.com/and-period/furumaru/pull/2227
* fix(gateway): コーディネータがユーザー一覧を取得するときの挙動を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2234


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.16...v1.11.17