### PR TITLE
feat(media): オンデマンド配信視聴ログ機能の実装

### DIFF
--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -26,6 +26,7 @@ type Database struct {
 	BroadcastViewerLog BroadcastViewerLog
 	Video              Video
 	VideoComment       VideoComment
+	VideoViewerLog     VideoViewerLog
 }
 
 type Broadcast interface {
@@ -173,6 +174,25 @@ type ListVideoCommentsParams struct {
 
 type UpdateVideoCommentParams struct {
 	Disabled bool
+}
+
+type VideoViewerLog interface {
+	Create(ctx context.Context, log *entity.VideoViewerLog) error
+	GetTotal(ctx context.Context, params *GetVideoTotalViewersParams) (int64, error)
+	Aggregate(ctx context.Context, params *AggregateVideoViewerLogsParams) (entity.AggregatedVideoViewerLogs, error)
+}
+
+type GetVideoTotalViewersParams struct {
+	VideoID      string
+	CreatedAtGte time.Time
+	CreatedAtLt  time.Time
+}
+
+type AggregateVideoViewerLogsParams struct {
+	VideoID      string
+	Interval     entity.AggregateVideoViewerLogInterval
+	CreatedAtGte time.Time
+	CreatedAtLt  time.Time
 }
 
 type Error struct {

--- a/api/internal/media/database/mysql/mysql.go
+++ b/api/internal/media/database/mysql/mysql.go
@@ -18,6 +18,7 @@ func NewDatabase(db *mysql.Client) *database.Database {
 		BroadcastViewerLog: newBroadcastViewerLog(db),
 		Video:              newVideo(db),
 		VideoComment:       newVideoComment(db),
+		VideoViewerLog:     newVideoViewerLog(db),
 	}
 }
 

--- a/api/internal/media/database/mysql/mysql_test.go
+++ b/api/internal/media/database/mysql/mysql_test.go
@@ -54,6 +54,8 @@ func deleteAll(ctx context.Context) error {
 		broadcastViewerLogTable,
 		broadcastCommentTable,
 		broadcastTable,
+		videoViewerLogTable,
+		videoCommentTable,
 		videoProductTable,
 		videoExperienceTable,
 		videoTable,

--- a/api/internal/media/database/mysql/video_viewer_log.go
+++ b/api/internal/media/database/mysql/video_viewer_log.go
@@ -1,0 +1,104 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/media/database"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/and-period/furumaru/api/pkg/mysql"
+)
+
+const videoViewerLogTable = "video_viewer_logs"
+
+type videoViewerLog struct {
+	db  *mysql.Client
+	now func() time.Time
+}
+
+func newVideoViewerLog(db *mysql.Client) database.VideoViewerLog {
+	return &videoViewerLog{
+		db:  db,
+		now: jst.Now,
+	}
+}
+
+func (l *videoViewerLog) Create(ctx context.Context, log *entity.VideoViewerLog) error {
+	now := l.now()
+	log.CreatedAt, log.UpdatedAt = now, now
+
+	err := l.db.DB.WithContext(ctx).Table(videoViewerLogTable).Create(&log).Error
+	return dbError(err)
+}
+
+func (l *videoViewerLog) GetTotal(ctx context.Context, params *database.GetVideoTotalViewersParams) (int64, error) {
+	var total int64
+
+	const field = "COUNT(DISTINCT(session_id)) AS total"
+	stmt := l.db.Statement(ctx, l.db.DB, videoViewerLogTable, field).
+		Where("video_id = ?", params.VideoID).
+		Where("user_agent NOT IN (?)", entity.ExcludeUserAgentLogs)
+	if !params.CreatedAtGte.IsZero() {
+		stmt = stmt.Where("created_at >= ?", params.CreatedAtGte)
+	}
+	if !params.CreatedAtLt.IsZero() {
+		stmt = stmt.Where("created_at < ?", params.CreatedAtLt)
+	}
+
+	err := stmt.Count(&total).Error
+	return total, dbError(err)
+}
+
+func (l *videoViewerLog) Aggregate(
+	ctx context.Context, params *database.AggregateVideoViewerLogsParams,
+) (entity.AggregatedVideoViewerLogs, error) {
+	var logs internalAggregatedVideoViewerLogs
+
+	fields := []string{
+		"video_id",
+		fmt.Sprintf("DATE_FORMAT(created_at, '%s') AS reported_at", params.Interval),
+		"COUNT(DISTINCT(session_id)) AS total",
+	}
+	stmt := l.db.Statement(ctx, l.db.DB, videoViewerLogTable, fields...).
+		Where("video_id = ?", params.VideoID).
+		Where("user_agent NOT IN (?)", entity.ExcludeUserAgentLogs)
+	if !params.CreatedAtGte.IsZero() {
+		stmt = stmt.Where("created_at >= ?", params.CreatedAtGte)
+	}
+	if !params.CreatedAtLt.IsZero() {
+		stmt = stmt.Where("created_at < ?", params.CreatedAtLt)
+	}
+	stmt = stmt.Group("video_id, reported_at").Order("reported_at ASC")
+
+	if err := stmt.Scan(&logs).Error; err != nil {
+		return nil, dbError(err)
+	}
+	return logs.Entities(), nil
+}
+
+type internalAggregatedVideoViewerLog struct {
+	VideoID    string
+	ReportedAt string
+	Total      int64
+}
+
+type internalAggregatedVideoViewerLogs []*internalAggregatedVideoViewerLog
+
+func (l *internalAggregatedVideoViewerLog) Entity() *entity.AggregatedVideoViewerLog {
+	reportedAt, _ := jst.Parse("2006-01-02 15:04:05", l.ReportedAt)
+	return &entity.AggregatedVideoViewerLog{
+		VideoID:    l.VideoID,
+		ReportedAt: reportedAt,
+		Total:      l.Total,
+	}
+}
+
+func (ls internalAggregatedVideoViewerLogs) Entities() entity.AggregatedVideoViewerLogs {
+	res := make(entity.AggregatedVideoViewerLogs, len(ls))
+	for i := range ls {
+		res[i] = ls[i].Entity()
+	}
+	return res
+}

--- a/api/internal/media/database/mysql/video_viewer_log_test.go
+++ b/api/internal/media/database/mysql/video_viewer_log_test.go
@@ -1,0 +1,266 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/media/database"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/and-period/furumaru/api/pkg/mysql"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVideoViewerLog(t *testing.T) {
+	assert.NotNil(t, newVideoViewerLog(nil))
+}
+
+func TestVideoViewerLog_Create(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	video := testVideo("video-id", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	err = db.DB.Create(&video).Error
+	require.NoError(t, err)
+
+	type args struct {
+		log *entity.VideoViewerLog
+	}
+	type want struct {
+		err error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				log: testVideoViewerLog("video-id", "session-id", "user-id", now()),
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		{
+			name: "already exists",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
+				log := testVideoViewerLog("video-id", "session-id", "user-id", now())
+				err := db.DB.Create(&log).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				log: testVideoViewerLog("video-id", "session-id", "user-id", now()),
+			},
+			want: want{
+				err: database.ErrAlreadyExists,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := delete(ctx, videoViewerLogTable)
+			require.NoError(t, err)
+
+			tt.setup(ctx, t, db)
+
+			db := &videoViewerLog{db: db, now: now}
+			err = db.Create(ctx, tt.args.log)
+			assert.ErrorIs(t, err, tt.want.err)
+		})
+	}
+}
+
+func TestVideoViewerLog_GetTotal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	video := testVideo("video-id", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	err = db.DB.Create(&video).Error
+	require.NoError(t, err)
+
+	logs := make(entity.VideoViewerLogs, 4)
+	logs[0] = testVideoViewerLog("video-id", "session-id01", "user-id01", now())
+	logs[1] = testVideoViewerLog("video-id", "session-id01", "user-id01", now().Add(1*time.Minute))
+	logs[2] = testVideoViewerLog("video-id", "session-id02", "user-id02", now())
+	logs[3] = testVideoViewerLog("video-id", "session-id02", "user-id02", now().Add(1*time.Minute))
+	logs[3].UserAgent = entity.ExcludeUserAgentLogs[0]
+	for _, log := range logs {
+		err = db.DB.Create(&log).Error
+		require.NoError(t, err)
+	}
+
+	type args struct {
+		params *database.GetVideoTotalViewersParams
+	}
+	type want struct {
+		total int64
+		err   error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				params: &database.GetVideoTotalViewersParams{
+					VideoID:      "video-id",
+					CreatedAtGte: now().Add(-time.Minute),
+					CreatedAtLt:  now().Add(time.Hour),
+				},
+			},
+			want: want{
+				total: 2,
+				err:   nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &videoViewerLog{db: db, now: now}
+			total, err := db.GetTotal(ctx, tt.args.params)
+			assert.ErrorIs(t, err, tt.want.err)
+			assert.Equal(t, tt.want.total, total)
+		})
+	}
+}
+
+func TestVideoViewerLog_Aggregate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	video := testVideo("video-id", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	err = db.DB.Create(&video).Error
+	require.NoError(t, err)
+
+	logs := make(entity.VideoViewerLogs, 4)
+	logs[0] = testVideoViewerLog("video-id", "session-id01", "user-id01", now())
+	logs[1] = testVideoViewerLog("video-id", "session-id01", "user-id01", now().Add(1*time.Minute))
+	logs[2] = testVideoViewerLog("video-id", "session-id02", "user-id02", now())
+	logs[3] = testVideoViewerLog("video-id", "session-id02", "user-id02", now().Add(1*time.Minute))
+	logs[3].UserAgent = entity.ExcludeUserAgentLogs[0]
+	for _, log := range logs {
+		err = db.DB.Create(&log).Error
+		require.NoError(t, err)
+	}
+
+	type args struct {
+		params *database.AggregateVideoViewerLogsParams
+	}
+	type want struct {
+		logs entity.AggregatedVideoViewerLogs
+		err  error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				params: &database.AggregateVideoViewerLogsParams{
+					VideoID:      "video-id",
+					Interval:     entity.AggregateVideoViewerLogIntervalMinute,
+					CreatedAtGte: now().Add(-time.Minute),
+					CreatedAtLt:  now().Add(time.Hour),
+				},
+			},
+			want: want{
+				logs: entity.AggregatedVideoViewerLogs{
+					{
+						VideoID:    "video-id",
+						ReportedAt: jst.Date(now().Year(), now().Month(), now().Day(), now().Hour(), now().Minute(), 0, 0),
+						Total:      2,
+					},
+					{
+						VideoID:    "video-id",
+						ReportedAt: jst.Date(now().Year(), now().Month(), now().Day(), now().Hour(), now().Minute()+1, 0, 0),
+						Total:      1,
+					},
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &videoViewerLog{db: db, now: now}
+			logs, err := db.Aggregate(ctx, tt.args.params)
+			assert.ErrorIs(t, err, tt.want.err)
+			assert.Equal(t, tt.want.logs, logs)
+		})
+	}
+}
+
+func testVideoViewerLog(videoID, sessionID, userID string, now time.Time) *entity.VideoViewerLog {
+	return &entity.VideoViewerLog{
+		VideoID:   videoID,
+		SessionID: sessionID,
+		CreatedAt: now,
+		UserID:    userID,
+		UserAgent: "user-agent",
+		ClientIP:  "127.0.0.1",
+		UpdatedAt: now,
+	}
+}

