### PR TITLE
Release for v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v2.0.1](https://github.com/and-period/furumaru/compare/v2.0.0...v2.0.1) - 2024-10-16
+- setup: clarityのJSコードを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2455
+
 ## [v2.0.0](https://github.com/and-period/furumaru/compare/v1.11.46...v2.0.0) - 2024-10-15
 - refactor(store): 決済周りのロジックを整理 by @taba2424 in https://github.com/and-period/furumaru/pull/2431
 - feat(store): 即時決済機能を有効に by @taba2424 in https://github.com/and-period/furumaru/pull/2436


### PR DESCRIPTION
This pull request is for the next release as v2.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* setup: clarityのJSコードを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2455


**Full Changelog**: https://github.com/and-period/furumaru/compare/v2.0.0...v2.0.1