### PR TITLE
Release for v1.11.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.20](https://github.com/and-period/furumaru/compare/v1.11.19...v1.11.20) - 2024-05-30
+- Fix/revert by @taba2424 in https://github.com/and-period/furumaru/pull/2248
+
 ## [v1.11.19](https://github.com/and-period/furumaru/compare/v1.11.18...v1.11.19) - 2024-05-30
 - fix(docs): APIドキュメントの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2244
 - feat: アーカイブの動画に配信日付の情報を追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2243


### PR DESCRIPTION
This pull request is for the next release as v1.11.20 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.20 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.19" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix/revert by @taba2424 in https://github.com/and-period/furumaru/pull/2248


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.19...v1.11.20