--- a/api/internal/media/entity/video_viewer_log.go
+++ b/api/internal/media/entity/video_viewer_log.go
@@ -1,0 +1,70 @@
+package entity
+
+import "time"
+
+type AggregateVideoViewerLogInterval string
+
+const (
+	AggregateVideoViewerLogIntervalSecond AggregateVideoViewerLogInterval = "%Y-%m-%d %H:%i:%s"
+	AggregateVideoViewerLogIntervalMinute AggregateVideoViewerLogInterval = "%Y-%m-%d %H:%i:00"
+	AggregateVideoViewerLogIntervalHour   AggregateVideoViewerLogInterval = "%Y-%m-%d %H:00:00"
+)
+
+// VideoViewerLog - オンデマンド配信視聴履歴情報
+type VideoViewerLog struct {
+	VideoID   string    `gorm:"primaryKey;<-:create"` // オンデマンド配信ID
+	SessionID string    `gorm:"primaryKey;<-:create"` // セッションID
+	CreatedAt time.Time `gorm:"primaryKey;<-:create"` // 登録日時
+	UserID    string    `gorm:"default:null"`         // ユーザーID
+	UserAgent string    `gorm:""`                     // ユーザーエージェント
+	ClientIP  string    `gorm:""`                     // 接続元IPアドレス
+	UpdatedAt time.Time `gorm:""`                     // 更新日時
+}
+
+type VideoViewerLogs []*VideoViewerLog
+
+// AggregatedVideoViewerLog - オンデマンド配信視聴履歴集計情報
+type AggregatedVideoViewerLog struct {
+	VideoID    string    // オンデマンド配信ID
+	ReportedAt time.Time // 集計日時
+	Total      int64     // 視聴合計回数
+}
+
+type AggregatedVideoViewerLogs []*AggregatedVideoViewerLog
+
+type NewVideoViewerLogParams struct {
+	VideoID   string
+	SessionID string
+	UserID    string
+	UserAgent string
+	ClientIP  string
+}
+
+func NewVideoViewerLog(params *NewVideoViewerLogParams) *VideoViewerLog {
+	return &VideoViewerLog{
+		VideoID:   params.VideoID,
+		SessionID: params.SessionID,
+		UserID:    params.UserID,
+		UserAgent: params.UserAgent,
+		ClientIP:  params.ClientIP,
+	}
+}
+
+func (ls AggregatedVideoViewerLogs) MapByReportedAt() map[time.Time]*AggregatedVideoViewerLog {
+	res := make(map[time.Time]*AggregatedVideoViewerLog)
+	for _, l := range ls {
+		res[l.ReportedAt] = l
+	}
+	return res
+}
+
+func (ls AggregatedVideoViewerLogs) GroupByVideoID() map[string]AggregatedVideoViewerLogs {
+	res := make(map[string]AggregatedVideoViewerLogs)
+	for _, l := range ls {
+		if _, ok := res[l.VideoID]; !ok {
+			res[l.VideoID] = make(AggregatedVideoViewerLogs, 0, len(ls))
+		}
+		res[l.VideoID] = append(res[l.VideoID], l)
+	}
+	return res
+}

