### PR TITLE
feat(user): マルシェ一覧と詳細のi18n対応

### DIFF
--- a/web/user/src/components/atoms/live/TheLiveCommentInputForm.vue
+++ b/web/user/src/components/atoms/live/TheLiveCommentInputForm.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import type { I18n } from '~/types/locales'
+
+const i18n = useI18n()
+const dt = (str: keyof I18n['lives']['details']) => {
+  return i18n.t(`lives.details.${str}`)
+}
+
 interface Props {
   isAuthenticated: boolean
   isSending: boolean
@@ -37,18 +44,20 @@ const handleSubmit = () => {
         v-model="modelValue"
         type="text"
         class="block w-full border-typography p-2 shadow-[0_1px_0_0] focus:border-0 focus:border-main focus:shadow-[0_2px_0_0] focus:outline-none focus:ring-0"
-        placeholder="コメントする…"
+        :placeholder="dt('commentPlaceholder')"
       >
       <button
         class="whitespace-nowrap rounded-lg bg-main px-4 py-2 text-white disabled:bg-main/50"
         type="submit"
         :disabled="!canSubmit || isSending"
       >
-        送信
+        {{ dt('submitButtonText') }}
       </button>
     </div>
     <span class="mt-1 text-[12px] tracking-[10%]">
-      <template v-if="!isAuthenticated">※ゲストとしてコメントします </template>
+      <template v-if="!isAuthenticated">
+        {{ dt('guestCommentNote') }}
+      </template>
     </span>
   </form>
 </template>

--- a/web/user/src/components/atoms/live/TheLiveDescription.vue
+++ b/web/user/src/components/atoms/live/TheLiveDescription.vue
@@ -83,7 +83,7 @@ const handleClickShowDetailButton = () => {
         provider="cloudFront"
         :src="coordinatorImgSrc"
         class="h-10 w-10 rounded-full hover:cursor-pointer"
-        :alt=coordinatorThumbnailAlt
+        :alt="coordinatorThumbnailAlt"
         @click="handleCLickCoordinator"
       />
       <div class="text-[12px] tracking-[1.2px]">

--- a/web/user/src/components/atoms/live/TheLiveDescription.vue
+++ b/web/user/src/components/atoms/live/TheLiveDescription.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { datetimeformatterFromUnixtime } from '~/lib/dayjs'
+import type { I18n } from '~/types/locales'
 
 interface Props {
   title: string
@@ -12,6 +13,12 @@ interface Props {
   coordinatorName: string
   coordinatorImgSrc: string
   coordinatorAddress: string
+}
+
+const i18n = useI18n()
+
+const dt = (str: keyof I18n['lives']['details']) => {
+  return i18n.t(`lives.details.${str}`)
 }
 
 const props = defineProps<Props>()
@@ -98,7 +105,7 @@ const handleClickShowDetailButton = () => {
         @click="handleClickShowDetailButton"
       >
         <div>
-          {{ showDetail ? 'マルシェの詳細を隠す' : 'マルシェの詳細を見る' }}
+          {{ showDetail ? dt('hideMarcheDetailsText') : dt('showMarcheDetailsText') }}
         </div>
         <div>
           <the-up-arrow-icon v-if="showDetail" />

--- a/web/user/src/components/atoms/live/TheLiveDescription.vue
+++ b/web/user/src/components/atoms/live/TheLiveDescription.vue
@@ -85,7 +85,7 @@ const handleClickShowDetailButton = () => {
           {{ marcheName }}/{{ coordinatorAddress }}
         </p>
         <p>
-          コーディネーター：
+          {{ dt('coordinatorLabel') }}:
           <span
             class="cursor-pointer hover:underline"
             @click="handleCLickCoordinator"

--- a/web/user/src/components/atoms/live/TheLiveDescription.vue
+++ b/web/user/src/components/atoms/live/TheLiveDescription.vue
@@ -21,6 +21,12 @@ const dt = (str: keyof I18n['lives']['details']) => {
   return i18n.t(`lives.details.${str}`)
 }
 
+const coordinatorThumbnailAlt = computed<string>(() => {
+  return i18n.t('lives.details.coordinatorThumbnailAlt', {
+    coordinatorName: props.coordinatorName,
+  })
+})
+
 const props = defineProps<Props>()
 
 interface Emits {
@@ -47,7 +53,7 @@ const handleClickShowDetailButton = () => {
         <div
           class="flex max-w-fit items-center justify-center rounded border-2 border-main px-2 font-bold text-main"
         >
-          アーカイブ
+          {{ dt('archivedStreamText') }}
         </div>
       </template>
       <template v-else-if="isLiveStreaming">
@@ -77,7 +83,7 @@ const handleClickShowDetailButton = () => {
         provider="cloudFront"
         :src="coordinatorImgSrc"
         class="h-10 w-10 rounded-full hover:cursor-pointer"
-        :alt="`${coordinatorName}のプロフィール画像`"
+        :alt=coordinatorThumbnailAlt
         @click="handleCLickCoordinator"
       />
       <div class="text-[12px] tracking-[1.2px]">

--- a/web/user/src/components/molecules/TheLiveTimelineProduct.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineProduct.vue
@@ -2,6 +2,7 @@
 import { ProductStatus, type Product } from '~/types/api'
 import { priceFormatter } from '~/lib/price'
 import { productStatusToString } from '~/lib/product'
+import type { I18n } from '~/types/locales'
 
 interface Props {
   product: Product
@@ -17,6 +18,9 @@ interface Emits {
 const emits = defineEmits<Emits>()
 
 const i18n = useI18n()
+const dt = (str: keyof I18n['lives']['details']) => {
+  return i18n.t(`lives.details.${str}`)
+}
 
 const formData = ref<number>(1)
 
@@ -99,11 +103,14 @@ const handleClickItem = () => {
         {{ product.name }}
       </div>
       <div>
-        <p
-          class="mb-2 text-[12px] font-bold after:ml-2 after:content-['(税込)']"
-        >
-          {{ priceFormatter(product.price) }}
-        </p>
+        <div class="flex flex-row mb-2 text-[12px] font-bold">
+          <p>
+            {{ priceFormatter(product.price) }}
+          </p>
+          <p class="ml-2">
+            {{ dt('itemPriceTaxIncludedText') }}
+          </p>
+        </div>
         <div class="flex h-6 items-center gap-2 text-[10px]">
           <div class="inline-flex h-full items-center">
             <select
@@ -135,7 +142,7 @@ const handleClickItem = () => {
             :disabled="!canAddCart"
             @click.stop="handleClickAddCart"
           >
-            カゴに入れる
+            {{ dt('addToCartText') }}
           </button>
         </div>
       </div>

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -153,6 +153,8 @@
       "showMarcheDetailsText": "Show Marché Details",
       "itemsTabLabel": "Marché Items",
       "commentsTabLabel": "Comments",
+      "itemPriceTaxIncludedText": "(tax included)",
+      "addToCartText": "Add to Cart",
       "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
     }
   }

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -147,6 +147,9 @@
     }
   },
   "lives": {
+    "list": {
+      "allMarcheTitle": "All Marché"
+    },
     "details": {
       "archivedStreamText": "archived stream",
       "coordinatorThumbnailAlt": "{coordinatorName}'s Profile Picture",

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -145,5 +145,10 @@
       "storageTypeFrozen": "Frozen",
       "producerInformationTitle": "Producer of this Product" 
     }
+  },
+  "lives": {
+    "details": {
+      "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
+    }
   }
 }

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -148,6 +148,8 @@
   },
   "lives": {
     "details": {
+      "archivedStreamText": "archived stream",
+      "coordinatorThumbnailAlt": "{coordinatorName}'s Profile Picture",
       "coordinatorLabel": "Coordinator",
       "hideMarcheDetailsText": "Hide Marché Details",
       "showMarcheDetailsText": "Show Marché Details",

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -148,6 +148,8 @@
   },
   "lives": {
     "details": {
+      "hideMarcheDetailsText": "Hide Marché Details",
+      "showMarcheDetailsText": "Show Marché Details",
       "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
     }
   }

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -123,7 +123,7 @@
       "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
     },
     "details": {
-      "itemThumbnailAlt": "{itemName}のサムネイル画像",
+      "itemThumbnailAlt": "Thumbnail of {itemName}",
       "producerLabel": "Producer",
       "highlightsLabel": "Highlights",
       "itemPriceTaxIncludedText": "(tax included)",
@@ -151,6 +151,8 @@
       "coordinatorLabel": "Coordinator",
       "hideMarcheDetailsText": "Hide Marché Details",
       "showMarcheDetailsText": "Show Marché Details",
+      "itemsTabLabel": "Marché Items",
+      "commentsTabLabel": "Comments",
       "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
     }
   }

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -155,7 +155,12 @@
       "commentsTabLabel": "Comments",
       "itemPriceTaxIncludedText": "(tax included)",
       "addToCartText": "Add to Cart",
-      "addCartSnackbarMessage": "Added {itemName} to your shopping cart"
+      "addCartSnackbarMessage": "Added {itemName} to your shopping cart",
+      "commentPlaceholder": "Leave a comment…",
+      "submitButtonText": "Submit",
+      "guestCommentNote": "Note: Comment as a Guest",
+      "noCommentsText": "No comments yet",
+      "guestNameLabel": "guest"
     }
   }
 }

--- a/web/user/src/locales/en_us.json
+++ b/web/user/src/locales/en_us.json
@@ -148,6 +148,7 @@
   },
   "lives": {
     "details": {
+      "coordinatorLabel": "Coordinator",
       "hideMarcheDetailsText": "Hide Marché Details",
       "showMarcheDetailsText": "Show Marché Details",
       "addCartSnackbarMessage": "Added {itemName} to your shopping cart"

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -149,6 +149,9 @@
     }
   },
   "lives": {
+    "list": {
+      "allMarcheTitle": "すべてのマルシェ"
+    },
     "details": {
       "archivedStreamText": "アーカイブ",
       "coordinatorThumbnailAlt": "{coordinatorName}のプロフィール画像",

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -155,6 +155,8 @@
       "showMarcheDetailsText": "マルシェの詳細を見る",
       "itemsTabLabel": "このマルシェの商品",
       "commentsTabLabel": "コメント",
+      "itemPriceTaxIncludedText": "(税込)",
+      "addToCartText": "カゴに入れる",
       "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"
     }
   }

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -150,6 +150,8 @@
   },
   "lives": {
     "details": {
+      "hideMarcheDetailsText": "マルシェの詳細を隠す",
+      "showMarcheDetailsText": "マルシェの詳細を見る",
       "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"
     }
   }

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -157,7 +157,12 @@
       "commentsTabLabel": "コメント",
       "itemPriceTaxIncludedText": "(税込)",
       "addToCartText": "カゴに入れる",
-      "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"
+      "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました",
+      "commentPlaceholder": "コメントをする…",
+      "submitButtonText": "送信",
+      "guestCommentNote": "※ゲストとしてコメントします",
+      "noCommentsText": "コメントはありません",
+      "guestNameLabel": "ゲスト"
     }
   }
 }

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -150,6 +150,7 @@
   },
   "lives": {
     "details": {
+      "coordinatorLabel": "コーディネーター",
       "hideMarcheDetailsText": "マルシェの詳細を隠す",
       "showMarcheDetailsText": "マルシェの詳細を見る",
       "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -153,6 +153,8 @@
       "coordinatorLabel": "コーディネーター",
       "hideMarcheDetailsText": "マルシェの詳細を隠す",
       "showMarcheDetailsText": "マルシェの詳細を見る",
+      "itemsTabLabel": "このマルシェの商品",
+      "commentsTabLabel": "コメント",
       "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"
     }
   }

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -147,5 +147,10 @@
       "storageTypeFrozen": "冷凍保存",
       "producerInformationTitle": "この商品の生産者"
     }
