### PR TITLE
Release for v1.11.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.32](https://github.com/and-period/furumaru/compare/v1.11.31...v1.11.32) - 2024-06-09
+- fix: Liveに紐づく関連商品のidsをPriorityでソートするように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2279
+
 ## [v1.11.31](https://github.com/and-period/furumaru/compare/v1.11.30...v1.11.31) - 2024-06-06
 - feat(store): 箱サイズのバリデーションを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2273
 - 商品の並べ替え登録機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2275


### PR DESCRIPTION
This pull request is for the next release as v1.11.32 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.32 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.31" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: Liveに紐づく関連商品のidsをPriorityでソートするように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2279


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.31...v1.11.32