--- a/api/internal/media/entity/video_viewer_log_test.go
+++ b/api/internal/media/entity/video_viewer_log_test.go
@@ -1,0 +1,113 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVideoViewerLog(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params *NewVideoViewerLogParams
+		expect *VideoViewerLog
+	}{
+		{
+			name: "success",
+			params: &NewVideoViewerLogParams{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+			expect: &VideoViewerLog{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewVideoViewerLog(tt.params)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestAggregatedVideoViewerLogs_MapByReportedAt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		logs   AggregatedVideoViewerLogs
+		expect map[time.Time]*AggregatedVideoViewerLog
+	}{
+		{
+			name: "success",
+			logs: AggregatedVideoViewerLogs{
+				{
+					VideoID:    "video-id",
+					ReportedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					Total:      1,
+				},
+			},
+			expect: map[time.Time]*AggregatedVideoViewerLog{
+				time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC): {
+					VideoID:    "video-id",
+					ReportedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					Total:      1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.logs.MapByReportedAt()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestAggregatedVideoViewerLogs_GroupByVideoID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		logs   AggregatedVideoViewerLogs
+		expect map[string]AggregatedVideoViewerLogs
+	}{
+		{
+			name: "success",
+			logs: AggregatedVideoViewerLogs{
+				{
+					VideoID:    "video-id",
+					ReportedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					Total:      1,
+				},
+			},
+			expect: map[string]AggregatedVideoViewerLogs{
+				"video-id": {
+					{
+						VideoID:    "video-id",
+						ReportedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+						Total:      1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.logs.GroupByVideoID()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/media/input.go
+++ b/api/internal/media/input.go
@@ -94,21 +94,6 @@ type CreateYoutubeBroadcastInput struct {
 	Public      bool   `validate:""`
 }
 
-type CreateBroadcastViewerLogInput struct {
-	ScheduleID string `validate:"required"`
-	SessionID  string `validate:"required"`
-	UserID     string `validate:""`
-	UserAgent  string `validate:""`
-	ClientIP   string `validate:"omitempty,ip_addr"`
-}
-
-type AggregateBroadcastViewerLogsInput struct {
-	ScheduleID   string                                     `validate:"required"`
-	Interval     entity.AggregateBroadcastViewerLogInterval `validate:"required"`
-	CreatedAtGte time.Time                                  `validate:""`
-	CreatedAtLt  time.Time                                  `validate:""`
-}
-
 type ListBroadcastCommentsInput struct {
 	ScheduleID   string    `validate:"required"`
 	WithDisabled bool      `validate:""`
@@ -132,6 +117,21 @@ type CreateBroadcastGuestCommentInput struct {
 type UpdateBroadcastCommentInput struct {
 	CommentID string `validate:"required"`
 	Disabled  bool   `validate:""`
+}
+
+type CreateBroadcastViewerLogInput struct {
+	ScheduleID string `validate:"required"`
+	SessionID  string `validate:"required"`
+	UserID     string `validate:""`
+	UserAgent  string `validate:""`
+	ClientIP   string `validate:"omitempty,ip_addr"`
+}
+
+type AggregateBroadcastViewerLogsInput struct {
+	ScheduleID   string                                     `validate:"required"`
+	Interval     entity.AggregateBroadcastViewerLogInterval `validate:"required"`
+	CreatedAtGte time.Time                                  `validate:""`
+	CreatedAtLt  time.Time                                  `validate:""`
 }
 
 type ListVideosInput struct {
@@ -207,4 +207,19 @@ type CreateVideoGuestCommentInput struct {
 type UpdateVideoCommentInput struct {
 	CommentID string `validate:"required"`
 	Disabled  bool   `validate:""`
+}
+
+type CreateVideoViewerLogInput struct {
+	VideoID   string `validate:"required"`
+	SessionID string `validate:"required"`
+	UserID    string `validate:""`
+	UserAgent string `validate:""`
+	ClientIP  string `validate:"omitempty,ip_addr"`
+}
+
+type AggregateVideoViewerLogsInput struct {
+	VideoID      string                                 `validate:"required"`
+	Interval     entity.AggregateVideoViewerLogInterval `validate:"required"`
+	CreatedAtGte time.Time                              `validate:""`
+	CreatedAtLt  time.Time                              `validate:""`
 }

--- a/api/internal/media/service.go
+++ b/api/internal/media/service.go
@@ -27,14 +27,14 @@ type Service interface {
 	AuthYoutubeBroadcast(ctx context.Context, in *AuthYoutubeBroadcastInput) (string, error)                                      // Youtubeライブ配信認証
 	AuthYoutubeBroadcastEvent(ctx context.Context, in *AuthYoutubeBroadcastEventInput) (*entity.BroadcastAuth, error)             // Youtubeライブ配信認証後処理
 	CreateYoutubeBroadcast(ctx context.Context, in *CreateYoutubeBroadcastInput) error                                            // Youtubeライブ配信登録
-	// ライブ視聴履歴
-	CreateBroadcastViewerLog(ctx context.Context, in *CreateBroadcastViewerLogInput) error                                                        // ライブ配信視聴履歴登録
-	AggregateBroadcastViewerLogs(ctx context.Context, in *AggregateBroadcastViewerLogsInput) (entity.AggregatedBroadcastViewerLogs, int64, error) // ライブ配信視聴履歴集計
 	// ライブコメント
 	ListBroadcastComments(ctx context.Context, in *ListBroadcastCommentsInput) (entity.BroadcastComments, string, error)     // ライブコメント一覧取得
 	CreateBroadcastComment(ctx context.Context, in *CreateBroadcastCommentInput) (*entity.BroadcastComment, error)           // ライブコメント登録
 	CreateBroadcastGuestComment(ctx context.Context, in *CreateBroadcastGuestCommentInput) (*entity.BroadcastComment, error) // ライブゲストコメント登録
 	UpdateBroadcastComment(ctx context.Context, in *UpdateBroadcastCommentInput) error                                       // ライブコメント更新
+	// ライブ視聴履歴
+	CreateBroadcastViewerLog(ctx context.Context, in *CreateBroadcastViewerLogInput) error                                                        // ライブ配信視聴履歴登録
+	AggregateBroadcastViewerLogs(ctx context.Context, in *AggregateBroadcastViewerLogsInput) (entity.AggregatedBroadcastViewerLogs, int64, error) // ライブ配信視聴履歴集計
 	// オンデマンド配信
 	ListVideos(ctx context.Context, in *ListVideosInput) (entity.Videos, int64, error)                       // 一覧取得
 	GetVideo(ctx context.Context, in *GetVideoInput) (*entity.Video, error)                                  // １件取得
@@ -47,6 +47,9 @@ type Service interface {
 	ListVideoComments(ctx context.Context, in *ListVideoCommentsInput) (entity.VideoComments, string, error) // 一覧取得
 	CreateVideoComment(ctx context.Context, in *CreateVideoCommentInput) (*entity.VideoComment, error)       // 登録
 	UpdateVideoComment(ctx context.Context, in *UpdateVideoCommentInput) error                               // 更新
+	// オンデマンド配信視聴履歴
+	CreateVideoViewerLog(ctx context.Context, in *CreateVideoViewerLogInput) error                                                    // オンデマンド配信視聴履歴登録
+	AggregateVideoViewerLogs(ctx context.Context, in *AggregateVideoViewerLogsInput) (entity.AggregatedVideoViewerLogs, int64, error) // オンデマンド配信視聴履歴集計
 	// コーディネータ
 	GetCoordinatorThumbnailUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)      // サムネイル画像アップロード用URLの生成
 	GetCoordinatorHeaderUploadURL(ctx context.Context, in *GenerateUploadURLInput) (*entity.UploadEvent, error)         // ヘッダー画像アップロード用URLの生成

--- a/api/internal/media/service/broadcast_comment_test.go
+++ b/api/internal/media/service/broadcast_comment_test.go
@@ -182,6 +182,12 @@ func TestCreateBroadcastComment(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &media.CreateBroadcastCommentInput{},
+			expectErr: exception.ErrInvalidArgument,
+		},
+		{
 			name: "failed to get broadcast",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Broadcast.EXPECT().GetByScheduleID(ctx, "schedule-id").Return(nil, assert.AnError)
@@ -260,6 +266,12 @@ func TestCreateBroadcastGuestComment(t *testing.T) {
 				Content:    "こんにちは",
 			},
 			expectErr: nil,
+		},
+		{
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &media.CreateBroadcastGuestCommentInput{},
+			expectErr: exception.ErrInvalidArgument,
 		},
 		{
 			name: "failed to get broadcast",

--- a/api/internal/media/service/broadcast_viewer_log_test.go
+++ b/api/internal/media/service/broadcast_viewer_log_test.go
@@ -57,6 +57,12 @@ func TestCreateBrodcastViewerLog(t *testing.T) {
 			expect: nil,
 		},
 		{
+			name:   "invalid argument",
+			setup:  func(ctx context.Context, mocks *mocks) {},
+			input:  &media.CreateBroadcastViewerLogInput{},
+			expect: exception.ErrInvalidArgument,
+		},
+		{
 			name: "failed to get broadcast",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Broadcast.EXPECT().GetByScheduleID(ctx, "schedule-id").Return(nil, assert.AnError)

--- a/api/internal/media/service/service_test.go
+++ b/api/internal/media/service/service_test.go
@@ -53,6 +53,7 @@ type dbMocks struct {
 	BroadcastViewerLog *mock_database.MockBroadcastViewerLog
 	Video              *mock_database.MockVideo
 	VideoComment       *mock_database.MockVideoComment
+	VideoViewerLog     *mock_database.MockVideoViewerLog
 }
 
 type testOptions struct {
@@ -103,6 +104,7 @@ func newDBMocks(ctrl *gomock.Controller) *dbMocks {
 		BroadcastViewerLog: mock_database.NewMockBroadcastViewerLog(ctrl),
 		Video:              mock_database.NewMockVideo(ctrl),
 		VideoComment:       mock_database.NewMockVideoComment(ctrl),
+		VideoViewerLog:     mock_database.NewMockVideoViewerLog(ctrl),
 	}
 }
 
@@ -122,6 +124,7 @@ func newService(mocks *mocks, opts ...testOption) *service {
 			BroadcastViewerLog: mocks.db.BroadcastViewerLog,
 			Video:              mocks.db.Video,
 			VideoComment:       mocks.db.VideoComment,
+			VideoViewerLog:     mocks.db.VideoViewerLog,
 		},
 		Cache:     mocks.cache,
 		User:      mocks.user,

--- a/api/internal/media/service/video_viewer_log.go
+++ b/api/internal/media/service/video_viewer_log.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/media"
+	"github.com/and-period/furumaru/api/internal/media/database"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+	"golang.org/x/sync/errgroup"
+)
+
+func (s *service) CreateVideoViewerLog(ctx context.Context, in *media.CreateVideoViewerLogInput) error {
+	if err := s.validator.Struct(in); err != nil {
+		return internalError(err)
+	}
+	video, err := s.db.Video.Get(ctx, in.VideoID)
+	if err != nil {
+		return internalError(err)
+	}
+	if !video.Published() {
+		return fmt.Errorf("%w: video is not published", exception.ErrFailedPrecondition)
+	}
+	params := &entity.NewVideoViewerLogParams{
+		VideoID:   video.ID,
+		SessionID: in.SessionID,
+		UserID:    in.UserID,
+		UserAgent: in.UserAgent,
+		ClientIP:  in.ClientIP,
+	}
+	log := entity.NewVideoViewerLog(params)
+	err = s.db.VideoViewerLog.Create(ctx, log)
+	return internalError(err)
+}
+
+func (s *service) AggregateVideoViewerLogs(
+	ctx context.Context, in *media.AggregateVideoViewerLogsInput,
+) (entity.AggregatedVideoViewerLogs, int64, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, 0, internalError(err)
+	}
+	var (
+		logs  entity.AggregatedVideoViewerLogs
+		total int64
+	)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		params := &database.AggregateVideoViewerLogsParams{
+			VideoID:      in.VideoID,
+			Interval:     in.Interval,
+			CreatedAtGte: in.CreatedAtGte,
+			CreatedAtLt:  in.CreatedAtLt,
+		}
+		logs, err = s.db.VideoViewerLog.Aggregate(ctx, params)
+		return
+	})
+	eg.Go(func() (err error) {
+		params := &database.GetVideoTotalViewersParams{
+			VideoID:      in.VideoID,
+			CreatedAtGte: in.CreatedAtGte,
+			CreatedAtLt:  in.CreatedAtLt,
+		}
+		total, err = s.db.VideoViewerLog.GetTotal(ctx, params)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, 0, internalError(err)
+	}
+	return logs, total, nil
+}

--- a/api/internal/media/service/video_viewer_log_test.go
+++ b/api/internal/media/service/video_viewer_log_test.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/media"
+	"github.com/and-period/furumaru/api/internal/media/database"
+	"github.com/and-period/furumaru/api/internal/media/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateVideoViewerLog(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2023, 10, 20, 18, 30, 0, 0)
+	video := &entity.Video{
+		ID:            "video-id",
+		CoordinatorID: "coordinator-id",
+		ProductIDs:    []string{"product-id"},
+		ExperienceIDs: []string{"experience-id"},
+		Title:         "じゃがいも収穫",
+		Description:   "じゃがいも収穫の説明",
+		Status:        entity.VideoStatusPublished,
+		ThumbnailURL:  "https://example.com/thumbnail.jpg",
+		VideoURL:      "https://example.com/video.mp4",
+		Public:        true,
+		Limited:       false,
+		VideoProducts: []*entity.VideoProduct{{
+			VideoID:   "video-id",
+			ProductID: "product-id",
+			Priority:  1,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}},
+		VideoExperiences: []*entity.VideoExperience{{
+			VideoID:      "video-id",
+			ExperienceID: "experience-id",
+			Priority:     1,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}},
+		PublishedAt: now.AddDate(0, 0, -1),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	log := &entity.VideoViewerLog{
+		VideoID:   "video-id",
+		SessionID: "session-id",
+		UserID:    "user-id",
+		UserAgent: "user-agent",
+		ClientIP:  "127.0.0.1",
+	}
+
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, mocks *mocks)
+		input  *media.CreateVideoViewerLogInput
+		expect error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().Get(ctx, "video-id").Return(video, nil)
+				mocks.db.VideoViewerLog.EXPECT().Create(ctx, log).Return(nil)
+			},
+			input: &media.CreateVideoViewerLogInput{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+			expect: nil,
+		},
+		{
+			name: "invalid argument",
+			setup: func(ctx context.Context, mocks *mocks) {
+			},
+			input:  &media.CreateVideoViewerLogInput{},
+			expect: exception.ErrInvalidArgument,
+		},
+		{
+			name: "failed to get video",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().Get(ctx, "video-id").Return(nil, assert.AnError)
+			},
+			input: &media.CreateVideoViewerLogInput{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+			expect: exception.ErrInternal,
+		},
+		{
+			name: "video is not published",
+			setup: func(ctx context.Context, mocks *mocks) {
+				video := &entity.Video{Status: entity.VideoStatusPrivate}
+				mocks.db.Video.EXPECT().Get(ctx, "video-id").Return(video, nil)
+			},
+			input: &media.CreateVideoViewerLogInput{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+			expect: exception.ErrFailedPrecondition,
+		},
+		{
+			name: "failed to create broadacast viewer log",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().Get(ctx, "video-id").Return(video, nil)
+				mocks.db.VideoViewerLog.EXPECT().Create(ctx, log).Return(assert.AnError)
+			},
+			input: &media.CreateVideoViewerLogInput{
+				VideoID:   "video-id",
+				SessionID: "session-id",
+				UserID:    "user-id",
+				UserAgent: "user-agent",
+				ClientIP:  "127.0.0.1",
+			},
+			expect: exception.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			err := service.CreateVideoViewerLog(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expect)
+		}))
+	}
+}
+
+func TestAggregateVideoViewerLogs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	aggregateParams := &database.AggregateVideoViewerLogsParams{
+		VideoID:      "video-id",
+		Interval:     entity.AggregateVideoViewerLogIntervalMinute,
+		CreatedAtGte: now,
+		CreatedAtLt:  now,
+	}
+	logs := entity.AggregatedVideoViewerLogs{
+		{
+			VideoID:    "video-id",
+			ReportedAt: now,
+			Total:      3,
+		},
+	}
+	totalParams := &database.GetVideoTotalViewersParams{
+		VideoID:      "video-id",
+		CreatedAtGte: now,
+		CreatedAtLt:  now,
+	}
+
+	tests := []struct {
+		name        string
+		setup       func(ctx context.Context, mocks *mocks)
+		input       *media.AggregateVideoViewerLogsInput
+		expect      entity.AggregatedVideoViewerLogs
+		expectTotal int64
+		expectErr   error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.VideoViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(logs, nil)
+				mocks.db.VideoViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(3), nil)
+			},
+			input: &media.AggregateVideoViewerLogsInput{
+				VideoID:      "video-id",
+				Interval:     entity.AggregateVideoViewerLogIntervalMinute,
+				CreatedAtGte: now,
+				CreatedAtLt:  now,
+			},
+			expect:      logs,
+			expectTotal: 3,
+			expectErr:   nil,
+		},
+		{
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &media.AggregateVideoViewerLogsInput{},
+			expect:    nil,
+			expectErr: exception.ErrInvalidArgument,
+		},
+		{
+			name: "failed to aggregate viewer logs",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.VideoViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(nil, assert.AnError)
+				mocks.db.VideoViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(3), nil)
+			},
+			input: &media.AggregateVideoViewerLogsInput{
+				VideoID:      "video-id",
+				Interval:     entity.AggregateVideoViewerLogIntervalMinute,
+				CreatedAtGte: now,
+				CreatedAtLt:  now,
+			},
+			expect:      nil,
+			expectTotal: 0,
+			expectErr:   exception.ErrInternal,
+		},
+		{
+			name: "failed to aggregate viewer logs",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.VideoViewerLog.EXPECT().Aggregate(gomock.Any(), aggregateParams).Return(logs, nil)
+				mocks.db.VideoViewerLog.EXPECT().GetTotal(gomock.Any(), totalParams).Return(int64(0), assert.AnError)
+			},
+			input: &media.AggregateVideoViewerLogsInput{
+				VideoID:      "video-id",
+				Interval:     entity.AggregateVideoViewerLogIntervalMinute,
+				CreatedAtGte: now,
+				CreatedAtLt:  now,
+			},
+			expect:      nil,
+			expectTotal: 0,
+			expectErr:   exception.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			actual, total, err := service.AggregateVideoViewerLogs(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expectErr)
+			assert.Equal(t, tt.expect, actual)
+			assert.Equal(t, tt.expectTotal, total)
+		}))
+	}
+}

