### PR TITLE
fix: nuxt-imgのfill属性を更新

### DIFF
--- a/web/user/src/components/molecules/TheAllArchiveItem.vue
+++ b/web/user/src/components/molecules/TheAllArchiveItem.vue
@@ -23,7 +23,7 @@ const handleClick = () => {
     <div class="flex justify-center">
       <nuxt-img
         provider="cloudFront"
-        fit="cover"
+        fit="contain"
         height="208px"
         class="aspect-video h-[208px] cursor-pointer object-cover"
         :src="imgSrc"

--- a/web/user/src/components/molecules/TheArchiveItem.vue
+++ b/web/user/src/components/molecules/TheArchiveItem.vue
@@ -66,7 +66,7 @@ const handleClick = () => {
         class="h-[208px] w-full object-cover"
         :src="imgSrc"
         :alt="`archive-${title}-thumbnail`"
-        fit="cover"
+        fit="contain"
         height="208px"
       />
     </div>

--- a/web/user/src/components/molecules/TheCoordinatorArchiveItem.vue
+++ b/web/user/src/components/molecules/TheCoordinatorArchiveItem.vue
@@ -27,7 +27,7 @@ const handleClick = () => {
     <div class="flex justify-center">
       <nuxt-img
         provider="cloudFront"
-        fit="cover"
+        fit="contain"
         class="aspect-video w-full object-cover"
         :width="width"
         :src="imgSrc"

--- a/web/user/src/components/molecules/TheCoordinatorLiveItem.vue
+++ b/web/user/src/components/molecules/TheCoordinatorLiveItem.vue
@@ -42,7 +42,7 @@ const handleClick = () => {
       <nuxt-img
         provider="cloudFront"
         height="208px"
-        fit="cover"
+        fit="contain"
         class="aspect-video max-h-[208px] cursor-pointer object-cover"
         :src="imgSrc"
         :alt="`live-${title}-thumbnail`"
@@ -60,7 +60,7 @@ const handleClick = () => {
               'border-2 border-main text-main': !isLiveStreaming(isLiveStatus),
             }"
           >
-            {{ isLiveStreaming(isLiveStatus) ? '配信中' : '配信予定' }}
+            {{ isLiveStreaming(isLiveStatus) ? "配信中" : "配信予定" }}
           </span>
           <span class="ml-2 text-main after:content-['〜']">{{
             formattedStartAt


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 画像の表示方法を改善しました。`nuxt-img`コンポーネントの`fit`属性を`"cover"`から`"contain"`に変更しました。
  - テキストコンテンツの文字列補間をシングルクォートからダブルクォートに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->