### PR TITLE
fix(user): purchaseのi18n対応でtypoによって文字列が読み込めていなかった部分を修正

### DIFF
--- a/web/user/src/pages/v1/purchase/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/confirmation.vue
@@ -384,7 +384,7 @@ useSeoMeta({
               </div>
               <the-text-input
                 v-model="checkoutFormData.creditCard.name"
-                :placeholder="ct('cardHolderNamePlaceholder')"
+                :placeholder="ct('cardholderNamePlaceholder')"
                 :with-label="false"
                 name="cc-name"
                 type="text"


### PR DESCRIPTION
## やったこと
- purchaseのtypo修正
<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイルの変更**
  - テキスト入力フィールドのプレースホルダーの文字列が修正されました。具体的には、「cardHolderNamePlaceholder」から「cardholderNamePlaceholder」に変更され、表示テキストが調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->