--- a/infra/mysql/schema/2024090202-media-create-video-viewer-logs.sql
+++ b/infra/mysql/schema/2024090202-media-create-video-viewer-logs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `media`.`video_viewer_logs` (
+  `video_id`     VARCHAR(22) NOT NULL,          -- オンデマンド配信ID
+  `session_id`   VARCHAR(22) NOT NULL,          -- セッションID
+  `created_at`   DATETIME(3) NOT NULL,          -- 登録日時
+  `user_id`      VARCHAR(22) NULL DEFAULT NULL, -- ユーザーID
+  `user_agent`   TEXT        NOT NULL,          -- ユーザーエージェント
+  `client_ip`    VARCHAR(15) NOT NULL,          -- 接続元IPアドレス
+  `updated_at`   DATETIME(3) NOT NULL,          -- 更新日時
+  PRIMARY KEY (`video_id`, `session_id`, `created_at` DESC),
+  CONSTRAINT `fk_video_viewer_logs_video_id`
+    FOREIGN KEY (`video_id`) REFERENCES `media`.`videos` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 動画視聴者ログの作成と集計を管理する機能を追加しました。
	- 新しいデータベーステーブル「video_viewer_logs」を導入し、視聴者のインタラクションを記録します。
- **バグ修正**
	- 無効な引数に対するエラーハンドリングを強化しました。
- **テスト**
	- 動画視聴者ログの作成と集計に関するユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->