### PR TITLE
feat(gateway): 体験関連のファイルアップロードURL取得APIの実装

### DIFF
--- a/api/internal/gateway/admin/v1/handler/uploader.go
+++ b/api/internal/gateway/admin/v1/handler/uploader.go
@@ -23,6 +23,7 @@ func (h *handler) uploadRoutes(rg *gin.RouterGroup) {
 	r.POST("/coordinators/bonus-video", h.CreateCoordinatorBonusVideoUploadURL)
 	r.POST("/experiences/image", h.CreateExperienceImageUploadURL)
 	r.POST("/experiences/video", h.CreateExperienceVideoUploadURL)
+	r.POST("/experiences/promotion-video", h.CreateExperiencePromotionVideoUploadURL)
 	r.POST("/producers/thumbnail", h.CreateProducerThumbnailUploadURL)
 	r.POST("/producers/header", h.CreateProducerHeaderUploadURL)
 	r.POST("/producers/promotion-video", h.CreateProducerPromotionVideoUploadURL)
@@ -100,15 +101,15 @@ func (h *handler) CreateCoordinatorBonusVideoUploadURL(ctx *gin.Context) {
 }
 
 func (h *handler) CreateExperienceImageUploadURL(ctx *gin.Context) {
-	// TODO: 詳細の実装
-	res := &response.UploadURLResponse{}
-	ctx.JSON(http.StatusOK, res)
+	h.getUploadURL(ctx, h.media.GetExperienceMediaImageUploadURL)
 }
 
 func (h *handler) CreateExperienceVideoUploadURL(ctx *gin.Context) {
-	// TODO: 詳細の実装
-	res := &response.UploadURLResponse{}
-	ctx.JSON(http.StatusOK, res)
+	h.getUploadURL(ctx, h.media.GetExperienceMediaVideoUploadURL)
+}
+
+func (h *handler) CreateExperiencePromotionVideoUploadURL(ctx *gin.Context) {
+	h.getUploadURL(ctx, h.media.GetExperiencePromotionVideoUploadURL)
 }
 
 func (h *handler) CreateProducerThumbnailUploadURL(ctx *gin.Context) {
@@ -152,15 +153,11 @@ func (h *handler) CreateScheduleOpeningVideoUploadURL(ctx *gin.Context) {
 }
 
 func (h *handler) CreateVideoThumbnailUploadURL(ctx *gin.Context) {
-	// TODO: 詳細の実装
-	res := &response.UploadURLResponse{}
-	ctx.JSON(http.StatusOK, res)
+	h.getUploadURL(ctx, h.media.GetVideoThumbnailUploadURL)
 }
 
 func (h *handler) CreateVideoFileUploadURL(ctx *gin.Context) {
-	// TODO: 詳細の実装
-	res := &response.UploadURLResponse{}
-	ctx.JSON(http.StatusOK, res)
+	h.getUploadURL(ctx, h.media.GetVideoFileUploadURL)
 }
 
 func (h *handler) getUploadURL(ctx *gin.Context, fn func(context.Context, *media.GenerateUploadURLInput) (*entity.UploadEvent, error)) {

--- a/api/internal/media/entity/regulation.go
+++ b/api/internal/media/entity/regulation.go
@@ -38,6 +38,11 @@ const (
 	ScheduleThumbnailPath         = "schedules/thumbnail"          // 開催スケジュールサムネイル
 	ScheduleImagePath             = "schedules/image"              // 開催スケジュール蓋絵
 	ScheduleOpeningVideoPath      = "schedules/opening-video"      // 開催スケジュールオープニング動画
+	ExperienceMediaImagePath      = "experiences/media/image"      // 体験メディア(画像)
+	ExperienceMediaVideoPath      = "experiences/media/video"      // 体験メディア(映像)
+	ExperiencePromotionVideoPath  = "experiences/promotion-video"  // 体験紹介映像
+	VideoThumbnailPath            = "videos/thumbnail"             // オンデマンド配信サムネイル画像
+	VideoMP4Path                  = "videos/mp4"                   // オンデマンド配信動画(mp4)
 )
 
 // ConversionType - ファイルの変換種別
@@ -149,6 +154,33 @@ var (
 		MaxSize: 200 << 20, // 200MB
 		Formats: set.New("video/mp4"),
 		dir:     ScheduleOpeningVideoPath,
+	}
+	// 体験関連
+	ExperienceMediaImageRegulation = &Regulation{
+		MaxSize: 10 << 20, // 10MB
+		Formats: set.New("image/png", "image/jpeg"),
+		dir:     ExperienceMediaImagePath,
+	}
+	ExperienceMediaVideoRegulation = &Regulation{
+		MaxSize: 200 << 20, // 200MB
+		Formats: set.New("video/mp4"),
+		dir:     ExperienceMediaVideoPath,
+	}
+	ExperiencePromotionVideoRegulation = &Regulation{
+		MaxSize: 200 << 20, // 200MB
+		Formats: set.New("video/mp4"),
+		dir:     ExperiencePromotionVideoPath,
+	}
+	// オンデマンド配信関連
+	VideoThumbnailRegulation = &Regulation{
+		MaxSize: 10 << 20, // 10MB
+		Formats: set.New("image/png", "image/jpeg"),
+		dir:     VideoThumbnailPath,
+	}
+	VideoMP4Regulation = &Regulation{
+		MaxSize: 3 << 30, // 3GB
+		Formats: set.New("video/mp4"),
+		dir:     VideoMP4Path,
 	}
 )
 

--- a/api/internal/media/service.go
+++ b/api/internal/media/service.go
@@ -64,4 +64,8 @@ type Service interface {
 	GetScheduleThumbnailUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)    // アイコン画像アップロード用URLの生成
 	GetScheduleImageUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)        // 蓋絵画像アップロード用URLの生成
 	GetScheduleOpeningVideoUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error) // オープニング動画アップロード用URLの生成
