### PR TITLE
feat(messenger): 体験注文時の通知実装

### DIFF
--- a/api/config/messenger/mailer/dev.yaml
+++ b/api/config/messenger/mailer/dev.yaml
@@ -1,6 +1,7 @@
 admin-register: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
 admin-reset-password: 'd-80b1acb90b2346eda830476e5f3eae38'
 user-received-contact: 'd-b91d425a9c3b4172b27d32d4873e47b5'
-user-order-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-product-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-experience-authorized: 'd-8e75f30aef69476990d23644f75a790e'
 user-order-shipped: 'd-45607d91970c4791a15da0fa8becf9cc'
 user-start-live: 'd-7205bbfbef054ca6b8976b2e399cd42a'

--- a/api/config/messenger/mailer/prd.yaml
+++ b/api/config/messenger/mailer/prd.yaml
@@ -1,6 +1,7 @@
 admin-register: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
 admin-reset-password: 'd-80b1acb90b2346eda830476e5f3eae38'
 user-received-contact: 'd-b91d425a9c3b4172b27d32d4873e47b5'
-user-order-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-product-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-experience-authorized: 'd-8e75f30aef69476990d23644f75a790e'
 user-order-shipped: 'd-45607d91970c4791a15da0fa8becf9cc'
 user-start-live: 'd-7205bbfbef054ca6b8976b2e399cd42a'

--- a/api/config/messenger/mailer/stg.yaml
+++ b/api/config/messenger/mailer/stg.yaml
@@ -1,6 +1,7 @@
 admin-register: 'd-6c7e4887e7c7462ab9b66b85cc4cd117'
 admin-reset-password: 'd-80b1acb90b2346eda830476e5f3eae38'
 user-received-contact: 'd-b91d425a9c3b4172b27d32d4873e47b5'
-user-order-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-product-authorized: 'd-be6a54c1aefd4ed4889994487a0b0d66'
+user-order-experience-authorized: 'd-8e75f30aef69476990d23644f75a790e'
 user-order-shipped: 'd-45607d91970c4791a15da0fa8becf9cc'
 user-start-live: 'd-7205bbfbef054ca6b8976b2e399cd42a'

--- a/api/internal/messenger/entity/mail_config.go
+++ b/api/internal/messenger/entity/mail_config.go
@@ -14,12 +14,13 @@ import (
 type EmailTemplateID string
 
 const (
-	EmailTemplateIDAdminRegister       EmailTemplateID = "admin-register"        // 管理者登録
-	EmailTemplateIDAdminResetPassword  EmailTemplateID = "admin-reset-password"  // 管理者パスワードリセット
-	EmailTemplateIDUserReceivedContact EmailTemplateID = "user-received-contact" // お問い合わせ受領
-	EmailTemplateIDUserOrderAuthorized EmailTemplateID = "user-order-authorized" // 支払い完了
-	EmailTemplateIDUserOrderShipped    EmailTemplateID = "user-order-shipped"    // 発送完了
-	EmailTemplateIDUserStartLive       EmailTemplateID = "user-start-live"       // ライブ配信開始
+	EmailTemplateIDAdminRegister                 EmailTemplateID = "admin-register"                   // 管理者登録
+	EmailTemplateIDAdminResetPassword            EmailTemplateID = "admin-reset-password"             // 管理者パスワードリセット
+	EmailTemplateIDUserReceivedContact           EmailTemplateID = "user-received-contact"            // お問い合わせ受領
+	EmailTemplateIDUserOrderProductAuthorized    EmailTemplateID = "user-order-product-authorized"    // 支払い完了
+	EmailTemplateIDUserOrderExperienceAuthorized EmailTemplateID = "user-order-experience-authorized" // 体験支払い完了
+	EmailTemplateIDUserOrderShipped              EmailTemplateID = "user-order-shipped"               // 発送完了
+	EmailTemplateIDUserStartLive                 EmailTemplateID = "user-start-live"                  // ライブ配信開始
 )
 
 // MailConfig - メール送信設定
@@ -100,6 +101,12 @@ func (b *TemplateDataBuilder) OrderPayment(payment *sentity.OrderPayment) *Templ
 	return b
 }
 
