### PR TITLE
Release for v1.11.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.11.41](https://github.com/and-period/furumaru/compare/v1.11.40...v1.11.41) - 2024-09-18
+- build(deps-dev): bump npm-run-all2 from 6.2.2 to 6.2.3 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2408
+- ライブ配信に紐づいてる商品のサムネイルのレイアウト調整 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2405
+
 ## [v1.11.40](https://github.com/and-period/furumaru/compare/v1.11.39...v1.11.40) - 2024-09-17
 - feat(user): 残っている部分のi18n対応と、ブラウザ言語を検知して切り替え by @sea-kai in https://github.com/and-period/furumaru/pull/2398
 - feat(workflow): arm64のコンテナを利用するように by @taba2424 in https://github.com/and-period/furumaru/pull/2407


### PR DESCRIPTION
This pull request is for the next release as v1.11.41 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.41 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.40" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps-dev): bump npm-run-all2 from 6.2.2 to 6.2.3 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2408
* ライブ配信に紐づいてる商品のサムネイルのレイアウト調整 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2405


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.40...v1.11.41