### PR TITLE
feat(media): オンデマンド配信一覧取得メソッドの改修

### DIFF
--- a/api/internal/gateway/admin/v1/handler/video.go
+++ b/api/internal/gateway/admin/v1/handler/video.go
@@ -65,11 +65,11 @@ func (h *handler) ListVideos(ctx *gin.Context) {
 	}
 
 	in := &media.ListVideosInput{
-		Name:          util.GetQuery(ctx, "name", ""),
-		CoordinatorID: util.GetQuery(ctx, "coordinatorId", ""),
-		Limit:         limit,
-		Offset:        offset,
-		NoLimit:       false,
+		Name:           util.GetQuery(ctx, "name", ""),
+		CoordinatorID:  util.GetQuery(ctx, "coordinatorId", ""),
+		ExcludeDeleted: true,
+		Limit:          limit,
+		Offset:         offset,
 	}
 	videos, total, err := h.media.ListVideos(ctx, in)
 	if err != nil {

--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -137,10 +137,15 @@ type Video interface {
 }
 
 type ListVideosParams struct {
-	Name          string
-	CoordinatorID string
-	Limit         int
-	Offset        int
+	Name                  string
+	CoordinatorID         string
+	OnlyPublished         bool
+	OnlyDisplayProduct    bool
+	OnlyDisplayExperience bool
+	ExcludeLimited        bool
+	ExcludeDeleted        bool
+	Limit                 int
+	Offset                int
 }
 
 type UpdateVideoParams struct {

--- a/api/internal/media/input.go
+++ b/api/internal/media/input.go
@@ -140,11 +140,16 @@ type UpdateBroadcastCommentInput struct {
 }
 
 type ListVideosInput struct {
-	Name          string `validate:""`
-	CoordinatorID string `validate:""`
-	Limit         int64  `validate:"required_without=NoLimit,min=0,max=200"`
-	Offset        int64  `validate:"min=0"`
-	NoLimit       bool   `validate:""`
+	Name                  string `validate:""`
+	CoordinatorID         string `validate:""`
+	OnlyPublished         bool   `validate:""`
+	OnlyDisplayProduct    bool   `validate:""`
+	OnlyDisplayExperience bool   `validate:""`
+	ExcludeLimited        bool   `validate:""`
+	ExcludeDeleted        bool   `validate:""`
+	Limit                 int64  `validate:"required_without=NoLimit,min=0,max=200"`
+	Offset                int64  `validate:"min=0"`
+	NoLimit               bool   `validate:""`
 }
 
 type GetVideoInput struct {

--- a/api/internal/media/service/video.go
+++ b/api/internal/media/service/video.go
@@ -19,10 +19,15 @@ func (s *service) ListVideos(ctx context.Context, in *media.ListVideosInput) (en
 		return nil, 0, internalError(err)
 	}
 	params := &database.ListVideosParams{
-		Name:          in.Name,
-		CoordinatorID: in.CoordinatorID,
-		Limit:         int(in.Limit),
-		Offset:        int(in.Offset),
+		Name:                  in.Name,
+		CoordinatorID:         in.CoordinatorID,
+		OnlyPublished:         in.OnlyPublished,
+		OnlyDisplayProduct:    in.OnlyDisplayProduct,
+		OnlyDisplayExperience: in.OnlyDisplayExperience,
+		ExcludeLimited:        in.ExcludeLimited,
+		ExcludeDeleted:        in.ExcludeDeleted,
+		Limit:                 int(in.Limit),
+		Offset:                int(in.Offset),
 	}
 	var (
 		videos entity.Videos

--- a/api/internal/media/service/video_test.go
+++ b/api/internal/media/service/video_test.go
@@ -22,10 +22,15 @@ func TestListVideos(t *testing.T) {
 
 	now := jst.Date(2023, 10, 20, 18, 30, 0, 0)
 	params := &database.ListVideosParams{
-		Name:          "じゃがいも収穫",
-		CoordinatorID: "coordinator-id",
-		Limit:         20,
-		Offset:        0,
+		Name:                  "じゃがいも収穫",
+		CoordinatorID:         "coordinator-id",
+		OnlyPublished:         true,
+		OnlyDisplayProduct:    false,
+		OnlyDisplayExperience: false,
+		ExcludeLimited:        false,
+		ExcludeDeleted:        true,
+		Limit:                 20,
+		Offset:                0,
 	}
 	videos := entity.Videos{
 		{
@@ -75,10 +80,16 @@ func TestListVideos(t *testing.T) {
 				mocks.db.Video.EXPECT().Count(gomock.Any(), params).Return(int64(1), nil)
 			},
 			input: &media.ListVideosInput{
-				Name:          "じゃがいも収穫",
-				CoordinatorID: "coordinator-id",
-				Limit:         20,
-				Offset:        0,
+				Name:                  "じゃがいも収穫",
+				CoordinatorID:         "coordinator-id",
+				OnlyPublished:         true,
+				OnlyDisplayProduct:    false,
+				OnlyDisplayExperience: false,
+				ExcludeLimited:        false,
+				ExcludeDeleted:        true,
+				Limit:                 20,
+				Offset:                0,
+				NoLimit:               false,
 			},
 			expect:      videos,
 			expectTotal: 1,
@@ -99,10 +110,15 @@ func TestListVideos(t *testing.T) {
 				mocks.db.Video.EXPECT().Count(gomock.Any(), params).Return(int64(1), nil)
 			},
 			input: &media.ListVideosInput{
-				Name:          "じゃがいも収穫",
-				CoordinatorID: "coordinator-id",
-				Limit:         20,
-				Offset:        0,
+				Name:                  "じゃがいも収穫",
+				CoordinatorID:         "coordinator-id",
+				OnlyPublished:         true,
+				OnlyDisplayProduct:    false,
+				OnlyDisplayExperience: false,
+				ExcludeLimited:        false,
+				ExcludeDeleted:        true,
+				Limit:                 20,
+				Offset:                0,
 			},
 			expect:      nil,
 			expectTotal: 0,
@@ -115,10 +131,15 @@ func TestListVideos(t *testing.T) {
 				mocks.db.Video.EXPECT().Count(gomock.Any(), params).Return(int64(0), assert.AnError)
 			},
 			input: &media.ListVideosInput{
-				Name:          "じゃがいも収穫",
-				CoordinatorID: "coordinator-id",
-				Limit:         20,
-				Offset:        0,
+				Name:                  "じゃがいも収穫",
+				CoordinatorID:         "coordinator-id",
+				OnlyPublished:         true,
+				OnlyDisplayProduct:    false,
+				OnlyDisplayExperience: false,
+				ExcludeLimited:        false,
+				ExcludeDeleted:        true,
+				Limit:                 20,
+				Offset:                0,
 			},
 			expect:      nil,
 			expectTotal: 0,


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 動画リストの取得において、削除済み動画を除外する新しいフィルタリングオプションを追加しました。
  - 動画の公開状態や表示条件に基づく詳細なフィルタリングが可能になりました。

- **バグ修正**
  - 動画リストの取得ロジックを改善し、より正確な結果を提供します。

- **テスト**
  - 新しいフィルタリングオプションに対応するため、動画リスト取得のテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->