### PR TITLE
feat(media): 合計視聴者数を取得できるように

### DIFF
--- a/api/internal/gateway/admin/v1/handler/schedule.go
+++ b/api/internal/gateway/admin/v1/handler/schedule.go
@@ -268,14 +268,15 @@ func (h *handler) AnalyzeSchedule(ctx *gin.Context) {
 		CreatedAtGte: startAt,
 		CreatedAtLt:  endAt,
 	}
-	viewerLogs, err := h.media.AggregateBroadcastViewerLogs(ctx, viewerLogsIn)
+	viewerLogs, totalViewers, err := h.media.AggregateBroadcastViewerLogs(ctx, viewerLogsIn)
 	if err != nil {
 		h.httpError(ctx, err)
 		return
 	}
 
 	res := &response.AnalyzeScheduleResponse{
-		ViewerLogs: service.NewBroadcastViewerLogs(viewerLogInterval, startAt, endAt, viewerLogs).Response(),
+		ViewerLogs:   service.NewBroadcastViewerLogs(viewerLogInterval, startAt, endAt, viewerLogs).Response(),
+		TotalViewers: totalViewers,
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/admin/v1/response/schedule.go
+++ b/api/internal/gateway/admin/v1/response/schedule.go
@@ -30,5 +30,6 @@ type SchedulesResponse struct {
 }
 
 type AnalyzeScheduleResponse struct {
-	ViewerLogs []*BroadcastViewerLog `json:"viewerLogs"` // 視聴者数ログ
+	ViewerLogs   []*BroadcastViewerLog `json:"viewerLogs"`   // 視聴者数ログ
+	TotalViewers int64                 `json:"totalViewers"` // 合計視聴者数
 }

--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -109,7 +109,14 @@ type UpdateBroadcastCommentParams struct {
 
 type BroadcastViewerLog interface {
 	Create(ctx context.Context, log *entity.BroadcastViewerLog) error
+	GetTotal(ctx context.Context, params *GetBroadcastTotalViewersParams) (int64, error)
 	Aggregate(ctx context.Context, params *AggregateBroadcastViewerLogsParams) (entity.AggregatedBroadcastViewerLogs, error)
+}
+
+type GetBroadcastTotalViewersParams struct {
+	BroadcastID  string
+	CreatedAtGte time.Time
+	CreatedAtLt  time.Time
 }
 
 type AggregateBroadcastViewerLogsParams struct {

--- a/api/internal/media/service.go
+++ b/api/internal/media/service.go
@@ -28,8 +28,8 @@ type Service interface {
 	AuthYoutubeBroadcastEvent(ctx context.Context, in *AuthYoutubeBroadcastEventInput) (*entity.BroadcastAuth, error)             // Youtubeライブ配信認証後処理
 	CreateYoutubeBroadcast(ctx context.Context, in *CreateYoutubeBroadcastInput) error                                            // Youtubeライブ配信登録
 	// ライブ視聴履歴
-	CreateBroadcastViewerLog(ctx context.Context, in *CreateBroadcastViewerLogInput) error                                                 // ライブ配信視聴履歴登録
-	AggregateBroadcastViewerLogs(ctx context.Context, in *AggregateBroadcastViewerLogsInput) (entity.AggregatedBroadcastViewerLogs, error) // ライブ配信視聴履歴集計
+	CreateBroadcastViewerLog(ctx context.Context, in *CreateBroadcastViewerLogInput) error                                                        // ライブ配信視聴履歴登録
+	AggregateBroadcastViewerLogs(ctx context.Context, in *AggregateBroadcastViewerLogsInput) (entity.AggregatedBroadcastViewerLogs, int64, error) // ライブ配信視聴履歴集計
 	// ライブコメント
 	ListBroadcastComments(ctx context.Context, in *ListBroadcastCommentsInput) (entity.BroadcastComments, string, error)     // ライブコメント一覧取得
 	CreateBroadcastComment(ctx context.Context, in *CreateBroadcastCommentInput) (*entity.BroadcastComment, error)           // ライブコメント登録

--- a/api/internal/media/service/broadcast_viewer_log.go
+++ b/api/internal/media/service/broadcast_viewer_log.go
@@ -6,6 +6,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/media"
 	"github.com/and-period/furumaru/api/internal/media/database"
 	"github.com/and-period/furumaru/api/internal/media/entity"
+	"golang.org/x/sync/errgroup"
 )
 
 func (s *service) CreateBroadcastViewerLog(ctx context.Context, in *media.CreateBroadcastViewerLogInput) error {
@@ -30,20 +31,40 @@ func (s *service) CreateBroadcastViewerLog(ctx context.Context, in *media.Create
 
 func (s *service) AggregateBroadcastViewerLogs(
 	ctx context.Context, in *media.AggregateBroadcastViewerLogsInput,
-) (entity.AggregatedBroadcastViewerLogs, error) {
+) (entity.AggregatedBroadcastViewerLogs, int64, error) {
 	if err := s.validator.Struct(in); err != nil {
-		return nil, internalError(err)
+		return nil, 0, internalError(err)
 	}
 	broadcast, err := s.db.Broadcast.GetByScheduleID(ctx, in.ScheduleID)
 	if err != nil {
-		return nil, internalError(err)
+		return nil, 0, internalError(err)
 	}
-	params := &database.AggregateBroadcastViewerLogsParams{
-		BroadcastID:  broadcast.ID,
-		Interval:     in.Interval,
-		CreatedAtGte: in.CreatedAtGte,
-		CreatedAtLt:  in.CreatedAtLt,
+	var (
+		logs  entity.AggregatedBroadcastViewerLogs
+		total int64
+	)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		params := &database.AggregateBroadcastViewerLogsParams{
+			BroadcastID:  broadcast.ID,
+			Interval:     in.Interval,
+			CreatedAtGte: in.CreatedAtGte,
+			CreatedAtLt:  in.CreatedAtLt,
+		}
+		logs, err = s.db.BroadcastViewerLog.Aggregate(ctx, params)
+		return
+	})
+	eg.Go(func() (err error) {
+		params := &database.GetBroadcastTotalViewersParams{
+			BroadcastID:  broadcast.ID,
+			CreatedAtGte: in.CreatedAtGte,
+			CreatedAtLt:  in.CreatedAtLt,
+		}
+		total, err = s.db.BroadcastViewerLog.GetTotal(ctx, params)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, 0, internalError(err)
 	}
-	logs, err := s.db.BroadcastViewerLog.Aggregate(ctx, params)
-	return logs, internalError(err)
+	return logs, total, nil
 }

--- a/api/internal/media/service/broadcast_viewer_log_test.go
+++ b/api/internal/media/service/broadcast_viewer_log_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/media/database"
 	"github.com/and-period/furumaru/api/internal/media/entity"
 	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,7 +108,7 @@ func TestAggregateBroadcastViewerLogs(t *testing.T) {
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
-	params := &database.AggregateBroadcastViewerLogsParams{
+	aggregateParams := &database.AggregateBroadcastViewerLogsParams{
 		BroadcastID:  "broadcast-id",
 		Interval:     entity.AggregateBroadcastViewerLogIntervalMinute,
 		CreatedAtGte: now,
@@ -120,18 +121,25 @@ func TestAggregateBroadcastViewerLogs(t *testing.T) {
 			Total:       3,
 		},
 	}
+	totalParams := &database.GetBroadcastTotalViewersParams{
+		BroadcastID:  "broadcast-id",
+		CreatedAtGte: now,
+		CreatedAtLt:  now,
+	}
 	tests := []struct {
-		name      string
-		setup     func(ctx context.Context, mocks *mocks)
-		input     *media.AggregateBroadcastViewerLogsInput
-		expect    entity.AggregatedBroadcastViewerLogs
-		expectErr error
+		name        string
+		setup       func(ctx context.Context, mocks *mocks)
+		input       *media.AggregateBroadcastViewerLogsInput
+		expect      entity.AggregatedBroadcastViewerLogs
+		expectTotal int64
+		expectErr   error
 	}{
 		{
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Broadcast.EXPECT().GetByScheduleID(ctx, "schedule-id").Return(broadcast, nil)
-				mocks.db.BroadcastViewerLog.EXPECT().Aggregate(ctx, params).Return(logs, nil)
+				mocks.db.BroadcastViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(logs, nil)
+				mocks.db.BroadcastViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(3), nil)
 			},
 			input: &media.AggregateBroadcastViewerLogsInput{
 				ScheduleID:   "schedule-id",
@@ -139,8 +147,9 @@ func TestAggregateBroadcastViewerLogs(t *testing.T) {
 				CreatedAtGte: now,
 				CreatedAtLt:  now,
 			},
-			expect:    logs,
-			expectErr: nil,
+			expect:      logs,
+			expectTotal: 3,
+			expectErr:   nil,
 		},
 		{
 			name:      "invalid argument",
@@ -160,14 +169,16 @@ func TestAggregateBroadcastViewerLogs(t *testing.T) {
 				CreatedAtGte: now,
 				CreatedAtLt:  now,
 			},
-			expect:    nil,
-			expectErr: exception.ErrInternal,
+			expect:      nil,
+			expectTotal: 0,
+			expectErr:   exception.ErrInternal,
 		},
 		{
 			name: "failed to aggregate viewer logs",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Broadcast.EXPECT().GetByScheduleID(ctx, "schedule-id").Return(broadcast, nil)
-				mocks.db.BroadcastViewerLog.EXPECT().Aggregate(ctx, params).Return(nil, assert.AnError)
+				mocks.db.BroadcastViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(nil, assert.AnError)
+				mocks.db.BroadcastViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(3), nil)
 			},
 			input: &media.AggregateBroadcastViewerLogsInput{
 				ScheduleID:   "schedule-id",
@@ -175,15 +186,34 @@ func TestAggregateBroadcastViewerLogs(t *testing.T) {
 				CreatedAtGte: now,
 				CreatedAtLt:  now,
 			},
-			expect:    nil,
-			expectErr: exception.ErrInternal,
+			expect:      nil,
+			expectTotal: 0,
+			expectErr:   exception.ErrInternal,
+		},
+		{
+			name: "failed to aggregate viewer logs",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Broadcast.EXPECT().GetByScheduleID(ctx, "schedule-id").Return(broadcast, nil)
+				mocks.db.BroadcastViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(logs, nil)
+				mocks.db.BroadcastViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(0), assert.AnError)
+			},
+			input: &media.AggregateBroadcastViewerLogsInput{
+				ScheduleID:   "schedule-id",
+				Interval:     entity.AggregateBroadcastViewerLogIntervalMinute,
+				CreatedAtGte: now,
+				CreatedAtLt:  now,
+			},
+			expect:      nil,
+			expectTotal: 0,
+			expectErr:   exception.ErrInternal,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
-			actual, err := service.AggregateBroadcastViewerLogs(ctx, tt.input)
+			actual, total, err := service.AggregateBroadcastViewerLogs(ctx, tt.input)
 			assert.ErrorIs(t, err, tt.expectErr)
 			assert.Equal(t, tt.expect, actual)
+			assert.Equal(t, tt.expectTotal, total)
 		}))
 	}
 }

