### PR TITLE
feat: コーディネータ登録時のパスワードを表示するように

### DIFF
--- a/api/internal/gateway/admin/v1/handler/coordinator.go
+++ b/api/internal/gateway/admin/v1/handler/coordinator.go
@@ -155,14 +155,16 @@ func (h *handler) CreateCoordinator(ctx *gin.Context) {
 		AddressLine2:      req.AddressLine2,
 		BusinessDays:      req.BusinessDays,
 	}
-	coordinator, err := h.user.CreateCoordinator(ctx, in)
+	coordinator, password, err := h.user.CreateCoordinator(ctx, in)
 	if err != nil {
 		h.httpError(ctx, err)
 		return
 	}
 
 	res := &response.CoordinatorResponse{
-		Coordinator: service.NewCoordinator(coordinator).Response(),
+		Coordinator:  service.NewCoordinator(coordinator).Response(),
+		ProductTypes: productTypes.Response(),
+		Password:     password,
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/admin/v1/response/coordinator.go
+++ b/api/internal/gateway/admin/v1/response/coordinator.go
@@ -38,6 +38,7 @@ type Coordinator struct {
 type CoordinatorResponse struct {
 	Coordinator  *Coordinator   `json:"coordinator"`  // コーディネータ情報
 	ProductTypes []*ProductType `json:"productTypes"` // 品目一覧
+	Password     string         `json:"password"`     // パスワード（登録時のみ）
 }
 
 type CoordinatorsResponse struct {

--- a/api/internal/user/service.go
+++ b/api/internal/user/service.go
@@ -35,7 +35,7 @@ type Service interface {
 	ListCoordinators(ctx context.Context, in *ListCoordinatorsInput) (entity.Coordinators, int64, error)           // 一覧取得
 	MultiGetCoordinators(ctx context.Context, in *MultiGetCoordinatorsInput) (entity.Coordinators, error)          // 一覧取得(ID指定)
 	GetCoordinator(ctx context.Context, in *GetCoordinatorInput) (*entity.Coordinator, error)                      // １件取得
-	CreateCoordinator(ctx context.Context, in *CreateCoordinatorInput) (*entity.Coordinator, error)                // 登録
+	CreateCoordinator(ctx context.Context, in *CreateCoordinatorInput) (*entity.Coordinator, string, error)        // 登録
 	UpdateCoordinator(ctx context.Context, in *UpdateCoordinatorInput) error                                       // 更新
 	UpdateCoordinatorEmail(ctx context.Context, in *UpdateCoordinatorEmailInput) error                             // メールアドレス更新
 	ResetCoordinatorPassword(ctx context.Context, in *ResetCoordinatorPasswordInput) error                         // パスワードリセット

--- a/api/internal/user/service/coordinator_test.go
+++ b/api/internal/user/service/coordinator_test.go
@@ -574,7 +574,7 @@ func TestCreateCoordinator(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
-			_, err := service.CreateCoordinator(ctx, tt.input)
+			_, _, err := service.CreateCoordinator(ctx, tt.input)
 			assert.ErrorIs(t, err, tt.expectErr)
 		}))
 	}

--- a/docs/swagger/admin/components/schemas/v1/coordinator.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/coordinator.response.yaml
@@ -7,9 +7,13 @@ coordinatorResponse:
       description: 品目一覧
       items:
         $ref: './../../../openapi.yaml#/components/schemas/productType'
+    password:
+      type: string
+      description: パスワード
   required:
   - coordinator
   - productTypes
+  - password
   example:
     coordinator:
       id: 'kSByoE6FetnPs5Byk3a9Zx'
@@ -44,6 +48,7 @@ coordinatorResponse:
       categoryName: '野菜'
       createdAt: 1640962800
       updatedAt: 1640962800
+    password: 'password'
 coordinatorsResponse:
   type: object
   properties:

--- a/web/admin/src/pages/coordinators/new.vue
+++ b/web/admin/src/pages/coordinators/new.vue
@@ -4,11 +4,12 @@ import { storeToRefs } from 'pinia'
 
 import { convertJapaneseToI18nPhoneNumber } from '~/lib/formatter'
 import { useAlert, useSearchAddress } from '~/lib/hooks'
-import { useCoordinatorStore, useProductTypeStore } from '~/store'
+import { useCommonStore, useCoordinatorStore, useProductTypeStore } from '~/store'
 import { type CreateCoordinatorRequest, Prefecture } from '~/types/api'
 import { type ImageUploadStatus } from '~/types/props'
 
 const router = useRouter()
+const commonStore = useCommonStore()
 const coordinatorStore = useCoordinatorStore()
 const productTypeStore = useProductTypeStore()
 const searchAddress = useSearchAddress()
@@ -73,7 +74,11 @@ const handleSubmit = async (): Promise<void> => {
       ...formData.value,
       phoneNumber: convertJapaneseToI18nPhoneNumber(formData.value.phoneNumber),
     }
-    await coordinatorStore.createCoordinator(req)
+    const res = await coordinatorStore.createCoordinator(req)
+    commonStore.addSnackbar({
+      message: `コーディネータの登録が完了しました。（初期パスワード：${res.password}）`,
+      color: 'info',
+    })
     router.push('/coordinators')
   }
   catch (err) {

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -1221,6 +1221,12 @@ export interface CoordinatorResponse {
      * @memberof CoordinatorResponse
      */
     'productTypes': Array<ProductType>;
+    /**
+     * パスワード
+     * @type {string}
+     * @memberof CoordinatorResponse
+     */
+    'password': string;
 }
 /**
  * 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コーディネーター作成時に生成されたパスワードをレスポンスに含めるようになりました。
  - コーディネーター作成の成功時に、ユーザーに初期パスワードを通知する機能を追加しました。

- **バグ修正**
  - コーディネーター作成処理におけるエラーハンドリングを改善しました。 

- **ドキュメント**
  - APIレスポンスにおける新しいパスワードフィールドを文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->