### PR TITLE
Release for v1.11.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.11.18](https://github.com/and-period/furumaru/compare/v1.11.17...v1.11.18) - 2024-05-30
+- 商品複製機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2235
+- feat(api): ライブ配信分析用APIの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2239
+- chore(deps): bump the dependencies group in /api with 42 updates by @dependabot in https://github.com/and-period/furumaru/pull/2237
+- chore(deps): bump the dependencies group in /docs/swagger with 3 updates by @dependabot in https://github.com/and-period/furumaru/pull/2225
+- YouTube連携のcallback画面と完了画面のUI作成 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2238
+- fix(gateway): 生産者が紐づかない場合の商品一覧取得APIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2240
+- fix(func): 画像リサイズ処理の引数取得処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2241
+
 ## [v1.11.17](https://github.com/and-period/furumaru/compare/v1.11.16...v1.11.17) - 2024-05-25
 - fix(media): YouTubeとの連携処理を見直し by @taba2424 in https://github.com/and-period/furumaru/pull/2229
 - fix(admin): Google認証後の処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2231


### PR DESCRIPTION
This pull request is for the next release as v1.11.18 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.18 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.17" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 商品複製機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2235
* feat(api): ライブ配信分析用APIの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2239
* chore(deps): bump the dependencies group in /api with 42 updates by @dependabot in https://github.com/and-period/furumaru/pull/2237
* chore(deps): bump the dependencies group in /docs/swagger with 3 updates by @dependabot in https://github.com/and-period/furumaru/pull/2225
* YouTube連携のcallback画面と完了画面のUI作成 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2238
* fix(gateway): 生産者が紐づかない場合の商品一覧取得APIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2240
* fix(func): 画像リサイズ処理の引数取得処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2241


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.17...v1.11.18