### PR TITLE
Release for v1.11.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.11.33](https://github.com/and-period/furumaru/compare/v1.11.32...v1.11.33) - 2024-06-12
+- feat(user): TOPのi18n対応 by @sea-kai in https://github.com/and-period/furumaru/pull/2277
+- feat(media): 合計視聴者数を取得できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2283
+- build(deps): bump the dependencies group across 1 directory with 46 updates by @dependabot in https://github.com/and-period/furumaru/pull/2282
+- Fix/web/admin/live dashborad by @wf-yamaday in https://github.com/and-period/furumaru/pull/2284
+
 ## [v1.11.32](https://github.com/and-period/furumaru/compare/v1.11.31...v1.11.32) - 2024-06-09
 - fix: Liveに紐づく関連商品のidsをPriorityでソートするように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2279
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.33 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.33 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.32" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(user): TOPのi18n対応 by @sea-kai in https://github.com/and-period/furumaru/pull/2277
* feat(media): 合計視聴者数を取得できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2283
* build(deps): bump the dependencies group across 1 directory with 46 updates by @dependabot in https://github.com/and-period/furumaru/pull/2282
* Fix/web/admin/live dashborad by @wf-yamaday in https://github.com/and-period/furumaru/pull/2284


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.32...v1.11.33