### PR TITLE
fix(docs): 体験関連のフィールド追加分をAPI Docsにも反映

### DIFF
--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -650,7 +650,7 @@ type CreateExperienceInput struct {
 	PricePreschool        int64                    `validate:"min=0"`
 	PriceSenior           int64                    `validate:"min=0"`
 	RecommendedPoints     []string                 `validate:"max=3,dive,max=128"`
-	PromotionVideoURL     string                   `validate:"required,url"`
+	PromotionVideoURL     string                   `validate:"omitempty,url"`
 	HostPostalCode        string                   `validate:"required,max=16,numeric"`
 	HostPrefectureCode    int32                    `validate:"required"`
 	HostCity              string                   `validate:"required,max=32"`
@@ -679,7 +679,7 @@ type UpdateExperienceInput struct {
 	PricePreschool        int64                    `validate:"min=0"`
 	PriceSenior           int64                    `validate:"min=0"`
 	RecommendedPoints     []string                 `validate:"max=3,dive,max=128"`
-	PromotionVideoURL     string                   `validate:"required,url"`
+	PromotionVideoURL     string                   `validate:"omitempty,url"`
 	HostPostalCode        string                   `validate:"required,max=16,numeric"`
 	HostPrefectureCode    int32                    `validate:"required"`
 	HostCity              string                   `validate:"required,max=32"`

--- a/docs/swagger/admin/components/schemas/entity/experience.yaml
+++ b/docs/swagger/admin/components/schemas/entity/experience.yaml
@@ -71,6 +71,9 @@ experience:
     recommendedPoint3:
       type: string
       description: おすすめポイント3
+    promotionVideoUrl:
+      type: string
+      description: 紹介動画URL
     hostPostalCode:
       type: string
       description: 開催地（郵便番号）
@@ -118,6 +121,10 @@ experience:
   - priceElementarySchool
   - pricePreschool
   - priceSenior
+  - recommendedPoint1
+  - recommendedPoint2
+  - recommendedPoint3
+  - promotionVideoUrl
   - hostPostalCode
   - hostPrefectureCode
   - hostCity
@@ -148,6 +155,7 @@ experience:
     recommendedPoint1: '新鮮なじゃがいもを堀ります'
     recommendedPoint2: 'じゃがいもの美味しさを体験'
     recommendedPoint3: '楽しい体験ができます'
+    promotionVideoUrl: 'https://example.com/promotion.mp4'
     hostPostalCode: '1600023'
     hostPrefectureCode: '13'
     hostCity: '新宿区'

--- a/docs/swagger/admin/components/schemas/v1/experience.request.yaml
+++ b/docs/swagger/admin/components/schemas/v1/experience.request.yaml
@@ -66,6 +66,9 @@ createExperienceRequest:
     recommendedPoint3:
       type: string
       description: おすすめポイント1(128文字まで)
+    promotionVideoUrl:
+      type: string
+      description: 紹介動画URL
     hostPostalCode:
       type: string
       description: 郵便番号(ハイフンなし)
@@ -106,6 +109,7 @@ createExperienceRequest:
   - recommendedPoint1
   - recommendedPoint2
   - recommendedPoint3
+  - promotionVideoUrl
   - hostPostalCode
   - hostPrefectureCode
   - hostCity
@@ -134,6 +138,7 @@ createExperienceRequest:
     recommendedPoint1: '新鮮なじゃがいもを収穫'
     recommendedPoint2: '新鮮なじゃがいもを収穫'
     recommendedPoint3: '新鮮なじゃがいもを収穫'
+    promotionVideoUrl: 'https://example.com/video.mp4'
     hostPostalCode: '1000014'
     hostPrefectureCode: 13
     hostCity: '東京都'
@@ -203,6 +208,9 @@ updateExperienceRequest:
     recommendedPoint3:
       type: string
       description: おすすめポイント1(128文字まで)
+    promotionVideoUrl:
+      type: string
+      description: 紹介動画URL
     hostPostalCode:
       type: string
       description: 郵便番号(ハイフンなし)
@@ -241,6 +249,7 @@ updateExperienceRequest:
   - recommendedPoint1
   - recommendedPoint2
   - recommendedPoint3
+  - promotionVideoUrl
   - hostPostalCode
   - hostPrefectureCode
   - hostCity
@@ -267,6 +276,7 @@ updateExperienceRequest:
     recommendedPoint1: '新鮮なじゃがいもを収穫'
     recommendedPoint2: '新鮮なじゃがいもを収穫'
     recommendedPoint3: '新鮮なじゃがいもを収穫'
+    promotionVideoUrl: 'https://example.com/video.mp4'
     hostPostalCode: '1000014'
     hostPrefectureCode: 13
     hostCity: '東京都'

--- a/docs/swagger/admin/components/schemas/v1/experience.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/experience.response.yaml
@@ -36,6 +36,7 @@ experienceResponse:
       recommendedPoint1: '新鮮なじゃがいもを堀ります'
       recommendedPoint2: 'じゃがいもの美味しさを体験'
       recommendedPoint3: '楽しい体験ができます'
+      promotionVideoUrl: 'https://example.com/promotion.mp4'
       hostPostalCode: '1000014'
       hostPrefectureCode: 13
       hostCity: '東京都'
@@ -155,6 +156,7 @@ experiencesResponse:
       recommendedPoint1: '新鮮なじゃがいもを堀ります'
       recommendedPoint2: 'じゃがいもの美味しさを体験'
       recommendedPoint3: '楽しい体験ができます'
+      promotionVideoUrl: 'https://example.com/promotion.mp4'
       hostPostalCode: '1000014'
       hostPrefectureCode: 13
       hostCity: '東京都'

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -1614,6 +1614,12 @@ export interface CreateExperienceRequest {
      */
     'recommendedPoint3': string;
     /**
+     * 紹介動画URL
+     * @type {string}
+     * @memberof CreateExperienceRequest
+     */
+    'promotionVideoUrl': string;
+    /**
      * 郵便番号(ハイフンなし)
      * @type {string}
      * @memberof CreateExperienceRequest
@@ -2529,19 +2535,25 @@ export interface Experience {
      * @type {string}
      * @memberof Experience
      */
-    'recommendedPoint1'?: string;
+    'recommendedPoint1': string;
     /**
      * おすすめポイント2
      * @type {string}
      * @memberof Experience
      */
-    'recommendedPoint2'?: string;
+    'recommendedPoint2': string;
     /**
      * おすすめポイント3
      * @type {string}
      * @memberof Experience
      */
-    'recommendedPoint3'?: string;
+    'recommendedPoint3': string;
+    /**
+     * 紹介動画URL
+     * @type {string}
+     * @memberof Experience
+     */
+    'promotionVideoUrl': string;
     /**
      * 開催地（郵便番号）
      * @type {string}
@@ -6314,6 +6326,12 @@ export interface UpdateExperienceRequest {
      * @memberof UpdateExperienceRequest
      */
     'recommendedPoint3': string;
+    /**
+     * 紹介動画URL
+     * @type {string}
+     * @memberof UpdateExperienceRequest
+     */
+    'promotionVideoUrl': string;
     /**
      * 郵便番号(ハイフンなし)
      * @type {string}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 経験の作成および更新リクエストにプロモーション動画URLを追加しました。これにより、プロモーションコンテンツを経験にリンクできるようになります。
  - 既存の推奨ポイントフィールド（`recommendedPoint1`、`recommendedPoint2`、`recommendedPoint3`）が必須となり、データの整合性が強化されました。

- **バグ修正**
  - プロモーション動画URLフィールドがオプションになり、提供されない場合でもバリデーションエラーが発生しなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->