### PR TITLE
Release for v1.11.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.11.34](https://github.com/and-period/furumaru/compare/v1.11.33...v1.11.34) - 2024-07-07
+- feat(user): 商品一覧のi18n対応 by @sea-kai in https://github.com/and-period/furumaru/pull/2285
+- build(deps): bump minimatch from 9.0.4 to 9.0.5 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2288
+- feat: トップページに動画イメージのUIを実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2289
+
 ## [v1.11.33](https://github.com/and-period/furumaru/compare/v1.11.32...v1.11.33) - 2024-06-12
 - feat(user): TOPのi18n対応 by @sea-kai in https://github.com/and-period/furumaru/pull/2277
 - feat(media): 合計視聴者数を取得できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2283


### PR DESCRIPTION
This pull request is for the next release as v1.11.34 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.34 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.33" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(user): 商品一覧のi18n対応 by @sea-kai in https://github.com/and-period/furumaru/pull/2285
* build(deps): bump minimatch from 9.0.4 to 9.0.5 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2288
* feat: トップページに動画イメージのUIを実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2289


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.33...v1.11.34