### PR TITLE
Release for v1.11.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.11.31](https://github.com/and-period/furumaru/compare/v1.11.30...v1.11.31) - 2024-06-06
+- feat(store): 箱サイズのバリデーションを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2273
+- 商品の並べ替え登録機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2275
+- fix: 商品詳細で説明に改行が反映されるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2269
+- setup: gtapの設定を明示的に書いてみる by @wf-yamaday in https://github.com/and-period/furumaru/pull/2276
+- feat(admin): 視聴者ログの可視化 by @taba2424 in https://github.com/and-period/furumaru/pull/2278
+
 ## [v1.11.30](https://github.com/and-period/furumaru/compare/v1.11.29...v1.11.30) - 2024-06-04
 - fix(store): ライブ商品一覧の並び順を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2270
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.31 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.31 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.30" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(store): 箱サイズのバリデーションを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2273
* 商品の並べ替え登録機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2275
* fix: 商品詳細で説明に改行が反映されるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2269
* setup: gtapの設定を明示的に書いてみる by @wf-yamaday in https://github.com/and-period/furumaru/pull/2276
* feat(admin): 視聴者ログの可視化 by @taba2424 in https://github.com/and-period/furumaru/pull/2278


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.30...v1.11.31