### PR TITLE
未ログイン時の購入フローでログインを挟まずにゲスト購入に流れるように変更

### DIFF
--- a/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
+++ b/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
@@ -59,14 +59,17 @@ const handelClickRemoveItemButton = (id: string) => {
       </div>
 
       <div class="my-9">
-        <div>{{ ct('cartCountLabel') }}{{ cart.items.length }}</div>
-        <div>{{ ct('shipFromLabel') }}{{ `${coordinator.prefecture}${coordinator.city}` }}</div>
-        <div>{{ ct('coordinatorLabel') }}{{ coordinator.username }}</div>
+        <div>{{ ct("cartCountLabel") }}{{ cart.items.length }}</div>
+        <div>
+          {{ ct("shipFromLabel")
+          }}{{ `${coordinator.prefecture}${coordinator.city}` }}
+        </div>
+        <div>{{ ct("coordinatorLabel") }}{{ coordinator.username }}</div>
       </div>
 
       <div class="flex items-center justify-between font-bold">
         <div class="text-[14px]">
-          {{ ct('totalPriceLabel') }}
+          {{ ct("totalPriceLabel") }}
         </div>
         <div class="text-[20px]">
           {{ priceStringFormatter(totalPrice) }}
@@ -75,18 +78,18 @@ const handelClickRemoveItemButton = (id: string) => {
 
       <hr class="my-5 border-main">
 
-      <div>{{ ct('shippingFeeNotice') }}</div>
+      <div>{{ ct("shippingFeeNotice") }}</div>
 
       <button
         class="mt-8 bg-main p-[14px] text-[16px] text-white"
         @click="handleBuyButton"
       >
-        {{ ct('checkoutButtonText') }}
+        {{ ct("checkoutButtonText") }}
       </button>
     </div>
 
     <div
-      class="relative col-span-10 rounded-3xl bg-white px-4 py-6 lg:px-16 lg:py-12"
+      class="relative rounded-3xl bg-white px-4 py-6 lg:px-16 lg:py-12 col-span-10"
     >
       <div
         class="absolute -left-4 top-12 hidden h-8 w-8 rotate-45 bg-white lg:block"
@@ -96,7 +99,7 @@ const handelClickRemoveItemButton = (id: string) => {
         <div
           class="mb-7 rounded-2xl bg-base p-2 text-center font-bold tracking-[1.2px] text-main"
         >
-          {{ ct('cartTitle') }} #{{ cartNumber }} -{{ coordinator.marcheName }}-
+          {{ ct("cartTitle") }} #{{ cartNumber }} -{{ coordinator.marcheName }}-
         </div>
 
         <div class="flex w-full flex-col text-main">
@@ -105,11 +108,11 @@ const handelClickRemoveItemButton = (id: string) => {
             class="hidden grid-cols-5 items-center border-b py-2 text-[12px] tracking-[1.2px] md:grid"
           >
             <div class="col-span-2">
-              {{ ct('productNameLabel') }}
+              {{ ct("productNameLabel") }}
             </div>
-            <div>{{ ct('productPriceLabel') }}</div>
-            <div>{{ ct('quantityLabel') }}</div>
-            <div>{{ ct('subtotalLabel') }}</div>
+            <div>{{ ct("productPriceLabel") }}</div>
+            <div>{{ ct("quantityLabel") }}</div>
+            <div>{{ ct("subtotalLabel") }}</div>
           </div>
 
           <!-- PC、タブレットのみで表示する -->
@@ -119,15 +122,27 @@ const handelClickRemoveItemButton = (id: string) => {
             class="hidden grid-cols-5 items-center border-b py-2 md:grid"
           >
             <div class="col-span-2 flex gap-4">
-              <nuxt-img
-                provider="cloudFront"
-                :src="item.product.thumbnail.url"
-                class="block h-16 w-16"
-                height="64px"
-                width="64px"
-                :alt="`${item.product.name}のサムネイル画像`"
-              />
-              {{ item.product.name }}
+              <template v-if="item.product?.thumbnail.url.endsWith('.mp4')">
+                <video
+                  :src="item.product.thumbnail.url"
+                  class="block h-16 w-16 aspect-square"
+                  autoplay
+                  loop
+                />
+              </template>
+              <template v-else>
+                <nuxt-img
+                  provider="cloudFront"
+                  :src="item.product.thumbnail.url"
+                  class="block h-16 w-16"
+                  height="64px"
+                  width="64px"
+                  :alt="`${item.product.name}のサムネイル画像`"
+                />
+              </template>
+              <div class="w-40 line-clamp-4 break-before-all">
+                {{ item.product.name }}
+              </div>
             </div>
             <div>
               {{ priceStringFormatter(item.product.price) }}
@@ -139,7 +154,7 @@ const handelClickRemoveItemButton = (id: string) => {
                 type="button"
                 @click="handelClickRemoveItemButton(item.product.id)"
               >
-                {{ ct('deleteButtonText') }}
+                {{ ct("deleteButtonText") }}
               </button>
             </div>
             <div>
@@ -153,14 +168,24 @@ const handelClickRemoveItemButton = (id: string) => {
             :key="j"
             class="flex gap-3 border-b py-2 md:hidden"
           >
-            <nuxt-img
-              provider="cloudFront"
-              :src="item.product.thumbnail.url"
-              class="block h-16 w-16"
-              width="64px"
-              height="64px"
-              :alt="`${item.product.name}のサムネイル画像`"
-            />
+            <template v-if="item.product?.thumbnail.url.endsWith('.mp4')">
+              <video
+                :src="item.product.thumbnail.url"
+                class="block h-16 w-16 aspect-square"
+                autoplay
+                loop
+              />
+            </template>
+            <template v-else>
+              <nuxt-img
+                provider="cloudFront"
+                :src="item.product.thumbnail.url"
+                class="block h-16 w-16"
+                width="64px"
+                height="64px"
+                :alt="`${item.product.name}のサムネイル画像`"
+              />
+            </template>
             <div class="flex grow flex-col justify-between">
               <div>
                 {{ item.product.name }}
@@ -171,13 +196,13 @@ const handelClickRemoveItemButton = (id: string) => {
                 </div>
 
                 <div class="flex items-center gap-4 text-[12px]">
-                  <div>{{ ct('quantityLabel') }}: {{ item.quantity }}</div>
+                  <div>{{ ct("quantityLabel") }}: {{ item.quantity }}</div>
                   <button
                     class="text-[12px] underline"
                     type="button"
                     @click="handelClickRemoveItemButton(item.product.id)"
                   >
-                    {{ ct('deleteButtonText') }}
+                    {{ ct("deleteButtonText") }}
                   </button>
                 </div>
               </div>
@@ -190,7 +215,7 @@ const handelClickRemoveItemButton = (id: string) => {
           <div class="lg:hidden">
             <div class="flex items-center justify-between">
               <div class="text-[14px]">
-                {{ ct('subtotalLabel') }}
+                {{ ct("subtotalLabel") }}
               </div>
               <div class="text-[20px]">
                 {{ priceStringFormatter(totalPrice) }}
@@ -198,7 +223,7 @@ const handelClickRemoveItemButton = (id: string) => {
             </div>
             <hr class="my-4 border-main">
             <div class="text-[12px]">
-              {{ ct('shippingFeeNotice') }}
+              {{ ct("shippingFeeNotice") }}
             </div>
           </div>
 
@@ -211,7 +236,7 @@ const handelClickRemoveItemButton = (id: string) => {
             <div class="flex grow flex-col gap-4 whitespace-nowrap">
               <div class="flex flex-col gap-2 text-center">
                 <div class="rounded-3xl bg-base py-[3px] text-[12px]">
-                  {{ ct('boxTypeLabel') }}
+                  {{ ct("boxTypeLabel") }}
                 </div>
                 <div class="text-[14px]">
                   {{ cart.boxType }}
@@ -220,7 +245,7 @@ const handelClickRemoveItemButton = (id: string) => {
 
               <div class="flex flex-col gap-2 text-center">
                 <div class="rounded-3xl bg-base py-[3px] text-[12px]">
-                  {{ ct('boxSizeLabel') }}
+                  {{ ct("boxSizeLabel") }}
                 </div>
                 <div class="text-[14px]">
                   {{ cart.boxSize }}
@@ -229,7 +254,7 @@ const handelClickRemoveItemButton = (id: string) => {
 
               <div class="flex flex-col gap-2 text-center">
                 <div class="rounded-3xl bg-base py-[3px] text-[12px]">
-                  {{ ct('utilizationRateLabel') }}
+                  {{ ct("utilizationRateLabel") }}
                 </div>
                 <div class="text-[14px]">
                   {{ cart.useRate }}
@@ -242,21 +267,21 @@ const handelClickRemoveItemButton = (id: string) => {
             <div class="hidden lg:block">
               <div class="flex items-center justify-between">
                 <div class="text-[14px]">
-                  {{ ct('subtotalLabel') }}
+                  {{ ct("subtotalLabel") }}
                 </div>
                 <div class="text-[20px]">
                   {{ priceStringFormatter(totalPrice) }}
                 </div>
               </div>
               <hr class="my-4 border-main">
-              <div>{{ ct('shippingFeeNotice') }}</div>
+              <div>{{ ct("shippingFeeNotice") }}</div>
             </div>
 
             <button
               class="bg-main p-[14px] text-[16px] text-white"
               @click="handleCartBuyButton"
             >
-              {{ ct('checkoutButtonText') }}
+              {{ ct("checkoutButtonText") }}
             </button>
           </div>
         </div>

--- a/web/user/src/pages/purchase/index.vue
+++ b/web/user/src/pages/purchase/index.vue
@@ -23,9 +23,12 @@ const handleClickBuyButton = (coordinatorId: string) => {
     router.push(`/v1/purchase/address?coordinatorId=${coordinatorId}`)
   }
   else {
-    router.push(
-      `/v1/purchase/auth?required=true&coordinatorId=${coordinatorId}`,
-    )
+    router.push({
+      path: '/v1/purchase/guest/address',
+      query: {
+        coordinatorId,
+      },
+    })
   }
 }
 
@@ -44,9 +47,8 @@ const handleClickCartBuyButton = (
   }
   else {
     router.push({
-      path: '/v1/purchase/auth',
+      path: '/v1/purchase/guest/address',
       query: {
-        required: true,
         coordinatorId,
         cartNumber,
       },
@@ -69,7 +71,7 @@ useSeoMeta({
 <template>
   <div class="container mx-auto px-4 xl:px-0 my-10">
     <div class="text-center text-[20px] font-bold tracking-[2px] text-main">
-      {{ ct('cartTitle') }}
+      {{ ct("cartTitle") }}
     </div>
 
     <!--

--- a/web/user/src/pages/v1/purchase/address.vue
+++ b/web/user/src/pages/v1/purchase/address.vue
@@ -240,7 +240,7 @@ useSeoMeta({
     <div
       class="mt-[32px] text-center text-[20px] font-bold tracking-[2px] text-main"
     >
-      {{ at('checkoutTitle') }}
+      {{ at("checkoutTitle") }}
     </div>
 
     <the-alert
@@ -263,7 +263,7 @@ useSeoMeta({
           <div
             class="mb-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
           >
-            {{ at('customerInformationTitle') }}
+            {{ at("customerInformationTitle") }}
           </div>
 
           <!-- デフォルトの住所が登録されている場合 -->
@@ -279,7 +279,9 @@ useSeoMeta({
                   class="h-4 w-4 accent-main"
                   value="default"
                 >
-                <label for="default-radio">{{ at('shippingAvobeAdderssLabel') }}</label>
+                <label for="default-radio">{{
+                  at("shippingAvobeAdderssLabel")
+                }}</label>
               </div>
               <div class="flex items-center gap-2">
                 <input
@@ -289,14 +291,16 @@ useSeoMeta({
                   class="h-4 w-4 accent-main"
                   value="other"
                 >
-                <label for="other-radio">{{ at('shippingAnotherAdderssLabel') }}</label>
+                <label for="other-radio">{{
+                  at("shippingAnotherAdderssLabel")
+                }}</label>
               </div>
             </div>
             <template v-if="targetAddress === 'other'">
               <div
                 class="my-6 text-[16px] font-bold tracking-[1.6px] text-main"
               >
-                {{ at('shippingInformationLabel') }}
+                {{ at("shippingInformationLabel") }}
               </div>
               <the-new-address-form
                 v-model:form-data="formData"
@@ -323,7 +327,7 @@ useSeoMeta({
           class="row-span-2 self-start bg-base px-[16px] py-[24px] text-main md:w-full md:p-10"
         >
           <div class="text-[14px] font-bold tracking-[1.6px] md:text-[16px]">
-            {{ at('orderDetailsTitle') }}
+            {{ at("orderDetailsTitle") }}
           </div>
 
           <template v-if="calcCartResponseItem">
@@ -332,17 +336,17 @@ useSeoMeta({
                 {{ calcCartResponseItem.coordinator.marcheName }}
               </p>
               <p>
-                {{ at('shipFromLabel') }}
+                {{ at("shipFromLabel") }}
                 {{
                   `${calcCartResponseItem.coordinator.prefecture}${calcCartResponseItem.coordinator.city}`
                 }}
               </p>
               <p>
-                {{ at('coordinatorLabel') }}
+                {{ at("coordinatorLabel") }}
                 {{ calcCartResponseItem.coordinator.username }}
               </p>
               <p>
-                {{ at('boxCountLabel') }}
+                {{ at("boxCountLabel") }}
                 {{ calcCartResponseItem.carts.length }}
               </p>
             </div>
@@ -354,27 +358,42 @@ useSeoMeta({
                   class="grid grid-cols-5 py-2 text-[12px] tracking-[1.2px]"
                 >
                   <template v-if="item.product">
-                    <nuxt-img
-                      v-if="item.product.thumbnail"
-                      provider="cloudFront"
-                      :src="item.product.thumbnail.url"
-                      :alt="itemThumbnailAlt(item.product.name)"
-                      width="56px"
-                      height="56px"
-                      class="block aspect-square h-[56px] w-[56px]"
-                    />
-                    <div class="col-span-3 pl-[24px] md:pl-0">
-                      <div>{{ item.product.name }}</div>
-                      <div
-                        class="mt-4 md:mt-0 md:items-center md:justify-self-end md:text-right"
+                    <template v-if="item.product.thumbnail">
+                      <template
+                        v-if="item.product.thumbnail.url.endsWith('.mp4')"
                       >
-                        {{ at('quantityLabel') }}{{ item.quantity }}
+                        <video
+                          width="56px"
+                          height="56px"
+                          :src="item.product.thumbnail.url"
+                          class="block aspect-square h-[56px] w-[56px]"
+                        />
+                      </template>
+                      <template v-else>
+                        <nuxt-img
+                          provider="cloudFront"
+                          :src="item.product.thumbnail.url"
+                          :alt="itemThumbnailAlt(item.product.name)"
+                          width="56px"
+                          height="56px"
+                          class="block aspect-square h-[56px] w-[56px]"
+                        />
+                      </template>
+                      <div class="col-span-3 pl-[24px] md:pl-0">
+                        <div>{{ item.product.name }}</div>
+                        <div
+                          class="mt-4 md:mt-0 md:items-center md:justify-self-end md:text-right"
+                        >
+                          {{ at("quantityLabel") }}{{ item.quantity }}
+                        </div>
                       </div>
-                    </div>
 
-                    <div class="flex items-center justify-self-end text-right">
-                      {{ priceFormatter(item.product.price) }}
-                    </div>
+                      <div
+                        class="flex items-center justify-self-end text-right"
+                      >
+                        {{ priceFormatter(item.product.price) }}
+                      </div>
+                    </template>
                   </template>
                 </div>
               </div>
@@ -398,7 +417,7 @@ useSeoMeta({
                         d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                       />
                     </svg>
-                    {{ at('couponAppliedMessage') }}
+                    {{ at("couponAppliedMessage") }}
                   </div>
                   <button @click="handleClickCancelPromotionCodeButton">
                     <svg
@@ -433,14 +452,14 @@ useSeoMeta({
                     class="whitespace-nowrap bg-main p-2 text-[14px] text-white md:text-[16px]"
                     @click="handleClickUsePromotionCodeButton"
                   >
-                    {{ at('applyButtonText') }}
+                    {{ at("applyButtonText") }}
                   </button>
                 </div>
                 <div
                   v-if="invalidPromotion"
                   class="mt-2 px-1 text-[12px] leading-[1.2px]"
                 >
-                  {{ at('couponInvalidMessage') }}
+                  {{ at("couponInvalidMessage") }}
                 </div>
               </template>
 
@@ -448,29 +467,29 @@ useSeoMeta({
                 class="mt-4 grid grid-cols-5 gap-y-4 border-y border-main py-6 text-[12px] tracking-[1.4px] md:grid-cols-2 md:text-[14px]"
               >
                 <div class="col-span-2 md:col-span-1">
-                  {{ at('itemTotalPriceLabel') }}
+                  {{ at("itemTotalPriceLabel") }}
                 </div>
                 <div class="col-span-3 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.subtotal) }}
                 </div>
                 <div class="col-span-2 md:col-span-1">
-                  {{ at('applyCouponLabel') }}
+                  {{ at("applyCouponLabel") }}
                 </div>
                 <div class="col-span-3 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.discount) }}
                 </div>
                 <div class="col-span-2 md:col-span-1">
-                  {{ at('shippingFeeLabel') }}
+                  {{ at("shippingFeeLabel") }}
                 </div>
                 <div class="col-span-3 text-right md:col-span-1">
-                  {{ at('calculateNextPageMessage') }}
+                  {{ at("calculateNextPageMessage") }}
                 </div>
               </div>
 
               <div
                 class="mt-6 grid grid-cols-2 text-[14px] font-bold tracking-[1.4px]"
               >
-                <div>{{ at('totalPriceLabel') }}</div>
+                <div>{{ at("totalPriceLabel") }}</div>
                 <div class="text-right">
                   {{ priceFormatter(calcCartResponseItem.total) }}
                 </div>
@@ -487,7 +506,7 @@ useSeoMeta({
             @click="handleClickBackCartButton"
           >
             <the-left-arrow-icon class="h-4 w-4" />
-            {{ at('backToCartButtonText') }}
+            {{ at("backToCartButtonText") }}
           </button>
 
           <template v-if="defaultAddress && targetAddress === 'default'">
@@ -496,7 +515,7 @@ useSeoMeta({
               class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
               @click="handleClickNextStepButton(defaultAddress.id)"
             >
-              {{ at('paymentMethodButtonText') }}
+              {{ at("paymentMethodButtonText") }}
             </button>
           </template>
           <template v-else>
@@ -506,7 +525,7 @@ useSeoMeta({
               type="submit"
               form="new-address-form"
             >
-              {{ at('paymentMethodButtonText') }}
+              {{ at("paymentMethodButtonText") }}
             </button>
           </template>
         </div>

--- a/web/user/src/pages/v1/purchase/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/confirmation.vue
@@ -204,7 +204,8 @@ onMounted(async () => {
     validPromotionCode.value ? promotionCode.value : undefined,
   )
 
-  checkoutFormData.value.requestId = calcCartResponseItem.value?.requestId ?? ''
+  checkoutFormData.value.requestId
+    = calcCartResponseItem.value?.requestId ?? ''
   checkoutFormData.value.coordinatorId = coordinatorId.value
   checkoutFormData.value.total = calcCartResponseItem.value?.total ?? 0
   checkoutFormData.value.callbackUrl = `${window.location.origin}/v1/purchase/complete`
@@ -223,7 +224,7 @@ useSeoMeta({
 <template>
   <div class="container mx-auto">
     <div class="text-center text-[20px] font-bold tracking-[2px] text-main">
-      {{ ct('checkoutTitle') }}
+      {{ ct("checkoutTitle") }}
     </div>
 
     <the-alert
@@ -231,9 +232,7 @@ useSeoMeta({
       class="mt-4 bg-white"
       type="error"
     >
-      {{
-        checkoutError
-      }}
+      {{ checkoutError }}
     </the-alert>
 
     <div
@@ -249,7 +248,7 @@ useSeoMeta({
           <div
             class="mb-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
           >
-            {{ ct('customerInformationTitle') }}
+            {{ ct("customerInformationTitle") }}
           </div>
           <the-address-info
             v-if="address"
@@ -259,7 +258,7 @@ useSeoMeta({
             <a
               href="#"
               class="underline"
-            >{{ ct('changeButtonText') }}</a>
+            >{{ ct("changeButtonText") }}</a>
           </div>
 
           <div class="items-center border-b py-2" />
@@ -268,21 +267,21 @@ useSeoMeta({
             <div
               class="pt-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
             >
-              {{ ct('shippingInformationLabel') }}
+              {{ ct("shippingInformationLabel") }}
             </div>
             <div class="pt-[27px] text-[14px] tracking-[1.4px] text-main">
-              {{ ct('shippingAvobeAdderssLabel') }}
+              {{ ct("shippingAvobeAdderssLabel") }}
             </div>
             <div class="pt-4 text-right tracking-[1.4px]">
               <a
                 href="#"
                 class="underline"
-              >{{ ct('changeButtonText') }}</a>
+              >{{ ct("changeButtonText") }}</a>
             </div>
           </div>
 
           <div class="items-center border-b py-2" />
-          {{ ct('paymentInformationTitle') }}
+          {{ ct("paymentInformationTitle") }}
           <div>
             <div
               class="pt-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
@@ -400,7 +399,7 @@ useSeoMeta({
                     :value="0"
                     disabled
                   >
-                    {{ ct('expirationMonthPlaceholder') }}
+                    {{ ct("expirationMonthPlaceholder") }}
                   </option>
                   <option
                     v-for="i in 12"
@@ -419,7 +418,7 @@ useSeoMeta({
                     value="0"
                     disabled
                   >
-                    {{ ct('expirationYearPlaceholder') }}
+                    {{ ct("expirationYearPlaceholder") }}
                   </option>
                   <option
                     v-for="i in 11"
@@ -449,7 +448,7 @@ useSeoMeta({
           class="row-span-2 self-start bg-base px-[16px] py-[24px] text-main md:w-full md:p-10"
         >
           <div class="text-[14px] font-bold tracking-[1.6px] md:text-[16px]">
-            {{ ct('orderDetailsTitle') }}
+            {{ ct("orderDetailsTitle") }}
           </div>
           <template v-if="calcCartResponseItem">
             <div class="my-[16px] text-[12px] tracking-[1.2px] md:my-6">
@@ -457,15 +456,18 @@ useSeoMeta({
                 {{ calcCartResponseItem.coordinator.marcheName }}
               </p>
               <p>
-                {{ ct('shipFromLabel') }} {{
+                {{ ct("shipFromLabel") }}
+                {{
                   `${calcCartResponseItem.coordinator.prefecture}${calcCartResponseItem.coordinator.city}`
                 }}
               </p>
               <p>
-                {{ ct('coordinatorLabel') }}
+                {{ ct("coordinatorLabel") }}
                 {{ calcCartResponseItem.coordinator.username }}
               </p>
-              <p>{{ ct('boxCountLabel') }}{{ calcCartResponseItem.carts.length }}</p>
+              <p>
+                {{ ct("boxCountLabel") }}{{ calcCartResponseItem.carts.length }}
+              </p>
             </div>
             <div>
               <div>
@@ -475,18 +477,29 @@ useSeoMeta({
                   class="grid grid-cols-5 border-t py-2 text-[12px] tracking-[1.2px]"
                 >
                   <template v-if="item.product">
-                    <img
-                      v-if="item.product.thumbnail"
-                      :src="item.product.thumbnailUrl"
-                      :alt="`${item.product.name}の画像`"
-                      class="block aspect-square h-[56px] w-[56px]"
+                    <template
+                      v-if="item.product.thumbnail.url.endsWith('.mp4')"
                     >
+                      <video
+                        width="56px"
+                        height="56px"
+                        :src="item.product.thumbnail.url"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      />
+                    </template>
+                    <template v-else>
+                      <img
+                        :src="item.product.thumbnailUrl"
+                        :alt="`${item.product.name}の画像`"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      >
+                    </template>
                     <div class="col-span-3 pl-[24px] md:pl-0">
                       <div>{{ item.product?.name }}</div>
                       <div
                         class="mt-4 md:mt-0 md:items-center md:justify-self-end md:text-right"
                       >
-                        {{ ct('quantityLabel') }}{{ item.quantity }}
+                        {{ ct("quantityLabel") }}{{ item.quantity }}
                       </div>
                     </div>
 
@@ -501,19 +514,19 @@ useSeoMeta({
                 class="grid grid-cols-5 gap-y-4 border-y border-main py-6 text-[12px] tracking-[1.4px] md:grid-cols-2 md:text-[14px]"
               >
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('itemTotalPriceLabel') }}
+                  {{ ct("itemTotalPriceLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.subtotal) }}
                 </div>
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('applyCouponLabel') }}
+                  {{ ct("applyCouponLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.discount) }}
                 </div>
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('shippingFeeLabel') }}
+                  {{ ct("shippingFeeLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.shippingFee) }}
@@ -523,7 +536,7 @@ useSeoMeta({
               <div
                 class="mt-6 grid grid-cols-2 text-[14px] font-bold tracking-[1.4px]"
               >
-                <div>{{ ct('totalPriceLabel') }}</div>
+                <div>{{ ct("totalPriceLabel") }}</div>
                 <div class="text-right">
                   {{ priceFormatter(calcCartResponseItem.total) }}
                 </div>
@@ -540,7 +553,7 @@ useSeoMeta({
             @click="handleClickPreviousStepButton"
           >
             <the-left-arrow-icon class="h-4 w-4" />
-            {{ ct('backToPreviousPageButtonText') }}
+            {{ ct("backToPreviousPageButtonText") }}
           </button>
           <button
             class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
@@ -550,7 +563,7 @@ useSeoMeta({
             "
             @click="handleClickNextStepButton"
           >
-            {{ ct('proceedToPaymentButtonText') }}
+            {{ ct("proceedToPaymentButtonText") }}
           </button>
         </div>
       </template>

--- a/web/user/src/pages/v1/purchase/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/confirmation.vue
@@ -489,7 +489,7 @@ useSeoMeta({
                     </template>
                     <template v-else>
                       <img
-                        :src="item.product.thumbnailUrl"
+                        :src="item.product.thumbnail.url"
                         :alt="`${item.product.name}の画像`"
                         class="block aspect-square h-[56px] w-[56px]"
                       >

--- a/web/user/src/pages/v1/purchase/guest/address.vue
+++ b/web/user/src/pages/v1/purchase/guest/address.vue
@@ -308,8 +308,7 @@ onMounted(async () => {
       calcCartResponseItemState.value.errorMessage = error.message
     }
     else {
-      calcCartResponseItemState.value.errorMessage
-        = gt('unknownErrorMessage')
+      calcCartResponseItemState.value.errorMessage = gt('unknownErrorMessage')
     }
   }
   finally {
@@ -327,7 +326,7 @@ useSeoMeta({
     <div
       class="mt-[32px] text-center text-[20px] font-bold tracking-[2px] text-main"
     >
-      {{ gt('checkoutTitle') }}
+      {{ gt("checkoutTitle") }}
     </div>
 
     <the-alert
@@ -345,7 +344,7 @@ useSeoMeta({
         <div
           class="mb-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
         >
-          {{ gt('customerInformationTitle') }}
+          {{ gt("customerInformationTitle") }}
         </div>
 
         <the-guest-address-form
@@ -368,7 +367,7 @@ useSeoMeta({
         class="row-span-2 self-start bg-base px-[16px] py-[24px] text-main md:w-full md:p-10"
       >
         <div class="text-[14px] font-bold tracking-[1.6px] md:text-[16px]">
-          {{ gt('orderDetailsTitle') }}
+          {{ gt("orderDetailsTitle") }}
         </div>
 
         <template v-if="calcCartResponseItem">
@@ -377,15 +376,18 @@ useSeoMeta({
               {{ calcCartResponseItem.coordinator.marcheName }}
             </p>
             <p>
-              {{ gt('shipFromLabel') }}{{
+              {{ gt("shipFromLabel")
+              }}{{
                 `${calcCartResponseItem.coordinator.prefecture}${calcCartResponseItem.coordinator.city}`
               }}
             </p>
             <p>
-              {{ gt('coordinatorLabel') }}
+              {{ gt("coordinatorLabel") }}
               {{ calcCartResponseItem.coordinator.username }}
             </p>
-            <p>{{ gt('boxCountLabel') }}{{ calcCartResponseItem.carts.length }}</p>
+            <p>
+              {{ gt("boxCountLabel") }}{{ calcCartResponseItem.carts.length }}
+            </p>
           </div>
           <div>
             <div class="divide-y border-y">
@@ -395,21 +397,34 @@ useSeoMeta({
                 class="grid grid-cols-5 py-2 text-[12px] tracking-[1.2px]"
               >
                 <template v-if="item.product">
-                  <nuxt-img
-                    v-if="item.product.thumbnail"
-                    width="56px"
-                    height="56px"
-                    provider="cloudFront"
-                    :src="item.product.thumbnail.url"
-                    :alt="itemThumbnailAlt(item.product.name)"
-                    class="block aspect-square h-[56px] w-[56px]"
-                  />
+                  <template v-if="item.product.thumbnail">
+                    <template
+                      v-if="item.product.thumbnail.url.endsWith('.mp4')"
+                    >
+                      <video
+                        width="56px"
+                        height="56px"
+                        :src="item.product.thumbnail.url"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      />
+                    </template>
+                    <template v-else>
+                      <nuxt-img
+                        width="56px"
+                        height="56px"
+                        provider="cloudFront"
+                        :src="item.product.thumbnail.url"
+                        :alt="itemThumbnailAlt(item.product.name)"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      />
+                    </template>
+                  </template>
                   <div class="col-span-3 pl-[24px] md:pl-0">
                     <div>{{ item.product.name }}</div>
                     <div
                       class="mt-4 md:mt-0 md:items-center md:justify-self-end md:text-right"
                     >
-                      {{ gt('quantityLabel') }}{{ item.quantity }}
+                      {{ gt("quantityLabel") }}{{ item.quantity }}
                     </div>
                   </div>
 
@@ -439,7 +454,7 @@ useSeoMeta({
                       d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                     />
                   </svg>
-                  {{ gt('couponAppliedMessage') }}
+                  {{ gt("couponAppliedMessage") }}
                 </div>
                 <button @click="handleClickCancelPromotionCodeButton">
                   <svg
@@ -474,14 +489,14 @@ useSeoMeta({
                   class="whitespace-nowrap bg-main p-2 text-[14px] text-white md:text-[16px]"
                   @click="handleClickUsePromotionCodeButton"
                 >
-                  {{ gt('applyButtonText') }}
+                  {{ gt("applyButtonText") }}
                 </button>
               </div>
               <div
                 v-if="invalidPromotion"
                 class="mt-2 px-1 text-[12px] leading-[1.2px]"
               >
-                {{ gt('couponInvalidMessage') }}
+                {{ gt("couponInvalidMessage") }}
               </div>
             </template>
 
@@ -489,29 +504,29 @@ useSeoMeta({
               class="mt-4 grid grid-cols-5 gap-y-4 border-y border-main py-6 text-[12px] tracking-[1.4px] md:grid-cols-2 md:text-[14px]"
             >
               <div class="col-span-2 md:col-span-1">
-                {{ gt('totalPriceLabel') }}
+                {{ gt("totalPriceLabel") }}
               </div>
               <div class="col-span-3 text-right md:col-span-1">
                 {{ priceFormatter(calcCartResponseItem.subtotal) }}
               </div>
               <div class="col-span-2 md:col-span-1">
-                {{ gt('applyCouponLabel') }}
+                {{ gt("applyCouponLabel") }}
               </div>
               <div class="col-span-3 text-right md:col-span-1">
                 {{ priceFormatter(calcCartResponseItem.discount) }}
               </div>
               <div class="col-span-2 md:col-span-1">
-                {{ gt('shippingFeeLabel') }}
+                {{ gt("shippingFeeLabel") }}
               </div>
               <div class="col-span-3 text-right md:col-span-1">
-                {{ gt('calculateNextPageMessage') }}
+                {{ gt("calculateNextPageMessage") }}
               </div>
             </div>
 
             <div
               class="mt-6 grid grid-cols-2 text-[14px] font-bold tracking-[1.4px]"
             >
-              <div>{{ gt('totalPriceLabel') }}</div>
+              <div>{{ gt("totalPriceLabel") }}</div>
               <div class="text-right">
                 {{ priceFormatter(calcCartResponseItem.total) }}
               </div>
@@ -528,7 +543,7 @@ useSeoMeta({
           @click="handleClickBackCartButton"
         >
           <the-left-arrow-icon class="h-4 w-4" />
-          {{ gt('backToCartButtonText') }}
+          {{ gt("backToCartButtonText") }}
         </button>
 
         <div>
@@ -536,7 +551,7 @@ useSeoMeta({
             class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
             @click="handleClickNextStepButton()"
           >
-            {{ gt('paymentMethodButtonText') }}
+            {{ gt("paymentMethodButtonText") }}
           </button>
         </div>
       </div>

--- a/web/user/src/pages/v1/purchase/guest/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/guest/confirmation.vue
@@ -224,7 +224,8 @@ onMounted(async () => {
     )
   }
 
-  checkoutFormData.value.requestId = calcCartResponseItem.value?.requestId ?? ''
+  checkoutFormData.value.requestId
+    = calcCartResponseItem.value?.requestId ?? ''
   checkoutFormData.value.coordinatorId = coordinatorId.value
   checkoutFormData.value.total = calcCartResponseItem.value?.total ?? 0
   checkoutFormData.value.callbackUrl = `${window.location.origin}/v1/purchase/guest/complete`
@@ -258,7 +259,7 @@ useSeoMeta({
 <template>
   <div class="container mx-auto">
     <div class="text-center text-[20px] font-bold tracking-[2px] text-main">
-      {{ ct('checkoutTitle') }}
+      {{ ct("checkoutTitle") }}
     </div>
 
     <the-alert
@@ -266,9 +267,7 @@ useSeoMeta({
       class="mt-4 bg-white"
       type="error"
     >
-      {{
-        checkoutError
-      }}
+      {{ checkoutError }}
     </the-alert>
 
     <the-alert
@@ -276,9 +275,7 @@ useSeoMeta({
       class="mt-4 bg-white"
       type="error"
     >
-      {{
-        '都道府県が指定されていません。住所を再度入力してください。'
-      }}
+      {{ "都道府県が指定されていません。住所を再度入力してください。" }}
     </the-alert>
 
     <div
@@ -294,7 +291,7 @@ useSeoMeta({
           <div
             class="mb-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
           >
-            {{ ct('customerInformationTitle') }}
+            {{ ct("customerInformationTitle") }}
           </div>
           <the-guest-address-info
             v-if="guestAddress"
@@ -307,10 +304,10 @@ useSeoMeta({
             <div
               class="pt-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
             >
-              {{ ct('shippingInformationLabel') }}
+              {{ ct("shippingInformationLabel") }}
             </div>
             <div class="pt-[27px] text-[14px] tracking-[1.4px] text-main">
-              {{ ct('shippingAvobeAdderssLabel') }}
+              {{ ct("shippingAvobeAdderssLabel") }}
             </div>
           </div>
 
@@ -320,7 +317,7 @@ useSeoMeta({
             <div
               class="pt-6 text-left text-[16px] font-bold tracking-[1.6px] text-main"
             >
-              {{ ct('paymentInformationTitle') }}
+              {{ ct("paymentInformationTitle") }}
             </div>
 
             <div class="mt-4 flex items-center justify-between">
@@ -435,7 +432,7 @@ useSeoMeta({
                     :value="0"
                     disabled
                   >
-                    {{ ct('expirationMonthPlaceholder') }}
+                    {{ ct("expirationMonthPlaceholder") }}
                   </option>
                   <option
                     v-for="i in 12"
@@ -454,7 +451,7 @@ useSeoMeta({
                     value="0"
                     disabled
                   >
-                    {{ ct('expirationYearPlaceholder') }}
+                    {{ ct("expirationYearPlaceholder") }}
                   </option>
                   <option
                     v-for="i in 11"
@@ -484,7 +481,7 @@ useSeoMeta({
           class="row-span-2 self-start bg-base px-[16px] py-[24px] text-main md:w-full md:p-10"
         >
           <div class="text-[14px] font-bold tracking-[1.6px] md:text-[16px]">
-            {{ ct('orderDetailsTitle') }}
+            {{ ct("orderDetailsTitle") }}
           </div>
           <template v-if="calcCartResponseItem">
             <div class="my-[16px] text-[12px] tracking-[1.2px] md:my-6">
@@ -492,15 +489,18 @@ useSeoMeta({
                 {{ calcCartResponseItem.coordinator.marcheName }}
               </p>
               <p>
-                {{ ct('shipFromLabel') }} {{
+                {{ ct("shipFromLabel") }}
+                {{
                   `${calcCartResponseItem.coordinator.prefecture}${calcCartResponseItem.coordinator.city}`
                 }}
               </p>
               <p>
-                {{ ct('coordinatorLabel') }}
+                {{ ct("coordinatorLabel") }}
                 {{ calcCartResponseItem.coordinator.username }}
               </p>
-              <p>{{ ct('boxCountLabel') }}{{ calcCartResponseItem.carts.length }}</p>
+              <p>
+                {{ ct("boxCountLabel") }}{{ calcCartResponseItem.carts.length }}
+              </p>
             </div>
             <div>
               <div>
@@ -510,18 +510,29 @@ useSeoMeta({
                   class="grid grid-cols-5 border-t py-2 text-[12px] tracking-[1.2px]"
                 >
                   <template v-if="item.product">
-                    <img
-                      v-if="item.product.thumbnail"
-                      :src="item.product.thumbnailUrl"
-                      :alt="`${item.product.name}の画像`"
-                      class="block aspect-square h-[56px] w-[56px]"
+                    <template
+                      v-if="item.product.thumbnail.url.endsWith('.mp4')"
                     >
+                      <video
+                        width="56px"
+                        height="56px"
+                        :src="item.product.thumbnail.url"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      />
+                    </template>
+                    <template v-else>
+                      <img
+                        :src="item.product.thumbnailUrl"
+                        :alt="`${item.product.name}の画像`"
+                        class="block aspect-square h-[56px] w-[56px]"
+                      >
+                    </template>
                     <div class="col-span-3 pl-[24px] md:pl-0">
                       <div>{{ item.product?.name }}</div>
                       <div
                         class="mt-4 md:mt-0 md:items-center md:justify-self-end md:text-right"
                       >
-                        {{ ct('quantityLabel') }}{{ item.quantity }}
+                        {{ ct("quantityLabel") }}{{ item.quantity }}
                       </div>
                     </div>
 
@@ -536,19 +547,19 @@ useSeoMeta({
                 class="grid grid-cols-5 gap-y-4 border-y border-main py-6 text-[12px] tracking-[1.4px] md:grid-cols-2 md:text-[14px]"
               >
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('itemTotalPriceLabel') }}
+                  {{ ct("itemTotalPriceLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.subtotal) }}
                 </div>
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('applyCouponLabel') }}
+                  {{ ct("applyCouponLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.discount) }}
                 </div>
                 <div class="col-span-3 md:col-span-1">
-                  {{ ct('shippingFeeLabel') }}
+                  {{ ct("shippingFeeLabel") }}
                 </div>
                 <div class="col-span-2 text-right md:col-span-1">
                   {{ priceFormatter(calcCartResponseItem.shippingFee) }}
@@ -558,7 +569,7 @@ useSeoMeta({
               <div
                 class="mt-6 grid grid-cols-2 text-[14px] font-bold tracking-[1.4px]"
               >
-                <div>{{ ct('totalPriceLabel') }}</div>
+                <div>{{ ct("totalPriceLabel") }}</div>
                 <div class="text-right">
                   {{ priceFormatter(calcCartResponseItem.total) }}
                 </div>
@@ -575,7 +586,7 @@ useSeoMeta({
             @click="handleClickPreviousStepButton"
           >
             <the-left-arrow-icon class="h-4 w-4" />
-            {{ ct('backToPreviousPageButtonText') }}
+            {{ ct("backToPreviousPageButtonText") }}
           </button>
           <button
             class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
@@ -585,7 +596,7 @@ useSeoMeta({
             "
             @click="handleClickNextStepButton"
           >
-            {{ ct('proceedToPaymentButtonText') }}
+            {{ ct("proceedToPaymentButtonText") }}
           </button>
         </div>
       </template>


### PR DESCRIPTION
## やったこと

- 未ログイン時に買い物カゴからの購入操作時にゲスト購入画面に直接遷移するように変更した。

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 商品のサムネイルが動画の場合、動画要素が表示されるように条件付きレンダリングを追加。
	- 認証されていないユーザーがゲストアドレスページにリダイレクトされるようにルーティングを変更。

- **バグ修正**
	- プロモーションコードの処理が改善され、適用時にカートアイテムが再計算されるように。

- **スタイル**
	- テンプレート内の文字列のフォーマットを一貫性のあるダブルクオートに変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->