### PR TITLE
feat: リサイズ時にwebp指定に

### DIFF
--- a/web/user/src/components/atoms/live/TheLiveDescription.vue
+++ b/web/user/src/components/atoms/live/TheLiveDescription.vue
@@ -67,6 +67,7 @@ const handleClickShowDetailButton = () => {
       <nuxt-img
         width="40"
         height="40"
+        format="webp"
         provider="cloudFront"
         :src="coordinatorImgSrc"
         class="h-10 w-10 rounded-full hover:cursor-pointer"

--- a/web/user/src/components/molecules/TheAllArchiveItem.vue
+++ b/web/user/src/components/molecules/TheAllArchiveItem.vue
@@ -25,6 +25,7 @@ const handleClick = () => {
         provider="cloudFront"
         fit="cover"
         height="208px"
+        format="webp"
         class="aspect-video h-[208px] cursor-pointer object-cover"
         :src="imgSrc"
         :alt="`live-${title}-thumbnail`"

--- a/web/user/src/components/molecules/TheArchiveItem.vue
+++ b/web/user/src/components/molecules/TheArchiveItem.vue
@@ -68,6 +68,7 @@ const handleClick = () => {
         :alt="`archive-${title}-thumbnail`"
         fit="cover"
         height="208px"
+        format="webp"
       />
     </div>
     <div class="mt-2 flex w-full flex-col gap-2">

--- a/web/user/src/components/molecules/TheCoordinatorArchiveItem.vue
+++ b/web/user/src/components/molecules/TheCoordinatorArchiveItem.vue
@@ -28,6 +28,7 @@ const handleClick = () => {
       <nuxt-img
         provider="cloudFront"
         fit="cover"
+        format="webp"
         class="aspect-video w-full object-cover"
         :width="width"
         :src="imgSrc"

--- a/web/user/src/components/molecules/TheCoordinatorLiveItem.vue
+++ b/web/user/src/components/molecules/TheCoordinatorLiveItem.vue
@@ -43,6 +43,7 @@ const handleClick = () => {
         provider="cloudFront"
         height="208px"
         fit="cover"
+        format="webp"
         class="aspect-video max-h-[208px] cursor-pointer object-cover"
         :src="imgSrc"
         :alt="`live-${title}-thumbnail`"

--- a/web/user/src/components/molecules/TheCoordinatorProductList.vue
+++ b/web/user/src/components/molecules/TheCoordinatorProductList.vue
@@ -54,6 +54,7 @@ const handleClickItem = () => {
       >
         <nuxt-img
           provider="cloudFront"
+          format="webp"
           :src="thumbnail.url"
           :alt="`${name}のサムネイル画像`"
           class="aspect-square w-full"

--- a/web/user/src/components/molecules/TheLiveItem.vue
+++ b/web/user/src/components/molecules/TheLiveItem.vue
@@ -64,6 +64,7 @@ const handleClick = () => {
           class="aspect-video w-full object-cover"
           fit="cover"
           sizes="320px md:368px"
+          format="webp"
         />
         <div
           v-if="!isLiveStreaming(isLiveStatus)"
@@ -119,6 +120,7 @@ const handleClick = () => {
               :alt="`${cnName}のーアバター画像`"
               width="40"
               height="40"
+              format="webp"
               class="h-10 w-10 rounded-full"
             />
           </div>

--- a/web/user/src/components/molecules/TheLiveTimelineItem.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineItem.vue
@@ -57,6 +57,7 @@ const handleClickAddCart = (name: string, id: string, quantity: number) => {
             class="mb-2 h-[48px] w-[48px] rounded-full"
             width="48px"
             height="48px"
+            format="webp"
           />
           <p
             v-if="username"

--- a/web/user/src/components/molecules/TheLiveTimelineProduct.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineProduct.vue
@@ -82,6 +82,7 @@ const handleClickItem = () => {
           provider="cloudFront"
           width="80px"
           height="80px"
+          format="webp"
           class="aspect-square h-full w-full"
           :class="{ 'hover:cursor-pointer hover:underline': canAddCart }"
           @click="handleClickItem"

--- a/web/user/src/components/molecules/TheProductListItem.vue
+++ b/web/user/src/components/molecules/TheProductListItem.vue
@@ -84,6 +84,7 @@ const handleClickAddCartButton = () => {
           :alt="`${name}のサムネイル画像`"
           fit="cover"
           sizes="180px md:250px"
+          format="webp"
           class="aspect-square w-full"
         />
       </picture>
@@ -158,6 +159,7 @@ const handleClickAddCartButton = () => {
           provider="cloudFront"
           width="64px"
           hidden="64px"
+          format="webp"
           :src="coordinator.thumbnailUrl"
           :alt="`${coordinator.username}のサムネイル画像`"
           class="block aspect-square h-14 w-14 rounded-full"

--- a/web/user/src/components/organisms/header/TheCartProductItem.vue
+++ b/web/user/src/components/organisms/header/TheCartProductItem.vue
@@ -44,6 +44,7 @@ const handleRemoveButton = () => {
         :alt="name"
         width="72px"
         height="72px"
+        format="webp"
         class="aspect-square h-[72px] w-[72px]"
       />
       <div class="flex grow flex-col">

--- a/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
+++ b/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
@@ -118,6 +118,7 @@ const handelClickRemoveItemButton = (id: string) => {
                 class="block h-16 w-16"
                 height="64px"
                 width="64px"
+                format="webp"
                 :alt="`${item.product.name}のサムネイル画像`"
               />
               {{ item.product.name }}
@@ -152,6 +153,7 @@ const handelClickRemoveItemButton = (id: string) => {
               class="block h-16 w-16"
               width="64px"
               height="64px"
+              format="webp"
               :alt="`${item.product.name}のサムネイル画像`"
             />
             <div class="flex grow flex-col justify-between">

--- a/web/user/src/components/organisms/purchase/TheRecommendItem.vue
+++ b/web/user/src/components/organisms/purchase/TheRecommendItem.vue
@@ -24,6 +24,7 @@ const priceString = computed(() => {
       provider="cloudFront"
       width="80px"
       height="80px"
+      format="webp"
     />
     <div
       class="flex w-full flex-col justify-between text-[12px] tracking-[1.2px]"

--- a/web/user/src/pages/account/edit/thumbnail.vue
+++ b/web/user/src/pages/account/edit/thumbnail.vue
@@ -86,6 +86,7 @@ useSeoMeta({
                 :src="user.thumbnailUrl"
                 width="120px"
                 height="120px"
+                format="webp"
                 provider="cloudFront"
                 alt="サムネイル"
                 class="h-[120px] w-[120px] rounded-full"

--- a/web/user/src/pages/account/index.vue
+++ b/web/user/src/pages/account/index.vue
@@ -158,6 +158,7 @@ definePageMeta({
                         class="h-14 w-14 rounded-full"
                         width="64px"
                         height="64px"
+                        format="webp"
                       />
                     </template>
                     <template v-else>
@@ -416,6 +417,7 @@ definePageMeta({
                   provider="cloudFront"
                   class="block max-w-[80px] rounded-full"
                   width="80px"
+                  format="webp"
                   :src="order.coordinator?.thumbnailUrl"
                   :alt="`${order.coordinator?.username}のサムネイル`"
                 />

--- a/web/user/src/pages/account/orders/[...id].vue
+++ b/web/user/src/pages/account/orders/[...id].vue
@@ -65,6 +65,7 @@ useSeoMeta({
               provider="cloudFront"
               class="block max-w-[80px] rounded-full"
               width="80px"
+              format="webp"
               :src="orderHistory.coordinator?.thumbnailUrl"
               :alt="`${orderHistory.coordinator?.username}のサムネイル`"
             />
@@ -167,6 +168,7 @@ useSeoMeta({
                 provider="cloudFront"
                 width="64px"
                 height="64px"
+                format="webp"
                 class="aspect-square h-16 w-16 object-contain"
                 :src="item.product.thumbnailUrl"
                 :alt="`${item.product.name}のサムネイル画像`"

--- a/web/user/src/pages/items/[...id].vue
+++ b/web/user/src/pages/items/[...id].vue
@@ -145,6 +145,7 @@ useSeoMeta({
           <nuxt-img
             provider="cloudFront"
             fill="contain"
+            format="webp"
             class="block h-full w-full object-contain"
             :src="
               selectedMediaIndex === -1
@@ -161,6 +162,7 @@ useSeoMeta({
             v-for="(m, i) in product.media"
             :key="i"
             width="72px"
+            format="webp"
             provider="cloudFront"
             :src="m.url"
             :alt="`${product.name}の画像_${i}`"
@@ -348,6 +350,7 @@ useSeoMeta({
             <nuxt-img
               provider="cloudFront"
               sizes="96px md:120px"
+              format="webp"
               :src="product.producer.thumbnailUrl"
               :alt="`${product.producer.username}`"
               class="mx-auto block aspect-square w-[96px] rounded-full md:w-[120px]"

--- a/web/user/src/pages/live/[...id].vue
+++ b/web/user/src/pages/live/[...id].vue
@@ -258,6 +258,7 @@ useSeoMeta({
                       provider="cloudFront"
                       width="32px"
                       height="32px"
+                      format="webp"
                       :src="
                         item.thumbnailUrl
                           ? item.thumbnailUrl

--- a/web/user/src/pages/v1/purchase/address.vue
+++ b/web/user/src/pages/v1/purchase/address.vue
@@ -345,6 +345,7 @@ useSeoMeta({
                       :alt="`${item.product.name}の画像`"
                       width="56px"
                       height="56px"
+                      format="webp"
                       class="block aspect-square h-[56px] w-[56px]"
                     />
                     <div class="col-span-3 pl-[24px] md:pl-0">

--- a/web/user/src/pages/v1/purchase/guest/address.vue
+++ b/web/user/src/pages/v1/purchase/guest/address.vue
@@ -386,6 +386,7 @@ useSeoMeta({
                     v-if="item.product.thumbnail"
                     width="56px"
                     height="56px"
+                    format="webp"
                     provider="cloudFront"
                     :src="item.product.thumbnail.url"
                     :alt="`${item.product.name}の画像`"


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
jpegのときにwidthのみ指定した変換がうまくいかないため、webp指定に変更してみます。

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - すべての画像要素に `format="webp"` 属性を追加しました。これにより、画像のレンダリングが改善され、パフォーマンスが向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->