### PR TITLE
fix: Liveに紐づく関連商品のidsをPriorityでソートするように修正

### DIFF
--- a/api/internal/store/entity/live_product.go
+++ b/api/internal/store/entity/live_product.go
@@ -52,8 +52,9 @@ func NewLiveProducts(liveID string, productIDs []string) LiveProducts {
 
 func (ps LiveProducts) ProductIDs() []string {
 	res := set.NewEmpty[string](len(ps))
-	for i := range ps {
-		res.Add(ps[i].ProductID)
+	orderedPs := ps.SortByPrimary()
+	for i := range orderedPs {
+		res.Add(orderedPs[i].ProductID)
 	}
 	return res.Slice()
 }

--- a/api/internal/store/entity/live_product.go
+++ b/api/internal/store/entity/live_product.go
@@ -3,8 +3,6 @@ package entity
 import (
 	"sort"
 	"time"
-
-	"github.com/and-period/furumaru/api/pkg/set"
 )
 
 // ライブ配信関連商品情報
@@ -51,12 +49,12 @@ func NewLiveProducts(liveID string, productIDs []string) LiveProducts {
 }
 
 func (ps LiveProducts) ProductIDs() []string {
-	res := set.NewEmpty[string](len(ps))
 	orderedPs := ps.SortByPrimary()
+	res := make([]string, 0, len(orderedPs))
 	for i := range orderedPs {
-		res.Add(orderedPs[i].ProductID)
+		res = append(res, orderedPs[i].ProductID)
 	}
-	return res.Slice()
+	return res
 }
 
 func (ps LiveProducts) GroupByLiveID() map[string]LiveProducts {

--- a/api/internal/store/entity/live_product_test.go
+++ b/api/internal/store/entity/live_product_test.go
@@ -79,17 +79,28 @@ func TestLiveProducts_ProductIDs(t *testing.T) {
 			products: LiveProducts{
 				{
 					LiveID:    "live-id",
-					ProductID: "product-id",
+					ProductID: "product-id-0",
+					Priority:  2,
+				},
+				{
+					LiveID:    "live-id",
+					ProductID: "product-id-1",
+					Priority:  1,
+				},
+				{
+					LiveID:    "live-id",
+					ProductID: "product-id-2",
+					Priority:  0,
 				},
 			},
-			expect: []string{"product-id"},
+			expect: []string{"product-id-2", "product-id-1", "product-id-0"},
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, tt.products.ProductIDs())
+			assert.Exactly(t, tt.expect, tt.products.ProductIDs())
 		})
 	}
 }


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 製品IDを取得する前に、製品をプライマリキーでソートするように変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->