--- a/docs/swagger/admin/components/schemas/v1/schedule.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/schedule.response.yaml
@@ -139,6 +139,10 @@ analyzeScheduleResponse:
       description: 視聴者ログ一覧
       items:
         $ref: './../../../openapi.yaml#/components/schemas/broadcastViewerLog'
+    totalViewers:
+      type: integer
+      format: int64
+      description: 合計視聴者数
   required:
   - viewerLogs
   example:
@@ -147,3 +151,4 @@ analyzeScheduleResponse:
       startAt: 1640962800
       endAt: 1640962800
       total: 100
+    totalViewers: 100

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -349,6 +349,12 @@ export interface AnalyzeScheduleResponse {
      * @memberof AnalyzeScheduleResponse
      */
     'viewerLogs': Array<BroadcastViewerLog>;
+    /**
+     * 合計視聴者数
+     * @type {number}
+     * @memberof AnalyzeScheduleResponse
+     */
+    'totalViewers'?: number;
 }
 /**
  * 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - スケジュール分析機能に「総視聴者数」が追加されました。これにより、放送の総視聴者数が表示されるようになりました。

- **テスト**
  - 新しいテスト機能「TestBroadcastViewerLog_GetTotal」を追加し、指定された期間内の放送の総視聴者数を取得する機能をテストします。

- **その他**
  - 内部APIのレスポンスに「TotalViewers」フィールドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->