### PR TITLE
Release for v1.11.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.11.43](https://github.com/and-period/furumaru/compare/v1.11.42...v1.11.43) - 2024-09-23
+- fix: topのボタン文言修正 by @sea-kai in https://github.com/and-period/furumaru/pull/2415
+
 ## [v1.11.42](https://github.com/and-period/furumaru/compare/v1.11.41...v1.11.42) - 2024-09-20
 - feat(user): Topの文言変更とスタイル調整 by @sea-kai in https://github.com/and-period/furumaru/pull/2412
 


### PR DESCRIPTION
This pull request is for the next release as v1.11.43 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.43 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.42" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: topのボタン文言修正 by @sea-kai in https://github.com/and-period/furumaru/pull/2415


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.42...v1.11.43