### PR TITLE
feat(store): 体験の注文情報を定義

### DIFF
--- a/api/internal/store/database/mysql/mysql_test.go
+++ b/api/internal/store/database/mysql/mysql_test.go
@@ -52,6 +52,7 @@ func deleteAll(ctx context.Context) error {
 	tables := []string{
 		// テストに対応したテーブルから追記(削除順)
 		paymentSystemTable,
+		orderExperienceTable,
 		orderFulfillmentTable,
 		orderPaymentTable,
 		orderItemTable,

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -760,10 +760,10 @@ func TestOrder_Create(t *testing.T) {
 	require.NoError(t, err)
 
 	fulfillments := make(entity.OrderFulfillments, 1)
-	fulfillments[0] = testOrderFulfillment("fulfillment-id", "order-id", 1, 1, now())
+	fulfillments[0] = testOrderFulfillment("fulfillment-id", "product-order-id", 1, 1, now())
 	items := make(entity.OrderItems, 2)
-	items[0] = testOrderItem("fulfillment-id", 1, "order-id", now())
-	items[1] = testOrderItem("fulfillment-id", 2, "order-id", now())
+	items[0] = testOrderItem("fulfillment-id", 1, "product-order-id", now())
+	items[1] = testOrderItem("fulfillment-id", 2, "product-order-id", now())
 
 	porder := testOrder("product-order-id", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
 	porder.Type = entity.OrderTypeProduct
@@ -824,7 +824,6 @@ func TestOrder_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/and-period/furumaru/api/internal/store/database"
 	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
 	"github.com/and-period/furumaru/api/pkg/mysql"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -52,8 +53,8 @@ func TestOrder_List(t *testing.T) {
 	}
 
 	orders := make(entity.Orders, 2)
-	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", 1, now())
-	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", 2, now())
+	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 2, now())
 	err = db.DB.Create(&orders).Error
 	require.NoError(t, err)
 	payments := make(entity.OrderPayments, 2)
@@ -160,18 +161,36 @@ func TestOrder_ListUserIDs(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	orders := make(entity.Orders, 2)
-	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", 1, now())
-	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", 2, now())
+	experienceTypes := make(entity.ExperienceTypes, 1)
+	experienceTypes[0] = testExperienceType("experience-type-id", "体験", now())
+	err = db.DB.Create(&experienceTypes).Error
+	require.NoError(t, err)
+	experiences := make(entity.Experiences, 1)
+	experiences[0] = testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
+	err = db.DB.Create(&experiences).Error
+	require.NoError(t, err)
+	for i := range experiences {
+		err = db.DB.Create(&experiences[i].ExperienceRevision).Error
+		require.NoError(t, err)
+	}
+
+	orders := make(entity.Orders, 3)
+	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 2, now())
+	orders[2] = testOrder("order-id03", "user-id", "", "coordinator-id", entity.OrderTypeExperience, 3, now())
 	err = db.DB.Create(&orders).Error
 	require.NoError(t, err)
-	payments := make(entity.OrderPayments, 2)
+
+	payments := make(entity.OrderPayments, 3)
 	payments[0] = testOrderPayment("order-id01", 1, "transaction-id01", "payment-id", now())
 	orders[0].OrderPayment = *payments[0]
 	payments[1] = testOrderPayment("order-id02", 1, "transaction-id02", "payment-id", now())
 	orders[1].OrderPayment = *payments[1]
+	payments[2] = testOrderPayment("order-id03", 1, "transaction-id03", "payment-id", now())
+	orders[2].OrderPayment = *payments[2]
 	err = db.DB.Create(&payments).Error
 	require.NoError(t, err)
+
 	fulfillments := make(entity.OrderFulfillments, 2)
 	fulfillments[0] = testOrderFulfillment("fulfillment-id01", "order-id01", 1, 1, now())
 	orders[0].OrderFulfillments = entity.OrderFulfillments{fulfillments[0]}
@@ -179,12 +198,19 @@ func TestOrder_ListUserIDs(t *testing.T) {
 	orders[1].OrderFulfillments = entity.OrderFulfillments{fulfillments[1]}
 	err = db.DB.Create(&fulfillments).Error
 	require.NoError(t, err)
+
 	items := make(entity.OrderItems, 2)
 	items[0] = testOrderItem("fulfillment-id01", 1, "order-id01", now())
 	orders[0].OrderItems = []*entity.OrderItem{items[0]}
 	items[1] = testOrderItem("fulfillment-id02", 2, "order-id02", now())
 	orders[1].OrderItems = []*entity.OrderItem{items[1]}
 	err = db.DB.Create(&items).Error
+	require.NoError(t, err)
+
+	oexperiences := make(entity.OrderExperiences, 1)
+	oexperiences[0] = testOrderExperience("order-id03", 1, now())
+	orders[2].OrderExperience = *oexperiences[0]
+	err = db.DB.Create(&oexperiences).Error
 	require.NoError(t, err)
 
 	type args struct {
@@ -276,8 +302,8 @@ func TestOrder_Count(t *testing.T) {
 	require.NoError(t, err)
 
 	orders := make(entity.Orders, 2)
-	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", 1, now())
-	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", 2, now())
+	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 2, now())
 	err = db.DB.Create(&orders).Error
 	require.NoError(t, err)
 	payments := make(entity.OrderPayments, 2)
@@ -386,7 +412,7 @@ func TestOrder_Get(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
-	o := testOrder("order-id", "user-id", "", "coordinator-id", 1, now())
+	o := testOrder("order-id", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
 	err = db.DB.Create(&o).Error
 	require.NoError(t, err)
 	payment := testOrderPayment("order-id", 1, "transaction-id", "payment-id", now())
@@ -497,7 +523,7 @@ func TestOrder_GetByTransactionID(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
-	o := testOrder("order-id", "user-id", "", "coordinator-id", 1, now())
+	o := testOrder("order-id", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
 	err = db.DB.Create(&o).Error
 	require.NoError(t, err)
 	payment := testOrderPayment("order-id", 1, "transaction-id", "payment-id", now())
@@ -611,7 +637,7 @@ func TestOrder_GetByTransactionIDWithSessionID(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
-	o := testOrder("order-id", "user-id", "", "coordinator-id", 1, now())
+	o := testOrder("order-id", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
 	err = db.DB.Create(&o).Error
 	require.NoError(t, err)
 	payment := testOrderPayment("order-id", 1, "transaction-id", "payment-id", now())
@@ -724,16 +750,31 @@ func TestOrder_Create(t *testing.T) {
 	err = db.DB.Create(&schedule).Error
 	require.NoError(t, err)
 
+	experienceType := testExperienceType("experience-type-id", "体験", now())
+	err = db.DB.Create(&experienceType).Error
+	require.NoError(t, err)
+	experience := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
+	err = db.DB.Create(&experience).Error
+	require.NoError(t, err)
+	err = db.DB.Create(&experience.ExperienceRevision).Error
+	require.NoError(t, err)
+
 	fulfillments := make(entity.OrderFulfillments, 1)
 	fulfillments[0] = testOrderFulfillment("fulfillment-id", "order-id", 1, 1, now())
 	items := make(entity.OrderItems, 2)
 	items[0] = testOrderItem("fulfillment-id", 1, "order-id", now())
 	items[1] = testOrderItem("fulfillment-id", 2, "order-id", now())
 
-	o := testOrder("order-id", "user-id", "", "coordinator-id", 1, now())
-	o.OrderPayment = *testOrderPayment("order-id", 1, "transaction-id", "payment-id", now())
-	o.OrderFulfillments = fulfillments
-	o.OrderItems = items
+	porder := testOrder("product-order-id", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	porder.Type = entity.OrderTypeProduct
+	porder.OrderPayment = *testOrderPayment("product-order-id", 1, "transaction-id", "payment-id", now())
+	porder.OrderFulfillments = fulfillments
+	porder.OrderItems = items
+
+	eorder := testOrder("experience-order-id", "user-id", "", "coordinator-id", entity.OrderTypeExperience, 2, now())
+	eorder.Type = entity.OrderTypeExperience
+	eorder.OrderPayment = *testOrderPayment("experience-order-id", 1, "transaction-id", "payment-id", now())
+	eorder.OrderExperience = *testOrderExperience("experience-order-id", 1, now())
 
 	type args struct {
 		order *entity.Order
@@ -748,10 +789,20 @@ func TestOrder_Create(t *testing.T) {
 		want  want
 	}{
 		{
-			name:  "success",
+			name:  "success product order",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
-				order: o,
+				order: porder,
+			},
+			want: want{
+				hasErr: false,
+			},
+		},
+		{
+			name:  "success experience order",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				order: eorder,
 			},
 			want: want{
 				hasErr: false,
@@ -760,11 +811,11 @@ func TestOrder_Create(t *testing.T) {
 		{
 			name: "already exists",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
-				err := db.DB.Create(&o).Error
+				err := db.DB.Create(&porder).Error
 				require.NoError(t, err)
 			},
 			args: args{
-				order: o,
+				order: porder,
 			},
 			want: want{
 				hasErr: true,
@@ -828,7 +879,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 	require.NoError(t, err)
 
 	create := func(t *testing.T, orderID string, status entity.OrderStatus, now time.Time) {
-		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order := testOrder(orderID, "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now)
 		order.Status = status
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
@@ -1020,7 +1071,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 	require.NoError(t, err)
 
 	create := func(t *testing.T, orderID string, status entity.OrderStatus, now time.Time) {
-		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order := testOrder(orderID, "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now)
 		order.Status = status
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
@@ -1187,7 +1238,7 @@ func TestOrder_UpdateRefund(t *testing.T) {
 	require.NoError(t, err)
 
 	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
-		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order := testOrder(orderID, "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now)
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
 
@@ -1347,7 +1398,7 @@ func TestOrder_Draft(t *testing.T) {
 	require.NoError(t, err)
 
 	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
-		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order := testOrder(orderID, "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now)
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
 
@@ -1454,7 +1505,7 @@ func TestOrder_Complete(t *testing.T) {
 	require.NoError(t, err)
 
 	create := func(t *testing.T, orderID string, status entity.PaymentStatus, now time.Time) {
-		order := testOrder(orderID, "user-id", "", "coordinator-id", 1, now)
+		order := testOrder(orderID, "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now)
 		err := db.DB.Create(&order).Error
 		require.NoError(t, err)
 
@@ -1562,8 +1613,8 @@ func TestOrder_Aggregate(t *testing.T) {
 	require.NoError(t, err)
 
 	orders := make(entity.Orders, 2)
-	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", 1, now())
-	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", 2, now())
+	orders[0] = testOrder("order-id01", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	orders[1] = testOrder("order-id02", "user-id", "", "coordinator-id", entity.OrderTypeProduct, 2, now())
 	err = db.DB.Create(&orders).Error
 	require.NoError(t, err)
 	payments := make(entity.OrderPayments, 2)
@@ -1684,8 +1735,8 @@ func TestOrder_AggregateByPromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	orders := make(entity.Orders, 2)
-	orders[0] = testOrder("order-id01", "user-id", "promotion-id", "coordinator-id", 1, now())
-	orders[1] = testOrder("order-id02", "user-id", "promotion-id", "coordinator-id", 2, now())
+	orders[0] = testOrder("order-id01", "user-id", "promotion-id", "coordinator-id", entity.OrderTypeProduct, 1, now())
+	orders[1] = testOrder("order-id02", "user-id", "promotion-id", "coordinator-id", entity.OrderTypeProduct, 2, now())
 	err = db.DB.Create(&orders).Error
 	require.NoError(t, err)
 	payments := make(entity.OrderPayments, 2)
@@ -1763,7 +1814,7 @@ func TestOrder_AggregateByPromotion(t *testing.T) {
 	}
 }
 
-func testOrder(id, userID, promotionID, coordinatorID string, mgmtID int64, now time.Time) *entity.Order {
+func testOrder(id, userID, promotionID, coordinatorID string, typ entity.OrderType, mgmtID int64, now time.Time) *entity.Order {
 	return &entity.Order{
 		ID:            id,
 		SessionID:     "session-id",
@@ -1771,6 +1822,7 @@ func testOrder(id, userID, promotionID, coordinatorID string, mgmtID int64, now 
 		PromotionID:   promotionID,
 		CoordinatorID: coordinatorID,
 		ManagementID:  mgmtID,
+		Type:          typ,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
@@ -1820,4 +1872,25 @@ func testOrderItem(fulfillmentID string, productID int64, orderID string, now ti
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
+}
+
+func testOrderExperience(orderID string, experienceID int64, now time.Time) *entity.OrderExperience {
+	e := &entity.OrderExperience{
+		OrderID:               orderID,
+		ExperienceRevisionID:  experienceID,
+		AdultCount:            1,
+		JuniorHighSchoolCount: 1,
+		ElementarySchoolCount: 2,
+		PreschoolCount:        0,
+		SeniorCount:           0,
+		Remarks: entity.OrderExperienceRemarks{
+			Transportation: "電車",
+			RequestedDate:  jst.Date(2024, 1, 2, 0, 0, 0, 0),
+			RequestedTime:  jst.Date(0, 1, 1, 18, 30, 0, 0),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	_ = e.Fill()
+	return e
 }

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -829,7 +829,7 @@ func TestOrder_Create(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -1021,7 +1021,7 @@ func TestOrder_UpdatePayment(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)
@@ -1188,7 +1188,7 @@ func TestOrder_UpdateFulfillment(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)
@@ -1348,7 +1348,7 @@ func TestOrder_UpdateRefund(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)
@@ -1455,7 +1455,7 @@ func TestOrder_Draft(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)
@@ -1563,7 +1563,7 @@ func TestOrder_Complete(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderTable)
+			err := delete(ctx, orderItemTable, orderFulfillmentTable, orderPaymentTable, orderExperienceTable, orderTable)
 			require.NoError(t, err)
 
 			tt.setup(ctx, t, db)

--- a/api/internal/store/entity/order.go
+++ b/api/internal/store/entity/order.go
@@ -37,6 +37,7 @@ type Order struct {
 	OrderPayment      `gorm:"-"`
 	OrderFulfillments `gorm:"-"`
 	OrderItems        `gorm:"-"`
+	OrderExperience   `gorm:"-"`
 	ID                string         `gorm:"primaryKey;<-:create"` // 注文履歴ID
 	UserID            string         `gorm:""`                     // ユーザーID
 	SessionID         string         `gorm:""`                     // 注文時セッションID
@@ -88,12 +89,31 @@ type NewProductOrderParams struct {
 	Promotion         *Promotion
 }
 
+type NewExperienceOrderParams struct {
+	OrderID               string
+	SessionID             string
+	CoordinatorID         string
+	Customer              *entity.User
+	BillingAddress        *entity.Address
+	Experience            *Experience
+	PaymentMethodType     PaymentMethodType
+	Promotion             *Promotion
+	AdultCount            int64
+	JuniorHighSchoolCount int64
+	ElementarySchoolCount int64
+	PreschoolCount        int64
+	SeniorCount           int64
+	Transportation        string
+	RequetsedDate         string
+	RequetsedTime         string
+}
+
 func NewProductOrder(params *NewProductOrderParams) (*Order, error) {
 	var promotionID string
 	if params.Promotion != nil {
 		promotionID = params.Promotion.ID
 	}
-	pparams := &NewOrderPaymentParams{
+	pparams := &NewProductOrderPaymentParams{
 		OrderID:    params.OrderID,
 		Address:    params.BillingAddress,
 		MethodType: params.PaymentMethodType,
@@ -102,7 +122,7 @@ func NewProductOrder(params *NewProductOrderParams) (*Order, error) {
 		Shipping:   params.Shipping,
 		Promotion:  params.Promotion,
 	}
-	payment, err := NewOrderPayment(pparams)
+	payment, err := NewProductOrderPayment(pparams)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +151,64 @@ func NewProductOrder(params *NewProductOrderParams) (*Order, error) {
 	}, nil
 }
 
-func (o *Order) Fill(payment *OrderPayment, fulfillments OrderFulfillments, items OrderItems) {
-	o.OrderPayment = *payment
+func NewExperienceOrder(params *NewExperienceOrderParams) (*Order, error) {
+	var promotionID string
+	if params.Promotion != nil {
+		promotionID = params.Promotion.ID
+	}
+	pparams := &NewExperienceOrderPaymentParams{
+		OrderID:               params.OrderID,
+		MethodType:            params.PaymentMethodType,
+		Address:               params.BillingAddress,
+		Experience:            params.Experience,
+		Promotion:             params.Promotion,
+		AdultCount:            params.AdultCount,
+		JuniorHighSchoolCount: params.JuniorHighSchoolCount,
+		ElementarySchoolCount: params.ElementarySchoolCount,
+		PreschoolCount:        params.PreschoolCount,
+		SeniorCount:           params.SeniorCount,
+	}
+	payment, err := NewExperienceOrderPayment(pparams)
+	if err != nil {
+		return nil, err
+	}
+	eparams := &NewOrderExperienceParams{
+		OrderID:               params.OrderID,
+		Experience:            params.Experience,
+		AdultCount:            params.AdultCount,
+		JuniorHighSchoolCount: params.JuniorHighSchoolCount,
+		ElementarySchoolCount: params.ElementarySchoolCount,
+		PreschoolCount:        params.PreschoolCount,
+		SeniorCount:           params.SeniorCount,
+		Transportation:        params.Transportation,
+		RequestedDate:         params.RequetsedDate,
+		RequestedTime:         params.RequetsedTime,
+	}
+	experience, err := NewOrderExperience(eparams)
+	if err != nil {
+		return nil, err
+	}
+	return &Order{
+		OrderPayment:    *payment,
+		OrderExperience: *experience,
+		ID:              params.OrderID,
+		SessionID:       params.SessionID,
+		UserID:          params.Customer.ID,
+		CoordinatorID:   params.CoordinatorID,
+		PromotionID:     promotionID,
+		Type:            OrderTypeExperience,
+		Status:          OrderStatusUnpaid, // 初期ステータスは「支払い待ち」で登録
+		ShippingMessage: "",
+	}, nil
+}
+
+func (o *Order) Fill(payment *OrderPayment, fulfillments OrderFulfillments, items OrderItems, experience *OrderExperience) {
+	if payment != nil {
+		o.OrderPayment = *payment
+	}
+	if experience != nil {
+		o.OrderExperience = *experience
+	}
 	o.OrderFulfillments = fulfillments
 	o.OrderItems = items
 }
@@ -273,13 +349,22 @@ func (os Orders) ProductRevisionIDs() []int64 {
 	return res.Slice()
 }
 
-func (os Orders) Fill(payments map[string]*OrderPayment, fulfillments map[string]OrderFulfillments, items map[string]OrderItems) {
+func (os Orders) Fill(
+	payments map[string]*OrderPayment,
+	fulfillments map[string]OrderFulfillments,
+	items map[string]OrderItems,
+	experiences map[string]*OrderExperience,
+) {
 	for _, o := range os {
 		payment, ok := payments[o.ID]
 		if !ok {
 			payment = &OrderPayment{}
 		}
-		o.Fill(payment, fulfillments[o.ID], items[o.ID])
+		experience, ok := experiences[o.ID]
+		if !ok {
+			experience = &OrderExperience{}
+		}
+		o.Fill(payment, fulfillments[o.ID], items[o.ID], experience)
 	}
 }
 

--- a/api/internal/store/entity/order_experience.go
+++ b/api/internal/store/entity/order_experience.go
@@ -1,0 +1,148 @@
+package entity
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"gorm.io/datatypes"
+)
+
+// OrderExperience - 注文体験情報
+type OrderExperience struct {
+	OrderID               string                 `gorm:"primaryKey;<-:create"`        // 注文履歴ID
+	ExperienceRevisionID  int64                  `gorm:"primaryKey;<-:create"`        // 体験ID
+	AdultCount            int64                  `gorm:""`                            // 大人人数
+	JuniorHighSchoolCount int64                  `gorm:""`                            // 中学生人数
+	ElementarySchoolCount int64                  `gorm:""`                            // 小学生人数
+	PreschoolCount        int64                  `gorm:""`                            // 幼児人数
+	SeniorCount           int64                  `gorm:""`                            // シニア人数
+	Remarks               OrderExperienceRemarks `gorm:"-"`                           // 備考
+	RemarksJSON           datatypes.JSON         `gorm:"default:null;column:remarks"` // 備考(JSON)
+	CreatedAt             time.Time              `gorm:"<-:create"`                   // 登録日時
+	UpdatedAt             time.Time              `gorm:""`                            // 更新日時
+}
+
+// OrderExperienceRemarks - 注文体験情報詳細
+type OrderExperienceRemarks struct {
+	Transportation string    `json:"transportation"` // 交通手段
+	RequestedDate  time.Time `json:"requestedDate"`  // 体験希望日
+	RequestedTime  time.Time `json:"requestedTime"`  // 体験希望時間
+}
+
+type OrderExperiences []*OrderExperience
+
+type NewOrderExperienceParams struct {
+	OrderID               string
+	Experience            *Experience
+	AdultCount            int64
+	JuniorHighSchoolCount int64
+	ElementarySchoolCount int64
+	PreschoolCount        int64
+	SeniorCount           int64
+	Transportation        string
+	RequestedDate         string
+	RequestedTime         string
+}
+
+type NewOrderExperienceRemarksParams struct {
+	Transportation string
+	RequestedDate  string
+	RequestedTime  string
+}
+
+func NewOrderExperience(params *NewOrderExperienceParams) (*OrderExperience, error) {
+	rparams := &NewOrderExperienceRemarksParams{
+		Transportation: params.Transportation,
+		RequestedDate:  params.RequestedDate,
+		RequestedTime:  params.RequestedTime,
+	}
+	remarks, err := NewOrderExperienceRemarks(rparams)
+	if err != nil {
+		return nil, err
+	}
+	return &OrderExperience{
+		OrderID:               params.OrderID,
+		ExperienceRevisionID:  params.Experience.ExperienceRevision.ID,
+		AdultCount:            params.AdultCount,
+		JuniorHighSchoolCount: params.JuniorHighSchoolCount,
+		ElementarySchoolCount: params.ElementarySchoolCount,
+		PreschoolCount:        params.PreschoolCount,
+		SeniorCount:           params.SeniorCount,
+		Remarks:               *remarks,
+	}, nil
+}
+
+func (o *OrderExperience) Fill() error {
+	remarks, err := o.unmarshalRemarks()
+	if err != nil {
+		return err
+	}
+	o.Remarks = *remarks
+	return nil
+}
+
+func (o *OrderExperience) unmarshalRemarks() (*OrderExperienceRemarks, error) {
+	if o.RemarksJSON == nil {
+		return &OrderExperienceRemarks{}, nil
+	}
+	var remarks *OrderExperienceRemarks
+	return remarks, json.Unmarshal(o.RemarksJSON, &remarks)
+}
+
+func (o *OrderExperience) FillJSON() error {
+	remarks, err := o.Remarks.Marshal()
+	if err != nil {
+		return err
+	}
+	o.RemarksJSON = remarks
+	return nil
+}
+
+func (os OrderExperiences) MapByOrderID() map[string]*OrderExperience {
+	m := make(map[string]*OrderExperience)
+	for _, o := range os {
+		m[o.OrderID] = o
+	}
+	return m
+}
+
+func (os OrderExperiences) Fill() error {
+	for _, o := range os {
+		if err := o.Fill(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewOrderExperienceRemarks(params *NewOrderExperienceRemarksParams) (*OrderExperienceRemarks, error) {
+	var (
+		requestedDate, requestedTime time.Time
+		err                          error
+	)
+	if params.RequestedDate != "" {
+		requestedDate, err = jst.ParseFromYYYYMMDD(params.RequestedDate)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if params.RequestedTime != "" {
+		requestedTime, err = jst.ParseFromHHMM(params.RequestedTime)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &OrderExperienceRemarks{
+		Transportation: params.Transportation,
+		RequestedDate:  requestedDate,
+		RequestedTime:  requestedTime,
+	}, nil
+}
+
+func (r *OrderExperienceRemarks) Marshal() ([]byte, error) {
+	if len(r.Transportation) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(r)
+}

--- a/api/internal/store/entity/order_experience_test.go
+++ b/api/internal/store/entity/order_experience_test.go
@@ -1,0 +1,186 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/and-period/furumaru/api/pkg/mysql"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+)
+
+func TestOrderExperience(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		params *NewOrderExperienceParams
+		expect *OrderExperience
+		hasErr bool
+	}{
+		{
+			name: "success",
+			params: &NewOrderExperienceParams{
+				OrderID: "order-id",
+				Experience: &Experience{
+					ID:            "experience-id",
+					CoordinatorID: "coordinator-id",
+					ProducerID:    "producer-id",
+					TypeID:        "experience-type-id",
+					Title:         "じゃがいも収穫",
+					Description:   "じゃがいもを収穫する体験",
+					Public:        true,
+					SoldOut:       false,
+					Status:        ExperienceStatusAccepting,
+					ThumbnailURL:  "http://example.com/thumbnail.png",
+					Media: MultiExperienceMedia{
+						{
+							URL:         "http://example.com/thumbnail.png",
+							IsThumbnail: true,
+						},
+					},
+					MediaJSON: datatypes.JSON([]byte(`[{"url":"http://example.com/thumbnail.png","isThumbnail":true}]`)),
+					RecommendedPoints: []string{
+						"ポイント1",
+						"ポイント2",
+					},
+					RecommendedPointsJSON: datatypes.JSON([]byte(`["ポイント1","ポイント2"]`)),
+					PromotionVideoURL:     "http://example.com/promotion.mp4",
+					Duration:              60,
+					Direction:             "彦根駅から徒歩10分",
+					BusinessOpenTime:      "1000",
+					BusinessCloseTime:     "1800",
+					HostPostalCode:        "5220061",
+					HostPrefecture:        "滋賀県",
+					HostPrefectureCode:    25,
+					HostCity:              "彦根市",
+					HostAddressLine1:      "金亀町１−１",
+					HostAddressLine2:      "",
+					HostLongitude:         136.251739,
+					HostLatitude:          35.276833,
+					HostGeolocation: mysql.Geometry{
+						X: 136.251739,
+						Y: 35.276833,
+					},
+					ExperienceRevision: ExperienceRevision{
+						ID:                    1,
+						ExperienceID:          "experience-id",
+						PriceAdult:            1000,
+						PriceJuniorHighSchool: 500,
+						PriceElementarySchool: 300,
+						PricePreschool:        0,
+						PriceSenior:           200,
+					},
+					StartAt:   now.AddDate(0, 0, -1),
+					EndAt:     now.AddDate(0, 0, 1),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				Transportation:        "徒歩",
+				RequestedDate:         "20210101",
+				RequestedTime:         "1000",
+				AdultCount:            1,
+				JuniorHighSchoolCount: 2,
+				ElementarySchoolCount: 3,
+				PreschoolCount:        4,
+				SeniorCount:           5,
+			},
+			expect: &OrderExperience{
+				OrderID:               "order-id",
+				ExperienceRevisionID:  1,
+				AdultCount:            1,
+				JuniorHighSchoolCount: 2,
+				ElementarySchoolCount: 3,
+				PreschoolCount:        4,
+				SeniorCount:           5,
+				Remarks: OrderExperienceRemarks{
+					Transportation: "徒歩",
+					RequestedDate:  jst.Date(2021, 1, 1, 0, 0, 0, 0),
+					RequestedTime:  jst.Date(0, 1, 1, 10, 0, 0, 0),
+				},
+			},
+			hasErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := NewOrderExperience(tt.params)
+			assert.Equal(t, tt.hasErr, err != nil, err)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestNewOrderExperienceRemarks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params *NewOrderExperienceRemarksParams
+		expect *OrderExperienceRemarks
+		hasErr bool
+	}{
+		{
+			name: "success",
+			params: &NewOrderExperienceRemarksParams{
+				Transportation: "徒歩",
+				RequestedDate:  "20220101",
+				RequestedTime:  "1000",
+			},
+			expect: &OrderExperienceRemarks{
+				Transportation: "徒歩",
+				RequestedDate:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				RequestedTime:  jst.Date(0, 1, 1, 10, 0, 0, 0),
+			},
+			hasErr: false,
+		},
+		{
+			name: "empty params",
+			params: &NewOrderExperienceRemarksParams{
+				Transportation: "",
+				RequestedDate:  "",
+				RequestedTime:  "",
+			},
+			expect: &OrderExperienceRemarks{
+				Transportation: "",
+				RequestedDate:  time.Time{},
+				RequestedTime:  time.Time{},
+			},
+			hasErr: false,
+		},
+		{
+			name: "invalid requested date",
+			params: &NewOrderExperienceRemarksParams{
+				Transportation: "徒歩",
+				RequestedDate:  "2022-01-01",
+				RequestedTime:  "1000",
+			},
+			expect: nil,
+			hasErr: true,
+		},
+		{
+			name: "invalid requested time",
+			params: &NewOrderExperienceRemarksParams{
+				Transportation: "徒歩",
+				RequestedDate:  "20220101",
+				RequestedTime:  "10:00",
+			},
+			expect: nil,
+			hasErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := NewOrderExperienceRemarks(tt.params)
+			assert.Equal(t, tt.hasErr, err != nil, err)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/store/exporter/sagawa/sagawa.go
+++ b/api/internal/store/exporter/sagawa/sagawa.go
@@ -225,7 +225,7 @@ func NewReceipt(params *ReceiptParams) exporter.Receipt {
 }
 
 func (r *Receipt) SetReceiptDetails(order *entity.Order, fulfillment *entity.OrderFulfillment) {
-	r.OrderID = order.OrderID
+	r.OrderID = order.ID
 	r.UserID = order.UserID
 	r.DivisionClientCodeType = ""
 	r.DivisionClientCode = ""

--- a/api/internal/store/service/cart.go
+++ b/api/internal/store/service/cart.go
@@ -78,14 +78,14 @@ func (s *service) CalcCart(ctx context.Context, in *store.CalcCartInput) (*entit
 	if err != nil {
 		return nil, nil, internalError(err)
 	}
-	params := &entity.NewOrderPaymentSummaryParams{
+	params := &entity.NewProductOrderPaymentSummaryParams{
 		PrefectureCode: in.PrefectureCode,
 		Baskets:        baskets,
 		Products:       products,
 		Shipping:       shipping,
 		Promotion:      promotion,
 	}
-	summary, err := entity.NewOrderPaymentSummary(params)
+	summary, err := entity.NewProductOrderPaymentSummary(params)
 	if err != nil {
 		return nil, nil, internalError(err)
 	}

--- a/infra/mysql/schema/2024090601-stores-create-order-experiences.sql
+++ b/infra/mysql/schema/2024090601-stores-create-order-experiences.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS `stores`.`order_experiences` (
+  `order_id`                 VARCHAR(22) NOT NULL,          -- 注文ID
+  `experience_revision_id`   BIGINT      NOT NULL,          -- 体験ID
+  `adult_count`              BIGINT      NOT NULL,          -- 大人人数
+  `junior_high_school_count` BIGINT      NOT NULL,          -- 中学生人数
+  `elementary_school_count`  BIGINT      NOT NULL,          -- 小学生人数
+  `preschool_count`          BIGINT      NOT NULL,          -- 幼児人数
+  `senior_count`             BIGINT      NOT NULL,          -- シニア人数
+  `remarks`                  JSON        NULL DEFAULT NULL, -- 備考
+  `created_at`               DATETIME(3) NOT NULL,          -- 登録日時
+  `updated_at`               DATETIME(3) NOT NULL,          -- 更新日時
+  PRIMARY KEY (`order_id`, `experience_revision_id`),
+  CONSTRAINT `fk_order_experiences_order_id`
+    FOREIGN KEY (`order_id`) REFERENCES `stores`.`orders` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_order_experiences_experience_revision_id`
+    FOREIGN KEY (`experience_revision_id`) REFERENCES `stores`.`experience_revisions` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 注文管理システムに体験注文をサポートする機能を追加。
  - 注文体験に関する新しいテーブルをデータベースに作成。

- **バグ修正**
  - 注文IDの取得方法を修正し、正しいフィールド参照を適用。

- **テスト**
  - 注文体験に関連する新しいユニットテストを追加し、テストカバレッジを強化。
  - 既存のテストケースを更新し、製品および体験注文の処理を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->