+  },
+  "lives": {
+    "details": {
+      "addCartSnackbarMessage": "買い物カゴに{itemName}を追加しました"
+    }
   }
 }

--- a/web/user/src/locales/ja_jp.json
+++ b/web/user/src/locales/ja_jp.json
@@ -150,6 +150,8 @@
   },
   "lives": {
     "details": {
+      "archivedStreamText": "アーカイブ",
+      "coordinatorThumbnailAlt": "{coordinatorName}のプロフィール画像",
       "coordinatorLabel": "コーディネーター",
       "hideMarcheDetailsText": "マルシェの詳細を隠す",
       "showMarcheDetailsText": "マルシェの詳細を見る",

--- a/web/user/src/pages/live/[...id].vue
+++ b/web/user/src/pages/live/[...id].vue
@@ -257,7 +257,7 @@ useSeoMeta({
                     v-if="comments.length === 0"
                     class="text-typography"
                   >
-                    コメントがありません。
+                    {{ dt('noCommentsText') }}
                   </div>
                   <div
                     v-for="(item, i) in comments"
@@ -281,7 +281,7 @@ useSeoMeta({
                       <div
                         class="whitespace-nowrap text-[14px] text-typography"
                       >
-                        {{ item.username ? item.username : 'ゲスト' }}
+                        {{ item.username ? item.username : dt('guestNameLabel') }}
                       </div>
                       <div class="line-clamp-2 text-main">
                         {{ item.comment }}

--- a/web/user/src/pages/live/[...id].vue
+++ b/web/user/src/pages/live/[...id].vue
@@ -9,6 +9,7 @@ import {
 } from '~/types/api'
 import type { Snackbar } from '~/types/props'
 import type { LiveTimeLineItem } from '~/types/props/schedule'
+import type { I18n } from '~/types/locales'
 
 const authStore = useAuthStore()
 const { isAuthenticated } = storeToRefs(authStore)
@@ -22,6 +23,10 @@ const { addCart } = shoppingCartStore
 const snackbarItems = ref<Snackbar[]>([])
 
 const i18n = useI18n()
+
+const dt = (str: keyof I18n['lives']['details']) => {
+  return i18n.t(`lives.details.${str}`)
+}
 
 const router = useRouter()
 const route = useRoute()
@@ -217,7 +222,7 @@ useSeoMeta({
                 }"
                 @click="clickTab('product')"
               >
-                このマルシェの商品
+                {{ dt('itemsTabLabel') }}
               </button>
               <button
                 class="rounded-t-xl p-4 text-center"
@@ -228,7 +233,7 @@ useSeoMeta({
                 }"
                 @click="clickTab('comment')"
               >
-                コメント
+                {{ dt('commentsTabLabel') }}
               </button>
             </div>
             <template v-if="selectedTab === 'product'">

--- a/web/user/src/pages/live/[...id].vue
+++ b/web/user/src/pages/live/[...id].vue
@@ -21,6 +21,8 @@ const { addCart } = shoppingCartStore
 
 const snackbarItems = ref<Snackbar[]>([])
 
+const i18n = useI18n()
+
 const router = useRouter()
 const route = useRoute()
 
@@ -124,9 +126,12 @@ const handleClickItem = (productId: string) => {
 }
 
 const handleClickAddCart = (name: string, id: string, quantity: number) => {
+  const message = i18n.t('items.details.addCartSnackbarMessage', {
+    itemName: name,
+  })
   addCart({ productId: id, quantity })
   snackbarItems.value.push({
-    text: `買い物カゴに「${name}」を追加しました`,
+    text: message,
     isShow: true,
   })
 }

--- a/web/user/src/pages/marches/index.vue
+++ b/web/user/src/pages/marches/index.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { useLiveStore } from '~/store/live'
+import type { I18n } from '~/types/locales'
+
+const i18n = useI18n()
 
 const route = useRoute()
 const router = useRouter()
+
+const lt = (str: keyof I18n['lives']['list']) => {
+  return i18n.t(`lives.list.${str}`)
+}
 
 const liveStore = useLiveStore()
 
@@ -69,7 +76,7 @@ useSeoMeta({
       <p
         class="text-center text-[14px] font-bold tracking-[2px] md:text-[20px]"
       >
-        すべてのマルシェ
+        {{ lt('allMarcheTitle')}}
       </p>
     </div>
     <hr class="mt-[40px]">

--- a/web/user/src/pages/marches/index.vue
+++ b/web/user/src/pages/marches/index.vue
@@ -76,7 +76,7 @@ useSeoMeta({
       <p
         class="text-center text-[14px] font-bold tracking-[2px] md:text-[20px]"
       >
-        {{ lt('allMarcheTitle')}}
+        {{ lt('allMarcheTitle') }}
       </p>
     </div>
     <hr class="mt-[40px]">

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -169,6 +169,8 @@ export interface I18n {
       showMarcheDetailsText: string
       itemsTabLabel: string
       commentsTabLabel: string
+      itemPriceTaxIncludedText: string
+      addToCartText: string
       addCartSnackbarMessage: string
     }
   }

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -164,6 +164,8 @@ export interface I18n {
 
   lives: {
     details: {
+      archivedStreamText: string
+      coordinatorThumbnailAlt: string
       coordinatorLabel: string
       hideMarcheDetailsText: string
       showMarcheDetailsText: string

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -172,6 +172,11 @@ export interface I18n {
       itemPriceTaxIncludedText: string
       addToCartText: string
       addCartSnackbarMessage: string
+      commentPlaceholder: string
+      submitButtonText: string
+      guestCommentNote: string
+      noCommentsText: string
+      guestNameLabel: string
     }
   }
 }

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -164,6 +164,8 @@ export interface I18n {
 
   lives: {
     details: {
+      hideMarcheDetailsText: string
+      showMarcheDetailsText: string
       addCartSnackbarMessage: string
     }
   }

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -163,6 +163,9 @@ export interface I18n {
   }
 
   lives: {
+    list: {
+      allMarcheTitle: string
+    }
     details: {
       archivedStreamText: string
       coordinatorThumbnailAlt: string

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -164,6 +164,7 @@ export interface I18n {
 
   lives: {
     details: {
+      coordinatorLabel: string
       hideMarcheDetailsText: string
       showMarcheDetailsText: string
       addCartSnackbarMessage: string

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -167,6 +167,8 @@ export interface I18n {
       coordinatorLabel: string
       hideMarcheDetailsText: string
       showMarcheDetailsText: string
+      itemsTabLabel: string
+      commentsTabLabel: string
       addCartSnackbarMessage: string
     }
   }

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -161,4 +161,10 @@ export interface I18n {
       producerInformationTitle: string
     }
   }
+
+  lives: {
+    details: {
+      addCartSnackbarMessage: string
+    }
+  }
 }


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
- マルシェ一覧のi18n対応(タイトルのみ)
- マルシェ詳細のi18n対応
 - マルシェ情報
 - 商品欄
 - コメント欄

## スクリーンショット
![furumaru_i18n_live_id](https://github.com/and-period/furumaru/assets/76773825/da8a858c-33ce-4241-b61b-3aace0873e1b)
<img width="1365" alt="スクリーンショット 2024-07-12 5 16 52" src="https://github.com/and-period/furumaru/assets/76773825/dda46e3c-fea9-4622-bfa2-4367ba7b0567">
<img width="1370" alt="スクリーンショット 2024-07-12 5 16 33" src="https://github.com/and-period/furumaru/assets/76773825/7b755481-8403-4403-bfff-f90f63d90cf5">
<img width="1377" alt="スクリーンショット 2024-07-12 5 17 10" src="https://github.com/and-period/furumaru/assets/76773825/3f8ed36a-ec56-4587-a3d8-34cf39374c9a">
<img width="1436" alt="スクリーンショット 2024-07-12 5 32 08" src="https://github.com/and-period/furumaru/assets/76773825/d6584140-3f76-4b8c-9250-5331d1937c10">

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コメント入力フォームやライブの説明、商品タイムライン、ライブページ、マルシェページでの表示テキストが国際化されました。
  - コメント入力フォームに国際化されたプレースホルダーとボタンテキストを追加。
  - 商品タイムラインでの商品価格と「カートに追加」ボタンのテキストが国際化されました。
  - マルシェページでのイベントタイトルが国際化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->