### PR TITLE
Release for v1.11.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.22](https://github.com/and-period/furumaru/compare/v1.11.21...v1.11.22) - 2024-05-31
+- feat(func): S3へのアップロード検証用のデバッグログ追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2252
+
 ## [v1.11.21](https://github.com/and-period/furumaru/compare/v1.11.20...v1.11.21) - 2024-05-30
 - fix(user): dayjsのインポート箇所のエラー修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2250
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.22 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.22 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.21" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(func): S3へのアップロード検証用のデバッグログ追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2252


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.21...v1.11.22