+	// 体験
+	GetExperienceMediaImageUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)     // メディア(画像)アップロード用URLの生成
+	GetExperienceMediaVideoUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)     // メディア(映像)アップロード用URLの生成
+	GetExperiencePromotionVideoUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error) // 紹介映像アップロード用URLの生成
 }

--- a/api/internal/media/service/upload.go
+++ b/api/internal/media/service/upload.go
@@ -48,19 +48,11 @@ func (s *service) GetBroadcastLiveMP4UploadURL(ctx context.Context, in *media.Ge
  * オンデマンド配信関連
  */
 func (s *service) GetVideoThumbnailUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
-	if err := s.validator.Struct(in); err != nil {
-		return nil, internalError(err)
-	}
-	// TODO: 詳細の実装
-	return &entity.UploadEvent{}, nil
+	return s.generateUploadURL(ctx, in, entity.VideoThumbnailRegulation)
 }
 
 func (s *service) GetVideoFileUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
-	if err := s.validator.Struct(in); err != nil {
-		return nil, internalError(err)
-	}
-	// TODO: 詳細の実装
-	return &entity.UploadEvent{}, nil
+	return s.generateUploadURL(ctx, in, entity.VideoMP4Regulation)
 }
 
 /**
@@ -141,6 +133,21 @@ func (s *service) GetScheduleImageUploadURL(ctx context.Context, in *media.Gener
 
 func (s *service) GetScheduleOpeningVideoUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
 	return s.generateUploadURL(ctx, in, entity.ScheduleOpeningVideoRegulation)
+}
+
+/**
+ * 体験関連
+ */
+func (s *service) GetExperienceMediaImageUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
+	return s.generateUploadURL(ctx, in, entity.ExperienceMediaImageRegulation)
+}
+
+func (s *service) GetExperienceMediaVideoUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
+	return s.generateUploadURL(ctx, in, entity.ExperienceMediaVideoRegulation)
+}
+
+func (s *service) GetExperiencePromotionVideoUploadURL(ctx context.Context, in *media.GenerateUploadURLInput) (*entity.UploadEvent, error) {
+	return s.generateUploadURL(ctx, in, entity.ExperiencePromotionVideoRegulation)
 }
 
 /**

--- a/api/internal/media/service/upload_test.go
+++ b/api/internal/media/service/upload_test.go
@@ -194,8 +194,10 @@ func TestGetVideoThumbnailUploadURL(t *testing.T) {
 		expect error
 	}{
 		{
-			name:  "success",
-			setup: func(ctx context.Context, mocks *mocks) {},
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				generateUploadURLMocks(mocks, t, entity.VideoThumbnailPath, "png", nil)
+			},
 			input: &media.GenerateUploadURLInput{
 				FileType: "image/png",
 			},
@@ -219,8 +221,10 @@ func TestGetVideoFileUploadURL(t *testing.T) {
 		expect error
 	}{
 		{
-			name:  "success",
-			setup: func(ctx context.Context, mocks *mocks) {},
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				generateUploadURLMocks(mocks, t, entity.VideoMP4Path, "mp4", nil)
+			},
 			input: &media.GenerateUploadURLInput{
 				FileType: "video/mp4",
 			},
@@ -650,6 +654,87 @@ func TestGetScheduleOpeningVideoUploadURL(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
 			_, err := service.GetScheduleOpeningVideoUploadURL(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expect)
+		}))
+	}
+}
+
+func TestGetExperienceMediaImageUploadURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, mocks *mocks)
+		input  *media.GenerateUploadURLInput
+		expect error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				generateUploadURLMocks(mocks, t, entity.ExperienceMediaImagePath, "png", nil)
+			},
+			input: &media.GenerateUploadURLInput{
+				FileType: "image/png",
+			},
+			expect: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			_, err := service.GetExperienceMediaImageUploadURL(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expect)
+		}))
+	}
+}
+
+func TestGetExperienceMediaVideoUploadURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, mocks *mocks)
+		input  *media.GenerateUploadURLInput
+		expect error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				generateUploadURLMocks(mocks, t, entity.ExperienceMediaVideoPath, "mp4", nil)
+			},
+			input: &media.GenerateUploadURLInput{
+				FileType: "video/mp4",
+			},
+			expect: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			_, err := service.GetExperienceMediaVideoUploadURL(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expect)
+		}))
+	}
+}
+
+func TestGetExperiencePromotionVideoUploadURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, mocks *mocks)
+		input  *media.GenerateUploadURLInput
+		expect error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				generateUploadURLMocks(mocks, t, entity.ExperiencePromotionVideoPath, "mp4", nil)
+			},
+			input: &media.GenerateUploadURLInput{
+				FileType: "video/mp4",
+			},
+			expect: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			_, err := service.GetExperiencePromotionVideoUploadURL(ctx, tt.input)
 			assert.ErrorIs(t, err, tt.expect)
 		}))
 	}

--- a/docs/swagger/admin/openapi.yaml
+++ b/docs/swagger/admin/openapi.yaml
@@ -261,6 +261,8 @@ paths:
     $ref: './paths/v1/upload/experiences/image.yaml'
   /v1/upload/experiences/video:
     $ref: './paths/v1/upload/experiences/video.yaml'
+  /v1/upload/experiences/promotion-video:
+    $ref: './paths/v1/upload/experiences/promotion-video.yaml'
   /v1/upload/producers/header:
     $ref: './paths/v1/upload/producers/header.yaml'
   /v1/upload/producers/thumbnail:

--- a/docs/swagger/admin/paths/v1/upload/experiences/promotion-video.yaml
+++ b/docs/swagger/admin/paths/v1/upload/experiences/promotion-video.yaml
@@ -1,0 +1,26 @@
+post:
+  summary: 体験紹介動画アップロード用URL取得
+  operationId: v1GetExperiencePromotionVideoUploadUrl
+  tags:
+  - Experience
+  security:
+  - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../../openapi.yaml#/components/schemas/v1GetUploadUrlRequest'
+  responses:
+    200:
+      description: 成功
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/v1UploadUrlResponse'
+    400:
+      description: バリデーションエラー
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -12660,6 +12660,46 @@ export const ExperienceApiAxiosParamCreator = function (configuration?: Configur
         },
         /**
          * 
+         * @summary 体験紹介動画アップロード用URL取得
+         * @param {GetUploadUrlRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        v1GetExperiencePromotionVideoUploadUrl: async (body: GetUploadUrlRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'body' is not null or undefined
+            assertParamExists('v1GetExperiencePromotionVideoUploadUrl', 'body', body)
+            const localVarPath = `/v1/upload/experiences/promotion-video`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary 体験動画アップロード用URL取得
          * @param {GetUploadUrlRequest} body 
          * @param {*} [options] Override http request option.
@@ -12860,6 +12900,19 @@ export const ExperienceApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary 体験紹介動画アップロード用URL取得
+         * @param {GetUploadUrlRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async v1GetExperiencePromotionVideoUploadUrl(body: GetUploadUrlRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UploadUrlResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.v1GetExperiencePromotionVideoUploadUrl(body, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ExperienceApi.v1GetExperiencePromotionVideoUploadUrl']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @summary 体験動画アップロード用URL取得
          * @param {GetUploadUrlRequest} body 
          * @param {*} [options] Override http request option.
@@ -12953,6 +13006,16 @@ export const ExperienceApiFactory = function (configuration?: Configuration, bas
         },
         /**
          * 
+         * @summary 体験紹介動画アップロード用URL取得
+         * @param {GetUploadUrlRequest} body 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        v1GetExperiencePromotionVideoUploadUrl(body: GetUploadUrlRequest, options?: RawAxiosRequestConfig): AxiosPromise<UploadUrlResponse> {
+            return localVarFp.v1GetExperiencePromotionVideoUploadUrl(body, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary 体験動画アップロード用URL取得
          * @param {GetUploadUrlRequest} body 
          * @param {*} [options] Override http request option.
@@ -13041,6 +13104,18 @@ export class ExperienceApi extends BaseAPI {
      */
     public v1GetExperienceImageUploadUrl(body: GetUploadUrlRequest, options?: RawAxiosRequestConfig) {
         return ExperienceApiFp(this.configuration).v1GetExperienceImageUploadUrl(body, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 体験紹介動画アップロード用URL取得
+     * @param {GetUploadUrlRequest} body 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ExperienceApi
+     */
+    public v1GetExperiencePromotionVideoUploadUrl(body: GetUploadUrlRequest, options?: RawAxiosRequestConfig) {
+        return ExperienceApiFp(this.configuration).v1GetExperiencePromotionVideoUploadUrl(body, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- プロモーション動画をアップロードするための新しいエンドポイントを追加しました。これにより、ユーザーは体験に関連するプロモーション動画のアップロードURLを取得できます。
	- さまざまなメディアタイプに対応するアップロードURL生成のための新しいメソッドを追加しました。

- **バグ修正**
	- 既存のアップロードメソッドの改善を行い、コードの可読性と効率を向上させました。

- **テスト**
	- 新しいメディアタイプに対するアップロードURL生成のテストを追加し、テストスイートの堅牢性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->