### PR TITLE
Release for v1.11.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.29](https://github.com/and-period/furumaru/compare/v1.11.28...v1.11.29) - 2024-06-03
+- fix: nuxt-imgのfill属性を更新 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2267
+
 ## [v1.11.28](https://github.com/and-period/furumaru/compare/v1.11.27...v1.11.28) - 2024-06-03
 - Fix/web/user/toppage/live/thumbnail by @wf-yamaday in https://github.com/and-period/furumaru/pull/2265
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.29 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.29 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.28" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: nuxt-imgのfill属性を更新 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2267


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.28...v1.11.29