### PR TITLE
fix: ゲストの購入手続き時に住所情報がリロードしても欠落しないように修正

### DIFF
--- a/web/user/src/pages/v1/purchase/guest/address.vue
+++ b/web/user/src/pages/v1/purchase/guest/address.vue
@@ -23,6 +23,7 @@ const itemThumbnailAlt = (itemName: string) => {
 
 const addressStore = useAddressStore()
 const { searchAddressByPostalCode } = addressStore
+const { guestAddress, email } = storeToRefs(addressStore)
 const shoppingCartStore = useShoppingCartStore()
 const { calcCartResponseItem } = storeToRefs(shoppingCartStore)
 const { calcCartItemByCoordinatorId, verifyGuestPromotionCode }
@@ -34,22 +35,38 @@ const calcCartResponseItemState = ref<{
   errorMessage: string
 }>({ isLoading: true, hasError: false, errorMessage: '' })
 
-const formData = ref<GuestCheckoutAddress>({
-  lastname: '',
-  firstname: '',
-  lastnameKana: '',
-  firstnameKana: '',
-  postalCode: '',
-  prefectureCode: 0,
-  city: '',
-  addressLine1: '',
-  addressLine2: '',
-  phoneNumber: '',
-})
+const initFormData = (): GuestCheckoutAddress => {
+  if (guestAddress.value) {
+    return guestAddress.value
+  }
+  else {
+    return {
+      lastname: '',
+      firstname: '',
+      lastnameKana: '',
+      firstnameKana: '',
+      postalCode: '',
+      prefectureCode: 0,
+      city: '',
+      addressLine1: '',
+      addressLine2: '',
+      phoneNumber: '',
+    }
+  }
+}
 
-const formEmailData = ref({
-  email: '',
-})
+const initEmailData = (): { email: string } => {
+  if (email.value) {
+    return { email: email.value }
+  }
+  else {
+    return { email: '' }
+  }
+}
+
+const formData = ref<GuestCheckoutAddress>(initFormData())
+
+const formEmailData = ref(initEmailData())
 
 const promotionCodeFormValue = ref<string>('')
 const invalidPromotion = ref<boolean>(false)

--- a/web/user/src/pages/v1/purchase/guest/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/guest/confirmation.vue
@@ -174,6 +174,7 @@ const doCheckout = async () => {
       boxNumber: cartNumber.value ?? 0,
     })
     console.log('debug', 'doCheckout', url)
+    addressStore.$reset()
     window.location.href = url
   }
   catch (error) {

--- a/web/user/src/store/address.ts
+++ b/web/user/src/store/address.ts
@@ -8,6 +8,12 @@ import type {
 } from '~/types/api'
 
 export const useAddressStore = defineStore('address', {
+  persist: {
+    storage: persistedState.cookiesWithOptions({
+      sameSite: 'strict',
+    }),
+  },
+
   state: () => {
     return {
       total: 0,


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ゲストユーザーのチェックアウトプロセスを強化。
  - 住所データの状態をセッション間で保持するための新しい設定を追加。
  
- **バグ修正**
  - プロモーションコードの検証ロジックを改善。

- **ドキュメント**
  - エラーメッセージとバリデーションの調整を行い、ユーザーに対するフィードバックを向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->