+func (b *TemplateDataBuilder) OrderBilling(address *uentity.Address) *TemplateDataBuilder {
+	b.data["郵便番号"] = address.PostalCode
+	b.data["住所"] = address.FullPath()
+	return b
+}
+
 func (b *TemplateDataBuilder) OrderFulfillment(fulfillments sentity.OrderFulfillments, addresses map[int64]*uentity.Address) *TemplateDataBuilder {
 	if len(fulfillments) == 0 || len(addresses) == 0 {
 		return b
@@ -124,6 +131,16 @@ func (b *TemplateDataBuilder) OrderItems(items sentity.OrderItems, products map[
 		data = append(data, newOrderItem(item, product))
 	}
 	b.data["商品一覧"] = data
+	return b
+}
+
+func (b *TemplateDataBuilder) OrderExperience(item *sentity.OrderExperience, experience *sentity.Experience) *TemplateDataBuilder {
+	b.data["体験概要"] = experience.Title
+	b.data["大人人数"] = strconv.FormatInt(item.AdultCount, 10)
+	b.data["中学生人数"] = strconv.FormatInt(item.JuniorHighSchoolCount, 10)
+	b.data["小学生人数"] = strconv.FormatInt(item.ElementarySchoolCount, 10)
+	b.data["幼児人数"] = strconv.FormatInt(item.PreschoolCount, 10)
+	b.data["シニア人数"] = strconv.FormatInt(item.SeniorCount, 10)
 	return b
 }
 

--- a/api/internal/messenger/entity/mail_config_test.go
+++ b/api/internal/messenger/entity/mail_config_test.go
@@ -46,6 +46,20 @@ func TestTemplateBuilder(t *testing.T) {
 			OrderID:           "order-id",
 			Quantity:          2,
 		}},
+		OrderExperience: sentity.OrderExperience{
+			OrderID:               "order-id",
+			ExperienceRevisionID:  1,
+			AdultCount:            2,
+			JuniorHighSchoolCount: 1,
+			ElementarySchoolCount: 0,
+			PreschoolCount:        0,
+			SeniorCount:           0,
+			Remarks: sentity.OrderExperienceRemarks{
+				Transportation: "電車",
+				RequestedDate:  now,
+				RequestedTime:  now,
+			},
+		},
 		ID:              "order-id",
 		UserID:          "user-id",
 		CoordinatorID:   "coordinator-id",
@@ -68,6 +82,49 @@ func TestTemplateBuilder(t *testing.T) {
 			Name:          "おいしいじゃがいも",
 			Public:        true,
 			ThumbnailURL:  "http://example.com/image.png",
+		},
+	}
+	experience := &sentity.Experience{
+		CoordinatorID: "coordinator-id",
+		ProducerID:    "producer-id",
+		TypeID:        "experience-type-id",
+		Title:         "じゃがいも収穫",
+		Description:   "じゃがいもを収穫する体験",
+		Public:        true,
+		SoldOut:       false,
+		Status:        sentity.ExperienceStatusAccepting,
+		Media: sentity.MultiExperienceMedia{{
+			URL:         "http://example.com/thumbnail.png",
+			IsThumbnail: true,
+		}},
+		RecommendedPoints: []string{
+			"じゃがいもを収穫する",
+			"じゃがいもを食べる",
+			"じゃがいもを持ち帰る",
+		},
+		PromotionVideoURL:  "http://example.com/promotion.mp4",
+		Duration:           60,
+		Direction:          "彦根駅から徒歩10分",
+		BusinessOpenTime:   "1000",
+		BusinessCloseTime:  "1800",
+		HostPostalCode:     "5220061",
+		HostPrefecture:     "滋賀県",
+		HostPrefectureCode: 25,
+		HostCity:           "彦根市",
+		HostAddressLine1:   "金亀町１−１",
+		HostAddressLine2:   "",
+		HostLongitude:      136.251739,
+		HostLatitude:       35.276833,
+		StartAt:            now.AddDate(0, -1, 0),
+		EndAt:              now.AddDate(0, 1, 0),
+		ExperienceRevision: sentity.ExperienceRevision{
+			ID:                    0,
+			ExperienceID:          "", // ignore
+			PriceAdult:            1000,
+			PriceJuniorHighSchool: 800,
+			PriceElementarySchool: 600,
+			PricePreschool:        400,
+			PriceSenior:           200,
 		},
 	}
 	addresses := map[int64]*uentity.Address{
@@ -103,8 +160,10 @@ func TestTemplateBuilder(t *testing.T) {
 			Contact("件名", "本文").
 			Live("マルシェ", "濵田 海斗", now, now).
 			OrderPayment(&order.OrderPayment).
+			OrderBilling(addresses[1]).
 			OrderFulfillment(order.OrderFulfillments, addresses).
 			OrderItems(order.OrderItems, products).
+			OrderExperience(&order.OrderExperience, experience).
 			Shipped(order.ShippingMessage)
 		data := builder.Build()
 		assert.Equal(t, "value", data["key"])
@@ -130,6 +189,12 @@ func TestTemplateBuilder(t *testing.T) {
 		assert.Equal(t, "1000014", data["郵便番号"])
 		assert.Equal(t, "東京都 千代田区 永田町1-7-1", data["住所"])
 		assert.Equal(t, "ありがとうございます", data["メッセージ"])
+		assert.Equal(t, "じゃがいも収穫", data["体験概要"])
+		assert.Equal(t, "2", data["大人人数"])
+		assert.Equal(t, "1", data["中学生人数"])
+		assert.Equal(t, "0", data["小学生人数"])
+		assert.Equal(t, "0", data["幼児人数"])
+		assert.Equal(t, "0", data["シニア人数"])
 		assert.Equal(t, []map[string]string{{
 			"商品名":      "おいしいじゃがいも",
 			"サムネイルURL": "http://example.com/image.png",

--- a/api/internal/messenger/entity/report_config.go
+++ b/api/internal/messenger/entity/report_config.go
@@ -10,9 +10,10 @@ import (
 type ReportTemplateID string
 
 const (
-	ReportTemplateIDReceivedContact ReportTemplateID = "received-contact" // お問い合わせ受領
-	ReportTemplateIDNotification    ReportTemplateID = "notification"     // お知らせ投稿
-	ReportTemplateIDOrderAuthorized ReportTemplateID = "order-authorized" // 支払い完了
+	ReportTemplateIDReceivedContact           ReportTemplateID = "received-contact"            // お問い合わせ受領
+	ReportTemplateIDNotification              ReportTemplateID = "notification"                // お知らせ投稿
+	ReportTemplateIDOrderProductAuthorized    ReportTemplateID = "order-product-authorized"    // 支払い完了（商品）
+	ReportTemplateIDOrderExperienceAuthorized ReportTemplateID = "order-experience-authorized" // 支払い完了（体験）
 )
 
 // ReportConfig - システムレポート送信設定

--- a/api/internal/messenger/service/notify_test.go
+++ b/api/internal/messenger/service/notify_test.go
@@ -226,50 +226,66 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 	orderIn := &store.GetOrderInput{
 		OrderID: "order-id",
 	}
-	order := &sentity.Order{
-		OrderPayment: sentity.OrderPayment{
-			OrderID:           "order-id",
-			AddressRevisionID: 1,
-			Status:            sentity.PaymentStatusPending,
-			TransactionID:     "transaction-id",
-			PaymentID:         "payment-id",
-			MethodType:        sentity.PaymentMethodTypeCreditCard,
-			Subtotal:          4460,
-			Discount:          446,
-			ShippingFee:       0,
-			Tax:               364,
-			Total:             4014,
-			PaidAt:            now,
-		},
-		OrderFulfillments: sentity.OrderFulfillments{
-			{
+	order := func(typ sentity.OrderType) *sentity.Order {
+		return &sentity.Order{
+			OrderPayment: sentity.OrderPayment{
 				OrderID:           "order-id",
 				AddressRevisionID: 1,
-				Status:            sentity.FulfillmentStatusUnfulfilled,
-				TrackingNumber:    "",
-				ShippingCarrier:   sentity.ShippingCarrierUnknown,
-				ShippingType:      sentity.ShippingTypeNormal,
-				BoxNumber:         1,
-				BoxSize:           sentity.ShippingSize60,
+				Status:            sentity.PaymentStatusPending,
+				TransactionID:     "transaction-id",
+				PaymentID:         "payment-id",
+				MethodType:        sentity.PaymentMethodTypeCreditCard,
+				Subtotal:          4460,
+				Discount:          446,
+				ShippingFee:       0,
+				Tax:               364,
+				Total:             4014,
+				PaidAt:            now,
 			},
-		},
-		OrderItems: sentity.OrderItems{
-			{
-				ProductRevisionID: 1,
-				OrderID:           "order-id",
-				Quantity:          1,
+			OrderFulfillments: sentity.OrderFulfillments{
+				{
+					OrderID:           "order-id",
+					AddressRevisionID: 1,
+					Status:            sentity.FulfillmentStatusUnfulfilled,
+					TrackingNumber:    "",
+					ShippingCarrier:   sentity.ShippingCarrierUnknown,
+					ShippingType:      sentity.ShippingTypeNormal,
+					BoxNumber:         1,
+					BoxSize:           sentity.ShippingSize60,
+				},
 			},
-			{
-				ProductRevisionID: 2,
-				OrderID:           "order-id",
-				Quantity:          2,
+			OrderItems: sentity.OrderItems{
+				{
+					ProductRevisionID: 1,
+					OrderID:           "order-id",
+					Quantity:          1,
+				},
+				{
+					ProductRevisionID: 2,
+					OrderID:           "order-id",
+					Quantity:          2,
+				},
 			},
-		},
-		ID:            "order-id",
-		UserID:        "user-id",
-		CoordinatorID: "coordinator-id",
-		PromotionID:   "",
-		Type:          sentity.OrderTypeProduct,
+			OrderExperience: sentity.OrderExperience{
+				OrderID:               "order-id",
+				ExperienceRevisionID:  1,
+				AdultCount:            2,
+				JuniorHighSchoolCount: 1,
+				ElementarySchoolCount: 0,
+				PreschoolCount:        0,
+				SeniorCount:           0,
+				Remarks: sentity.OrderExperienceRemarks{
+					Transportation: "電車",
+					RequestedDate:  now,
+					RequestedTime:  now,
+				},
+			},
+			ID:            "order-id",
+			UserID:        "user-id",
+			CoordinatorID: "coordinator-id",
+			PromotionID:   "",
+			Type:          typ,
+		}
 	}
 	coordinatorIn := &user.GetCoordinatorInput{
 		CoordinatorID: "coordinator-id",
@@ -309,6 +325,15 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 			},
 		},
 	}
+	experiencesIn := &store.MultiGetExperiencesByRevisionInput{
+		ExperienceRevisionIDs: []int64{1},
+	}
+	experiences := sentity.Experiences{
+		{
+			ID:    "experience-id",
+			Title: "じゃがいも収穫",
+		},
+	}
 	addresses := uentity.Addresses{
 		{
 			AddressRevision: uentity.AddressRevision{
@@ -337,10 +362,38 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 		input     *messenger.NotifyOrderAuthorizedInput
 		expectErr error
 	}{
+		// Common
 		{
-			name: "success",
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &messenger.NotifyOrderAuthorizedInput{},
+			expectErr: exception.ErrInvalidArgument,
+		},
+		{
+			name: "failed to get order",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order, nil)
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(nil, assert.AnError)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "unknown order type",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeUnknown), nil)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: nil,
+		},
+		// OrderType Product
+		{
+			name: "product success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
 				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).Times(2)
@@ -380,7 +433,7 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 							UserType:  entity.UserTypeUser,
 							UserIDs:   []string{"user-id"},
 							Email: &entity.MailConfig{
-								TemplateID: entity.EmailTemplateIDUserOrderAuthorized,
+								TemplateID: entity.EmailTemplateIDUserOrderProductAuthorized,
 								Substitutions: map[string]interface{}{
 									"注文番号":  "order-id",
 									"決済方法":  "クレジットカード決済",
@@ -410,7 +463,7 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 								},
 							},
 							Report: &entity.ReportConfig{
-								TemplateID: entity.ReportTemplateIDOrderAuthorized,
+								TemplateID: entity.ReportTemplateIDOrderProductAuthorized,
 								Overview:   "&. 太郎",
 								Author:     "&. コーディネータ",
 								Link:       "http://admin.example.com/orders/order-id",
@@ -427,25 +480,9 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "invalid argument",
-			setup:     func(ctx context.Context, mocks *mocks) {},
-			input:     &messenger.NotifyOrderAuthorizedInput{},
-			expectErr: exception.ErrInvalidArgument,
-		},
-		{
-			name: "failed to get order",
+			name: "product failed to get coordinator",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(nil, assert.AnError)
-			},
-			input: &messenger.NotifyOrderAuthorizedInput{
-				OrderID: "order-id",
-			},
-			expectErr: exception.ErrInternal,
-		},
-		{
-			name: "failed to get coordinator",
-			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order, nil)
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(nil, assert.AnError)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
 				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).AnyTimes()
@@ -456,9 +493,9 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 			expectErr: exception.ErrInternal,
 		},
 		{
-			name: "failed to multi get products",
+			name: "product failed to multi get products",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order, nil)
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).AnyTimes()
@@ -469,9 +506,9 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 			expectErr: exception.ErrInternal,
 		},
 		{
-			name: "failed to multi get addresses",
+			name: "product failed to multi get addresses",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order, nil)
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
 				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError).MinTimes(1)
@@ -482,13 +519,161 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 			expectErr: exception.ErrInternal,
 		},
 		{
-			name: "failed to send message",
+			name: "product failed to send message",
 			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order, nil)
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
 				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).Times(2)
 				mocks.db.ReceivedQueue.EXPECT().MultiCreate(ctx, gomock.Any()).Return(assert.AnError)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		// OrderType Experience
+		{
+			name: "experience success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(experiences, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+				mocks.db.ReceivedQueue.EXPECT().
+					MultiCreate(ctx, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, queues ...*entity.ReceivedQueue) error {
+						expect := []*entity.ReceivedQueue{
+							{
+								ID:         queues[0].ID, // ignore
+								NotifyType: entity.NotifyTypeEmail,
+								EventType:  entity.EventTypeOrderAuthorized,
+								UserType:   entity.UserTypeUser,
+								UserIDs:    []string{"user-id"},
+								Done:       false,
+							},
+							{
+								ID:         queues[1].ID, // ignore
+								NotifyType: entity.NotifyTypeReport,
+								EventType:  entity.EventTypeOrderAuthorized,
+								UserType:   entity.UserTypeUser,
+								UserIDs:    []string{"user-id"},
+								Done:       false,
+							},
+						}
+						assert.Equal(t, expect, queues)
+						return nil
+					})
+				mocks.producer.EXPECT().
+					SendMessage(ctx, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, b []byte) (string, error) {
+						payload := &entity.WorkerPayload{}
+						err := json.Unmarshal(b, payload)
+						require.NoError(t, err)
+						expect := &entity.WorkerPayload{
+							QueueID:   payload.QueueID, // ignore
+							EventType: entity.EventTypeOrderAuthorized,
+							UserType:  entity.UserTypeUser,
+							UserIDs:   []string{"user-id"},
+							Email: &entity.MailConfig{
+								TemplateID: entity.EmailTemplateIDUserOrderExperienceAuthorized,
+								Substitutions: map[string]interface{}{
+									"注文番号":  "order-id",
+									"決済方法":  "クレジットカード決済",
+									"商品金額":  "4460",
+									"配送手数料": "0",
+									"割引金額":  "446",
+									"消費税":   "364",
+									"合計金額":  "4014",
+									"郵便番号":  "1000014",
+									"住所":    "東京都 千代田区 永田町1-7-1",
+									"体験概要":  "じゃがいも収穫",
+									"大人人数":  "2",
+									"中学生人数": "1",
+									"小学生人数": "0",
+									"幼児人数":  "0",
+									"シニア人数": "0",
+								},
+							},
+							Report: &entity.ReportConfig{
+								TemplateID: entity.ReportTemplateIDOrderExperienceAuthorized,
+								Overview:   "&. 太郎",
+								Author:     "&. コーディネータ",
+								Link:       "http://admin.example.com/orders/order-id",
+								ReceivedAt: now.UTC(),
+							},
+						}
+						assert.Equal(t, expect, payload)
+						return "message-id", nil
+					})
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: nil,
+		},
+		{
+			name: "experience failed to get coordinator",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(nil, assert.AnError)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(experiences, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "experience failed to multi get experiences",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(nil, assert.AnError)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "experience failed to multi get addresses",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(experiences, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "experience failed to create received queue",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(experiences, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+				mocks.db.ReceivedQueue.EXPECT().MultiCreate(ctx, gomock.Any()).Return(assert.AnError)
+			},
+			input: &messenger.NotifyOrderAuthorizedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "experience failed to send message",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeExperience), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetExperiencesByRevision(gomock.Any(), experiencesIn).Return(experiences, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+				mocks.db.ReceivedQueue.EXPECT().MultiCreate(ctx, gomock.Any()).Return(nil)
+				mocks.producer.EXPECT().SendMessage(ctx, gomock.Any()).Return("", assert.AnError)
 			},
 			input: &messenger.NotifyOrderAuthorizedInput{
 				OrderID: "order-id",


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザーオーダーに関する新しいメールテンプレートが追加され、より詳細な通知が可能に。
	- 注文の請求情報や体験データを収集する新しいメソッドが追加され、通知内容が充実。

- **バグ修正**
	- 注文通知の処理が改善され、エラー処理が強化。

- **テスト**
	- 注文通知のテストが強化され、さまざまなシナリオをカバー。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->