### PR TITLE
Release for v1.11.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.11.46](https://github.com/and-period/furumaru/compare/v1.11.45...v1.11.46) - 2024-10-08
+- feat(store): 0円決済の対応 by @taba2424 in https://github.com/and-period/furumaru/pull/2427
+- fix(store): 0円決済時のステータスを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2429
+- 未ログイン時の購入フローでログインを挟まずにゲスト購入に流れるように変更 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2430
+- 住所入力フォームの郵便番号のエラーハンドリングを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2419
+
 ## [v1.11.45](https://github.com/and-period/furumaru/compare/v1.11.44...v1.11.45) - 2024-10-02
 - build(deps): bump the dependencies group across 1 directory with 60 updates by @dependabot in https://github.com/and-period/furumaru/pull/2417
 - 大嶋さんからの指摘を修正 by @hamachans in https://github.com/and-period/furumaru/pull/2426


### PR DESCRIPTION
This pull request is for the next release as v1.11.46 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.11.46 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.11.45" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(store): 0円決済の対応 by @taba2424 in https://github.com/and-period/furumaru/pull/2427
* fix(store): 0円決済時のステータスを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2429
* 未ログイン時の購入フローでログインを挟まずにゲスト購入に流れるように変更 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2430
* 住所入力フォームの郵便番号のエラーハンドリングを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2419


**Full Changelog**: https://github.com/and-period/furumaru/compare/v1.11.45...v1.11.46