### PR TITLE
feat(gateway): オンデマンド配信一覧取得APIの実装

### DIFF
--- a/api/internal/gateway/admin/v1/handler/experience.go
+++ b/api/internal/gateway/admin/v1/handler/experience.go
@@ -178,6 +178,20 @@ func (h *handler) DeleteExperience(ctx *gin.Context) {
 	ctx.Status(http.StatusNoContent)
 }
 
+func (h *handler) multiGetExperiences(ctx context.Context, experienceIDs []string) (service.Experiences, error) {
+	if len(experienceIDs) == 0 {
+		return service.Experiences{}, nil
+	}
+	in := &store.MultiGetExperiencesInput{
+		ExperienceIDs: experienceIDs,
+	}
+	experiences, err := h.store.MultiGetExperiences(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewExperiences(experiences), nil
+}
+
 func (h *handler) getExperience(ctx context.Context, experienceID string) (*service.Experience, error) {
 	// TODO: 詳細の実装
 	return &service.Experience{}, nil

--- a/api/internal/gateway/admin/v1/handler/video.go
+++ b/api/internal/gateway/admin/v1/handler/video.go
@@ -1,11 +1,16 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/request"
 	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/response"
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/service"
+	"github.com/and-period/furumaru/api/internal/gateway/util"
+	"github.com/and-period/furumaru/api/internal/media"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 )
 
 func (h *handler) videoRoutes(rg *gin.RouterGroup) {
@@ -13,19 +18,97 @@ func (h *handler) videoRoutes(rg *gin.RouterGroup) {
 
 	r.GET("", h.ListVideos)
 	r.POST("", h.CreateVideo)
-	r.GET("/:videoId", h.GetVideo)
-	r.PATCH("/:videoId", h.UpdateVideo)
-	r.DELETE("/:videoId", h.DeleteVideo)
+	r.GET("/:videoId", h.filterAccessVideo, h.GetVideo)
+	r.PATCH("/:videoId", h.filterAccessVideo, h.UpdateVideo)
+	r.DELETE("/:videoId", h.filterAccessVideo, h.DeleteVideo)
+}
+
+func (h *handler) filterAccessVideo(ctx *gin.Context) {
+	params := &filterAccessParams{
+		coordinator: func(ctx *gin.Context) (bool, error) {
+			video, err := h.getVideo(ctx, util.GetParam(ctx, "videoId"))
+			if err != nil {
+				return false, err
+			}
+			return video.CoordinatorID == getAdminID(ctx), nil
+		},
+		producer: func(ctx *gin.Context) (bool, error) {
+			return false, nil
+		},
+	}
+	if err := filterAccess(ctx, params); err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+	ctx.Next()
 }
 
 func (h *handler) ListVideos(ctx *gin.Context) {
-	// TODO: 詳細の実装
+	const (
+		defaultLimit  = 20
+		defaultOffset = 0
+	)
+
+	limit, err := util.GetQueryInt64(ctx, "limit", defaultLimit)
+	if err != nil {
+		h.badRequest(ctx, err)
+		return
+	}
+	offset, err := util.GetQueryInt64(ctx, "offset", defaultOffset)
+	if err != nil {
+		h.badRequest(ctx, err)
+		return
+	}
+
+	in := &media.ListVideosInput{
+		Name:          util.GetQuery(ctx, "name", ""),
+		CoordinatorID: util.GetQuery(ctx, "coordinatorId", ""),
+		Limit:         limit,
+		Offset:        offset,
+		NoLimit:       false,
+	}
+	videos, total, err := h.media.ListVideos(ctx, in)
+	if err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+	if len(videos) == 0 {
+		res := &response.VideosResponse{
+			Videos: []*response.Video{},
+		}
+		ctx.JSON(http.StatusOK, res)
+		return
+	}
+
+	var (
+		coordinators service.Coordinators
+		products     service.Products
+		experiences  service.Experiences
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		coordinators, err = h.multiGetCoordinators(ectx, videos.CoordinatorIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		products, err = h.multiGetProducts(ectx, videos.ProductIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		experiences, err = h.multiGetExperiences(ectx, videos.ExperienceIDs())
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+
 	res := &response.VideosResponse{
-		Videos:       []*response.Video{},
-		Coordinators: []*response.Coordinator{},
-		Products:     []*response.Product{},
-		Experiences:  []*response.Experience{},
-		Total:        0,
+		Videos:       service.NewVideos(videos).Response(),
+		Coordinators: coordinators.Response(),
+		Products:     products.Response(),
+		Experiences:  experiences.Response(),
+		Total:        total,
 	}
 	ctx.JSON(http.StatusOK, res)
 }
@@ -70,4 +153,9 @@ func (h *handler) UpdateVideo(ctx *gin.Context) {
 func (h *handler) DeleteVideo(ctx *gin.Context) {
 	// TODO: 詳細の実装
 	ctx.Status(http.StatusNoContent)
+}
+
+func (h *handler) getVideo(ctx context.Context, videoID string) (*service.Video, error) {
+	// TODO: 詳細の実装
+	return &service.Video{}, nil
 }

--- a/api/internal/gateway/admin/v1/service/experience_test.go
+++ b/api/internal/gateway/admin/v1/service/experience_test.go
@@ -71,39 +71,39 @@ func TestExperienceStatus_Response(t *testing.T) {
 		expect int32
 	}{
 		{
-			name:   "ExperienceStatusUnknown",
-			status: ExperienceStatusUnknown,
-			expect: 0,
-		},
-		{
-			name:   "ExperienceStatusPrivate",
+			name:   "private",
 			status: ExperienceStatusPrivate,
 			expect: 1,
 		},
 		{
-			name:   "ExperienceStatusWaiting",
+			name:   "waiting",
 			status: ExperienceStatusWaiting,
 			expect: 2,
 		},
 		{
-			name:   "ExperienceStatusAccepting",
+			name:   "accepting",
 			status: ExperienceStatusAccepting,
 			expect: 3,
 		},
 		{
-			name:   "ExperienceStatusSoldOut",
+			name:   "sold out",
 			status: ExperienceStatusSoldOut,
 			expect: 4,
 		},
 		{
-			name:   "ExperienceStatusFinished",
+			name:   "finished",
 			status: ExperienceStatusFinished,
 			expect: 5,
 		},
 		{
-			name:   "ExperienceStatusArchived",
+			name:   "archived",
 			status: ExperienceStatusArchived,
 			expect: 6,
+		},
+		{
+			name:   "unknown",
+			status: ExperienceStatusUnknown,
+			expect: 0,
 		},
 	}
 

--- a/api/internal/gateway/admin/v1/service/video.go
+++ b/api/internal/gateway/admin/v1/service/video.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/response"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+)
+
+// VideoStatus - オンデマンド配信状況
+type VideoStatus int32
+
+const (
+	VideoStatusUnknown   VideoStatus = 0
+	VideoStatusPrivate   VideoStatus = 1 // 非公開
+	VideoStatusWaiting   VideoStatus = 2 // 公開前
+	VideoStatusLimited   VideoStatus = 3 // 限定公開
+	VideoStatusPublished VideoStatus = 4 // 公開済み
+)
+
+type Video struct {
+	response.Video
+}
+
+type Videos []*Video
+
+func NewVideoStatus(status entity.VideoStatus) VideoStatus {
+	switch status {
+	case entity.VideoStatusPrivate:
+		return VideoStatusPrivate
+	case entity.VideoStatusWaiting:
+		return VideoStatusWaiting
+	case entity.VideoStatusLimited:
+		return VideoStatusLimited
+	case entity.VideoStatusPublished:
+		return VideoStatusPublished
+	default:
+		return VideoStatusUnknown
+	}
+}
+
+func (s VideoStatus) Response() int32 {
+	return int32(s)
+}
+
+func NewVideo(video *entity.Video) *Video {
+	return &Video{
+		Video: response.Video{
+			ID:            video.ID,
+			CoordinatorID: video.CoordinatorID,
+			ProductIDs:    video.ProductIDs,
+			ExperienceIDs: video.ExperienceIDs,
+			Title:         video.Title,
+			Description:   video.Description,
+			Status:        NewVideoStatus(video.Status).Response(),
+			ThumbnailURL:  video.ThumbnailURL,
+			VideoURL:      video.VideoURL,
+			Public:        video.Public,
+			Limited:       video.Limited,
+			PublishedAt:   video.PublishedAt.Unix(),
+			CreatedAt:     video.CreatedAt.Unix(),
+			UpdatedAt:     video.UpdatedAt.Unix(),
+		},
+	}
+}
+
+func (v *Video) Response() *response.Video {
+	return &v.Video
+}
+
+func NewVideos(videos entity.Videos) Videos {
+	res := make(Videos, len(videos))
+	for i := range videos {
+		res[i] = NewVideo(videos[i])
+	}
+	return res
+}
+
+func (vs Videos) Response() []*response.Video {
+	res := make([]*response.Video, len(vs))
+	for i := range vs {
+		res[i] = vs[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/admin/v1/service/video_test.go
+++ b/api/internal/gateway/admin/v1/service/video_test.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/admin/v1/response"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideoStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status entity.VideoStatus
+		expect VideoStatus
+	}{
+		{
+			name:   "private",
+			status: entity.VideoStatusPrivate,
+			expect: VideoStatusPrivate,
+		},
+		{
+			name:   "waiting",
+			status: entity.VideoStatusWaiting,
+			expect: VideoStatusWaiting,
+		},
+		{
+			name:   "limited",
+			status: entity.VideoStatusLimited,
+			expect: VideoStatusLimited,
+		},
+		{
+			name:   "published",
+			status: entity.VideoStatusPublished,
+			expect: VideoStatusPublished,
+		},
+		{
+			name:   "unknown",
+			status: entity.VideoStatusUnknown,
+			expect: VideoStatusUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NewVideoStatus(tt.status)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideoStatus_Response(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status VideoStatus
+		expect int32
+	}{
+		{
+			name:   "private",
+			status: VideoStatusPrivate,
+			expect: 1,
+		},
+		{
+			name:   "waiting",
+			status: VideoStatusWaiting,
+			expect: 2,
+		},
+		{
+			name:   "limited",
+			status: VideoStatusLimited,
+			expect: 3,
+		},
+		{
+			name:   "published",
+			status: VideoStatusPublished,
+			expect: 4,
+		},
+		{
+			name:   "unknown",
+			status: VideoStatusUnknown,
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.status.Response()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2024, 8, 24, 18, 30, 0, 0)
+
+	tests := []struct {
+		name   string
+		videos entity.Videos
+		expect Videos
+	}{
+		{
+			name: "name",
+			videos: entity.Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        entity.VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: entity.VideoProducts{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: entity.VideoExperiences{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			expect: Videos{
+				{
+					Video: response.Video{
+						ID:            "video-id",
+						CoordinatorID: "coordinator-id",
+						ProductIDs:    []string{"product-id"},
+						ExperienceIDs: []string{"experience-id"},
+						Title:         "じゃがいもの育て方",
+						Description:   "じゃがいもの育て方の動画です。",
+						Status:        int32(VideoStatusPublished),
+						ThumbnailURL:  "https://example.com/thumbnail.jpg",
+						VideoURL:      "https://example.com/video.mp4",
+						Public:        true,
+						Limited:       false,
+						PublishedAt:   now.AddDate(0, 0, -1).Unix(),
+						CreatedAt:     now.Unix(),
+						UpdatedAt:     now.Unix(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NewVideos(tt.videos)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos_Response(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2024, 8, 24, 18, 30, 0, 0)
+
+	tests := []struct {
+		name   string
+		videos Videos
+		expect []*response.Video
+	}{
+		{
+			name: "name",
+			videos: Videos{
+				{
+					Video: response.Video{
+						ID:            "video-id",
+						CoordinatorID: "coordinator-id",
+						ProductIDs:    []string{"product-id"},
+						ExperienceIDs: []string{"experience-id"},
+						Title:         "じゃがいもの育て方",
+						Description:   "じゃがいもの育て方の動画です。",
+						Status:        int32(VideoStatusPublished),
+						ThumbnailURL:  "https://example.com/thumbnail.jpg",
+						VideoURL:      "https://example.com/video.mp4",
+						Public:        true,
+						Limited:       false,
+						PublishedAt:   now.AddDate(0, 0, -1).Unix(),
+						CreatedAt:     now.Unix(),
+						UpdatedAt:     now.Unix(),
+					},
+				},
+			},
+			expect: []*response.Video{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        int32(VideoStatusPublished),
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					PublishedAt:   now.AddDate(0, 0, -1).Unix(),
+					CreatedAt:     now.Unix(),
+					UpdatedAt:     now.Unix(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.videos.Response())
+		})
+	}
+}

--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -137,6 +137,7 @@ type Video interface {
 }
 
 type ListVideosParams struct {
+	Name          string
 	CoordinatorID string
 	Limit         int
 	Offset        int

--- a/api/internal/media/database/mysql/video_test.go
+++ b/api/internal/media/database/mysql/video_test.go
@@ -29,8 +29,11 @@ func TestVideo_List(t *testing.T) {
 
 	videos := make(entity.Videos, 3)
 	videos[0] = testVideo("video-id01", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[0].PublishedAt = now().AddDate(0, 0, -1)
 	videos[1] = testVideo("video-id02", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[1].PublishedAt = now().AddDate(0, 0, -2)
 	videos[2] = testVideo("video-id03", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[2].PublishedAt = now().AddDate(0, -1, 0)
 	err = db.DB.Create(&videos).Error
 	require.NoError(t, err)
 	for _, video := range videos {
@@ -58,13 +61,14 @@ func TestVideo_List(t *testing.T) {
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
 				params: &database.ListVideosParams{
-					CoordinatorID: "",
-					Limit:         1,
+					Name:          "オンデマンド配信",
+					CoordinatorID: "coordinator-id",
+					Limit:         2,
 					Offset:        1,
 				},
 			},
 			want: want{
-				videos: entity.Videos{},
+				videos: videos[1:],
 				err:    nil,
 			},
 		},
@@ -132,13 +136,14 @@ func TestVideo_Count(t *testing.T) {
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
 				params: &database.ListVideosParams{
-					CoordinatorID: "",
+					Name:          "オンデマンド配信",
+					CoordinatorID: "coordinator-id",
 					Limit:         1,
 					Offset:        1,
 				},
 			},
 			want: want{
-				total: 0,
+				total: 3,
 				err:   nil,
 			},
 		},

--- a/api/internal/media/entity/video_experience.go
+++ b/api/internal/media/entity/video_experience.go
@@ -1,6 +1,9 @@
 package entity
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // オンデマンド配信関連体験情報
 type VideoExperience struct {
@@ -12,3 +15,29 @@ type VideoExperience struct {
 }
 
 type VideoExperiences []*VideoExperience
+
+func (es VideoExperiences) ExperienceIDs() []string {
+	res := make([]string, len(es))
+	for i := range es {
+		res[i] = es[i].ExperienceID
+	}
+	return res
+}
+
+func (es VideoExperiences) GroupByVideoID() map[string]VideoExperiences {
+	res := make(map[string]VideoExperiences, len(es))
+	for _, e := range es {
+		if _, ok := res[e.VideoID]; !ok {
+			res[e.VideoID] = make(VideoExperiences, 0, len(es))
+		}
+		res[e.VideoID] = append(res[e.VideoID], e)
+	}
+	return res
+}
+
+func (es VideoExperiences) SortByPriority() VideoExperiences {
+	sort.SliceStable(es, func(i, j int) bool {
+		return es[i].Priority < es[j].Priority
+	})
+	return es
+}

--- a/api/internal/media/entity/video_experience_test.go
+++ b/api/internal/media/entity/video_experience_test.go
@@ -1,0 +1,103 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideoExperiences_ExperienceIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		experiences VideoExperiences
+		expect      []string
+	}{
+		{
+			name: "success",
+			experiences: VideoExperiences{
+				{VideoID: "video-id01", ExperienceID: "experience-id01"},
+				{VideoID: "video-id02", ExperienceID: "experience-id02"},
+				{VideoID: "video-id02", ExperienceID: "experience-id03"},
+			},
+			expect: []string{"experience-id01", "experience-id02", "experience-id03"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.experiences.ExperienceIDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideoExperiences_GroupByVideoID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		experiences VideoExperiences
+		expect      map[string]VideoExperiences
+	}{
+		{
+			name: "success",
+			experiences: VideoExperiences{
+				{VideoID: "video-id01", ExperienceID: "experience-id01"},
+				{VideoID: "video-id02", ExperienceID: "experience-id02"},
+				{VideoID: "video-id02", ExperienceID: "experience-id03"},
+			},
+			expect: map[string]VideoExperiences{
+				"video-id01": {
+					{VideoID: "video-id01", ExperienceID: "experience-id01"},
+				},
+				"video-id02": {
+					{VideoID: "video-id02", ExperienceID: "experience-id02"},
+					{VideoID: "video-id02", ExperienceID: "experience-id03"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.experiences.GroupByVideoID()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideoExperiences_SortByPrority(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		experiences VideoExperiences
+		expect      VideoExperiences
+	}{
+		{
+			name: "success",
+			experiences: VideoExperiences{
+				{VideoID: "video-id01", Priority: 1, ExperienceID: "experience-id01"},
+				{VideoID: "video-id02", Priority: 3, ExperienceID: "experience-id03"},
+				{VideoID: "video-id02", Priority: 2, ExperienceID: "experience-id02"},
+			},
+			expect: VideoExperiences{
+				{VideoID: "video-id01", Priority: 1, ExperienceID: "experience-id01"},
+				{VideoID: "video-id02", Priority: 2, ExperienceID: "experience-id02"},
+				{VideoID: "video-id02", Priority: 3, ExperienceID: "experience-id03"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.experiences.SortByPriority()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/media/entity/video_product.go
+++ b/api/internal/media/entity/video_product.go
@@ -1,6 +1,9 @@
 package entity
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // オンデマンド配信関連商品情報
 type VideoProduct struct {
@@ -12,3 +15,29 @@ type VideoProduct struct {
 }
 
 type VideoProducts []*VideoProduct
+
+func (ps VideoProducts) ProductIDs() []string {
+	res := make([]string, len(ps))
+	for i := range ps {
+		res[i] = ps[i].ProductID
+	}
+	return res
+}
+
+func (ps VideoProducts) GroupByVideoID() map[string]VideoProducts {
+	res := make(map[string]VideoProducts, len(ps))
+	for _, p := range ps {
+		if _, ok := res[p.VideoID]; !ok {
+			res[p.VideoID] = make(VideoProducts, 0, len(ps))
+		}
+		res[p.VideoID] = append(res[p.VideoID], p)
+	}
+	return res
+}
+
+func (ps VideoProducts) SortByPriority() VideoProducts {
+	sort.SliceStable(ps, func(i, j int) bool {
+		return ps[i].Priority < ps[j].Priority
+	})
+	return ps
+}

--- a/api/internal/media/entity/video_product_test.go
+++ b/api/internal/media/entity/video_product_test.go
@@ -1,0 +1,103 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideoProducts_ProductIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		products VideoProducts
+		expect   []string
+	}{
+		{
+			name: "success",
+			products: VideoProducts{
+				{VideoID: "video-id01", ProductID: "product-id01"},
+				{VideoID: "video-id02", ProductID: "product-id02"},
+				{VideoID: "video-id02", ProductID: "product-id03"},
+			},
+			expect: []string{"product-id01", "product-id02", "product-id03"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.products.ProductIDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideoProducts_GroupByVideoID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		products VideoProducts
+		expect   map[string]VideoProducts
+	}{
+		{
+			name: "success",
+			products: VideoProducts{
+				{VideoID: "video-id01", ProductID: "product-id01"},
+				{VideoID: "video-id02", ProductID: "product-id02"},
+				{VideoID: "video-id02", ProductID: "product-id03"},
+			},
+			expect: map[string]VideoProducts{
+				"video-id01": {
+					{VideoID: "video-id01", ProductID: "product-id01"},
+				},
+				"video-id02": {
+					{VideoID: "video-id02", ProductID: "product-id02"},
+					{VideoID: "video-id02", ProductID: "product-id03"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.products.GroupByVideoID()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideoProducts_SortByPrority(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		products VideoProducts
+		expect   VideoProducts
+	}{
+		{
+			name: "success",
+			products: VideoProducts{
+				{VideoID: "video-id01", Priority: 1, ProductID: "product-id01"},
+				{VideoID: "video-id02", Priority: 3, ProductID: "product-id03"},
+				{VideoID: "video-id02", Priority: 2, ProductID: "product-id02"},
+			},
+			expect: VideoProducts{
+				{VideoID: "video-id01", Priority: 1, ProductID: "product-id01"},
+				{VideoID: "video-id02", Priority: 2, ProductID: "product-id02"},
+				{VideoID: "video-id02", Priority: 3, ProductID: "product-id03"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.products.SortByPriority()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/media/entity/video_test.go
+++ b/api/internal/media/entity/video_test.go
@@ -1,0 +1,388 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideo_SetStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		video  *Video
+		expect VideoStatus
+	}{
+		{
+			name: "private",
+			video: &Video{
+				Public:      false,
+				Limited:     false,
+				PublishedAt: now.AddDate(0, 0, -1),
+			},
+			expect: VideoStatusPrivate,
+		},
+		{
+			name: "waiting",
+			video: &Video{
+				Public:      true,
+				Limited:     false,
+				PublishedAt: now.AddDate(0, 0, 1),
+			},
+			expect: VideoStatusWaiting,
+		},
+		{
+			name: "limited",
+			video: &Video{
+				Public:      true,
+				Limited:     true,
+				PublishedAt: now.AddDate(0, 0, -1),
+			},
+			expect: VideoStatusLimited,
+		},
+		{
+			name: "public",
+			video: &Video{
+				Public:      true,
+				Limited:     false,
+				PublishedAt: now.AddDate(0, 0, -1),
+			},
+			expect: VideoStatusPublished,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.video.SetStatus(now)
+			assert.Equal(t, tt.expect, tt.video.Status)
+		})
+	}
+}
+
+func TestVideos_IDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		videos Videos
+		expect []string
+	}{
+		{
+			name: "success",
+			videos: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: []*VideoProduct{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: []*VideoExperience{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			expect: []string{"video-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.videos.IDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos_CoordinatorIDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		videos Videos
+		expect []string
+	}{
+		{
+			name: "success",
+			videos: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: []*VideoProduct{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: []*VideoExperience{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			expect: []string{"coordinator-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.videos.CoordinatorIDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos_ProductIDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		videos Videos
+		expect []string
+	}{
+		{
+			name: "success",
+			videos: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: []*VideoProduct{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: []*VideoExperience{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			expect: []string{"product-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.videos.ProductIDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos_ExperienceIDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		videos Videos
+		expect []string
+	}{
+		{
+			name: "success",
+			videos: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: []*VideoProduct{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: []*VideoExperience{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			expect: []string{"experience-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.videos.ExperienceIDs()
+			assert.ElementsMatch(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestVideos_Fill(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name        string
+		videos      Videos
+		products    map[string]VideoProducts
+		experiences map[string]VideoExperiences
+		expect      Videos
+	}{
+		{
+			name: "success",
+			videos: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusUnknown,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					PublishedAt:   now.AddDate(0, 0, -1),
+					CreatedAt:     now,
+					UpdatedAt:     now,
+				},
+			},
+			products: map[string]VideoProducts{
+				"video-id": {
+					{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+				},
+			},
+			experiences: map[string]VideoExperiences{
+				"video-id": {
+					{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					},
+				},
+			},
+			expect: Videos{
+				{
+					ID:            "video-id",
+					CoordinatorID: "coordinator-id",
+					ProductIDs:    []string{"product-id"},
+					ExperienceIDs: []string{"experience-id"},
+					Title:         "じゃがいもの育て方",
+					Description:   "じゃがいもの育て方の動画です。",
+					Status:        VideoStatusPublished,
+					ThumbnailURL:  "https://example.com/thumbnail.jpg",
+					VideoURL:      "https://example.com/video.mp4",
+					Public:        true,
+					Limited:       false,
+					VideoProducts: []*VideoProduct{{
+						VideoID:   "video-id",
+						ProductID: "product-id",
+						Priority:  1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					}},
+					VideoExperiences: []*VideoExperience{{
+						VideoID:      "video-id",
+						ExperienceID: "experience-id",
+						Priority:     1,
+						CreatedAt:    now,
+						UpdatedAt:    now,
+					}},
+					PublishedAt: now.AddDate(0, 0, -1),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.videos.Fill(tt.products, tt.experiences, now)
+			assert.Equal(t, tt.expect, tt.videos)
+		})
+	}
+}

--- a/api/internal/media/input.go
+++ b/api/internal/media/input.go
@@ -140,6 +140,7 @@ type UpdateBroadcastCommentInput struct {
 }
 
 type ListVideosInput struct {
+	Name          string `validate:""`
 	CoordinatorID string `validate:""`
 	Limit         int64  `validate:"required_without=NoLimit,min=0,max=200"`
 	Offset        int64  `validate:"min=0"`

--- a/api/internal/media/service/service_test.go
+++ b/api/internal/media/service/service_test.go
@@ -49,6 +49,7 @@ type dbMocks struct {
 	Broadcast          *mock_database.MockBroadcast
 	BroadcastComment   *mock_database.MockBroadcastComment
 	BroadcastViewerLog *mock_database.MockBroadcastViewerLog
+	Video              *mock_database.MockVideo
 }
 
 type testOptions struct {
@@ -96,6 +97,7 @@ func newDBMocks(ctrl *gomock.Controller) *dbMocks {
 		Broadcast:          mock_database.NewMockBroadcast(ctrl),
 		BroadcastComment:   mock_database.NewMockBroadcastComment(ctrl),
 		BroadcastViewerLog: mock_database.NewMockBroadcastViewerLog(ctrl),
+		Video:              mock_database.NewMockVideo(ctrl),
 	}
 }
 
@@ -113,6 +115,7 @@ func newService(mocks *mocks, opts ...testOption) *service {
 			Broadcast:          mocks.db.Broadcast,
 			BroadcastComment:   mocks.db.BroadcastComment,
 			BroadcastViewerLog: mocks.db.BroadcastViewerLog,
+			Video:              mocks.db.Video,
 		},
 		Cache:     mocks.cache,
 		Store:     mocks.store,

--- a/api/internal/media/service/video.go
+++ b/api/internal/media/service/video.go
@@ -4,15 +4,38 @@ import (
 	"context"
 
 	"github.com/and-period/furumaru/api/internal/media"
+	"github.com/and-period/furumaru/api/internal/media/database"
 	"github.com/and-period/furumaru/api/internal/media/entity"
+	"golang.org/x/sync/errgroup"
 )
 
 func (s *service) ListVideos(ctx context.Context, in *media.ListVideosInput) (entity.Videos, int64, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return nil, 0, internalError(err)
 	}
-	// TODO: 詳細の実装
-	return entity.Videos{}, 0, nil
+	params := &database.ListVideosParams{
+		Name:          in.Name,
+		CoordinatorID: in.CoordinatorID,
+		Limit:         int(in.Limit),
+		Offset:        int(in.Offset),
+	}
+	var (
+		videos entity.Videos
+		total  int64
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		videos, err = s.db.Video.List(ectx, params)
+		return
+	})
+	eg.Go(func() (err error) {
+		total, err = s.db.Video.Count(ectx, params)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, 0, internalError(err)
+	}
+	return videos, total, nil
 }
 
 func (s *service) GetVideo(ctx context.Context, in *media.GetVideoInput) (*entity.Video, error) {

--- a/infra/mysql/schema/2024082501-media-create-fulltext-index.sql
+++ b/infra/mysql/schema/2024082501-media-create-fulltext-index.sql
@@ -1,0 +1,1 @@
+CREATE FULLTEXT INDEX `ftx_videos` ON `media`.`videos` (`title`, `description`) WITH PARSER ngram;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 複数の体験を一度に取得するための新しいメソッド「multiGetExperiences」を追加しました。
  - 動画へのアクセス制御を実施する「filterAccessVideo」メソッドを追加しました。
  - ページネーション機能を持つ動画リストの取得が可能になりました。
  - 動画管理機能が強化され、動画のステータス、ID、コーディネーターID、商品ID、体験IDを取得する新しいメソッドを追加しました。

- **バグ修正**
  - 動画リストおよびカウント機能の実装を改善し、正しいデータを取得できるようにしました。

- **テスト**
  - 動画および体験の機能を検証するための新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->