### PR TITLE
fix(store): experienceのDB操作を修正

### DIFF
--- a/api/internal/store/database/mysql/experience.go
+++ b/api/internal/store/database/mysql/experience.go
@@ -317,7 +317,7 @@ func newExperienceHostGeolocation(longitude, latitude float64) mysql.Geometry {
 }
 
 func (e *internalExperience) entity() *entity.Experience {
-	if e == nil || e.HostGeolocation.X == 0 && e.HostGeolocation.Y == 0 {
+	if e == nil {
 		return nil
 	}
 	e.Experience.HostLongitude = e.HostGeolocation.X

--- a/api/internal/store/database/mysql/experience.go
+++ b/api/internal/store/database/mysql/experience.go
@@ -143,7 +143,7 @@ func (e *experience) Create(ctx context.Context, experience *entity.Experience) 
 		experience.CreatedAt, experience.UpdatedAt = now, now
 		experience.ExperienceRevision.CreatedAt, experience.ExperienceRevision.UpdatedAt = now, now
 
-		internal := newInternelExperience(experience)
+		internal := newInternalExperience(experience)
 
 		if err := tx.WithContext(ctx).Table(experienceTable).Create(&internal).Error; err != nil {
 			return err
@@ -292,15 +292,15 @@ func (e *experience) fill(ctx context.Context, tx *gorm.DB, experiences ...*enti
 }
 
 type internalExperience struct {
-	entity.Experience
-	HostGeolocation mysql.Geometry `gorm:""`  // 開催場所(座標情報)
-	HostLongitude   float64        `gorm:"-"` // 開催場所(座標情報:経度)
-	HostLatitude    float64        `gorm:"-"` // 開催場所(座標情報:緯度)
+	entity.Experience `gorm:"embedded"`
+	HostGeolocation   mysql.Geometry `gorm:""`  // 開催場所(座標情報)
+	HostLongitude     float64        `gorm:"-"` // 開催場所(座標情報:経度)
+	HostLatitude      float64        `gorm:"-"` // 開催場所(座標情報:緯度)
 }
 
 type internalExperiences []*internalExperience
 
-func newInternelExperience(experience *entity.Experience) *internalExperience {
+func newInternalExperience(experience *entity.Experience) *internalExperience {
 	return &internalExperience{
 		Experience:      *experience,
 		HostGeolocation: newExperienceHostGeolocation(experience.HostLongitude, experience.HostLatitude),

--- a/api/internal/store/database/mysql/experience.go
+++ b/api/internal/store/database/mysql/experience.go
@@ -90,7 +90,7 @@ func (e *experience) List(ctx context.Context, params *database.ListExperiencesP
 func (e *experience) Count(ctx context.Context, params *database.ListExperiencesParams) (int64, error) {
 	p := listExperiencesParams(*params)
 
-	total, err := e.db.Count(ctx, e.db.DB, &internalExperience{}, p.stmt)
+	total, err := e.db.Count(ctx, e.db.DB, &entity.Experience{}, p.stmt)
 	return total, dbError(err)
 }
 
@@ -317,11 +317,11 @@ func newExperienceHostGeolocation(longitude, latitude float64) mysql.Geometry {
 }
 
 func (e *internalExperience) entity() *entity.Experience {
-	if e == nil {
+	if e == nil || e.HostGeolocation.X == 0 && e.HostGeolocation.Y == 0 {
 		return nil
 	}
-	e.Experience.HostLongitude = e.HostLongitude
-	e.Experience.HostLatitude = e.HostLatitude
+	e.Experience.HostLongitude = e.HostGeolocation.X
+	e.Experience.HostLatitude = e.HostGeolocation.Y
 	return &e.Experience
 }
 

--- a/api/internal/store/database/mysql/experience_test.go
+++ b/api/internal/store/database/mysql/experience_test.go
@@ -37,14 +37,14 @@ func TestExperience_List(t *testing.T) {
 	types[1] = testExperienceType("experience-type-id02", "トマト収穫", now())
 	err = db.DB.Create(&types).Error
 	require.NoError(t, err)
-	experiences := make(entity.Experiences, 3)
+	experiences := make(internalExperiences, 3)
 	experiences[0] = testExperience("experience-id01", "experience-type-id01", "coordinator-id", "producer-id", 1, now())
 	experiences[0].StartAt = now().AddDate(0, 0, -1)
 	experiences[1] = testExperience("experience-id02", "experience-type-id02", "coordinator-id", "producer-id", 2, now())
 	experiences[1].StartAt = now().AddDate(0, 0, -2)
 	experiences[2] = testExperience("experience-id03", "experience-type-id02", "coordinator-id", "producer-id", 3, now())
 	experiences[2].StartAt = now().AddDate(0, -1, 0)
-	err = db.DB.Create(&experiences).Error
+	err = db.DB.Table(experienceTable).Create(&experiences).Error
 	require.NoError(t, err)
 	for i := range experiences {
 		err := db.DB.Create(&experiences[i].ExperienceRevision).Error
@@ -75,7 +75,7 @@ func TestExperience_List(t *testing.T) {
 				},
 			},
 			want: want{
-				experiences: experiences[1:],
+				experiences: experiences[1:].entities(),
 				err:         nil,
 			},
 		},
@@ -93,7 +93,7 @@ func TestExperience_List(t *testing.T) {
 			actual, err := db.List(ctx, tt.args.params)
 			assert.ErrorIs(t, err, tt.want.err)
 			fillIgnoreExperiencesFields(actual, now())
-			assert.ElementsMatch(t, tt.want.experiences, actual)
+			assert.Equal(t, tt.want.experiences, actual)
 		})
 	}
 }
@@ -117,11 +117,11 @@ func TestExperience_Count(t *testing.T) {
 	types[1] = testExperienceType("experience-type-id02", "トマト収穫", now())
 	err = db.DB.Create(&types).Error
 	require.NoError(t, err)
-	experiences := make(entity.Experiences, 3)
+	experiences := make(internalExperiences, 3)
 	experiences[0] = testExperience("experience-id01", "experience-type-id01", "coordinator-id", "producer-id", 1, now())
 	experiences[1] = testExperience("experience-id02", "experience-type-id02", "coordinator-id", "producer-id", 2, now())
 	experiences[2] = testExperience("experience-id03", "experience-type-id02", "coordinator-id", "producer-id", 3, now())
-	err = db.DB.Create(&experiences).Error
+	err = db.DB.Table(experienceTable).Create(&experiences).Error
 	require.NoError(t, err)
 	for i := range experiences {
 		err := db.DB.Create(&experiences[i].ExperienceRevision).Error
@@ -193,11 +193,11 @@ func TestExperience_MultiGet(t *testing.T) {
 	types[1] = testExperienceType("experience-type-id02", "トマト収穫", now())
 	err = db.DB.Create(&types).Error
 	require.NoError(t, err)
-	experiences := make(entity.Experiences, 3)
+	experiences := make(internalExperiences, 3)
 	experiences[0] = testExperience("experience-id01", "experience-type-id01", "coordinator-id", "producer-id", 1, now())
 	experiences[1] = testExperience("experience-id02", "experience-type-id02", "coordinator-id", "producer-id", 2, now())
 	experiences[2] = testExperience("experience-id03", "experience-type-id02", "coordinator-id", "producer-id", 3, now())
-	err = db.DB.Create(&experiences).Error
+	err = db.DB.Table(experienceTable).Create(&experiences).Error
 	require.NoError(t, err)
 	for i := range experiences {
 		err := db.DB.Create(&experiences[i].ExperienceRevision).Error
@@ -224,7 +224,7 @@ func TestExperience_MultiGet(t *testing.T) {
 				experienceIDs: []string{"experience-id01", "experience-id02"},
 			},
 			want: want{
-				experiences: experiences[:2],
+				experiences: experiences[:2].entities(),
 				err:         nil,
 			},
 		},
@@ -266,11 +266,11 @@ func TestExperience_MultiGetByRevision(t *testing.T) {
 	types[1] = testExperienceType("experience-type-id02", "トマト収穫", now())
 	err = db.DB.Create(&types).Error
 	require.NoError(t, err)
-	experiences := make(entity.Experiences, 3)
+	experiences := make(internalExperiences, 3)
 	experiences[0] = testExperience("experience-id01", "experience-type-id01", "coordinator-id", "producer-id", 1, now())
 	experiences[1] = testExperience("experience-id02", "experience-type-id02", "coordinator-id", "producer-id", 2, now())
 	experiences[2] = testExperience("experience-id03", "experience-type-id02", "coordinator-id", "producer-id", 3, now())
-	err = db.DB.Create(&experiences).Error
+	err = db.DB.Table(experienceTable).Create(&experiences).Error
 	require.NoError(t, err)
 	for i := range experiences {
 		err := db.DB.Create(&experiences[i].ExperienceRevision).Error
@@ -297,7 +297,7 @@ func TestExperience_MultiGetByRevision(t *testing.T) {
 				revisionIDs: []int64{1, 2, 3},
 			},
 			want: want{
-				experiences: experiences,
+				experiences: experiences.entities(),
 				err:         nil,
 			},
 		},
@@ -338,7 +338,7 @@ func TestExperience_Get(t *testing.T) {
 	err = db.DB.Create(&typ).Error
 	require.NoError(t, err)
 	e := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-	err = db.DB.Create(&e).Error
+	err = db.DB.Table(experienceTable).Create(&e).Error
 	require.NoError(t, err)
 	err = db.DB.Create(&e.ExperienceRevision).Error
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestExperience_Get(t *testing.T) {
 				experienceID: "experience-id",
 			},
 			want: want{
-				experience: e,
+				experience: e.entity(),
 				err:        nil,
 			},
 		},
@@ -431,7 +431,7 @@ func TestExperience_Create(t *testing.T) {
 			name:  "success",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
-				experience: testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now()),
+				experience: testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now()).entity(),
 			},
 			want: want{
 				err: nil,
@@ -441,13 +441,13 @@ func TestExperience_Create(t *testing.T) {
 			name: "already exists",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				e := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-				err := db.DB.Create(&e).Error
+				err := db.DB.Table(experienceTable).Create(&e).Error
 				require.NoError(t, err)
 				err = db.DB.Create(&e.ExperienceRevision).Error
 				require.NoError(t, err)
 			},
 			args: args{
-				experience: testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now()),
+				experience: testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now()).entity(),
 			},
 			want: want{
 				err: database.ErrAlreadyExists,
@@ -507,7 +507,7 @@ func TestExperience_Update(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				e := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-				err := db.DB.Create(&e).Error
+				err := db.DB.Table(experienceTable).Create(&e).Error
 				require.NoError(t, err)
 				err = db.DB.Create(&e.ExperienceRevision).Error
 				require.NoError(t, err)
@@ -598,7 +598,7 @@ func TestExperience_Delete(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {
 				e := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-				err := db.DB.Create(&e).Error
+				err := db.DB.Table(experienceTable).Create(&e).Error
 				require.NoError(t, err)
 				err = db.DB.Create(&e.ExperienceRevision).Error
 				require.NoError(t, err)
@@ -629,54 +629,59 @@ func TestExperience_Delete(t *testing.T) {
 	}
 }
 
-func testExperience(experienceID, typeID, coordinatorID, producerID string, revisionID int64, now time.Time) *entity.Experience {
-	e := &entity.Experience{
-		ID:            experienceID,
-		CoordinatorID: coordinatorID,
-		ProducerID:    producerID,
-		TypeID:        typeID,
-		Title:         "じゃがいも収穫",
-		Description:   "じゃがいもを収穫する体験です。",
-		Public:        true,
-		SoldOut:       false,
-		Status:        entity.ExperienceStatusAccepting,
-		ThumbnailURL:  "http://example.com/thumbnail01.png",
-		Media: entity.MultiExperienceMedia{
-			{
-				URL:         "http://example.com/thumbnail01.png",
-				IsThumbnail: true,
+func testExperience(experienceID, typeID, coordinatorID, producerID string, revisionID int64, now time.Time) *internalExperience {
+	internal := &internalExperience{
+		Experience: entity.Experience{
+			ID:            experienceID,
+			CoordinatorID: coordinatorID,
+			ProducerID:    producerID,
+			TypeID:        typeID,
+			Title:         "じゃがいも収穫",
+			Description:   "じゃがいもを収穫する体験です。",
+			Public:        true,
+			SoldOut:       false,
+			Status:        entity.ExperienceStatusAccepting,
+			ThumbnailURL:  "http://example.com/thumbnail01.png",
+			Media: entity.MultiExperienceMedia{
+				{
+					URL:         "http://example.com/thumbnail01.png",
+					IsThumbnail: true,
+				},
+				{
+					URL:         "http://example.com/thumbnail02.png",
+					IsThumbnail: false,
+				},
 			},
-			{
-				URL:         "http://example.com/thumbnail02.png",
-				IsThumbnail: false,
+			RecommendedPoints: []string{
+				"じゃがいもを収穫する",
+				"じゃがいもを食べる",
+				"じゃがいもを持ち帰る",
 			},
+			PromotionVideoURL:  "http://example.com/promotion.mp4",
+			Duration:           60,
+			Direction:          "彦根駅から徒歩10分",
+			BusinessOpenTime:   "1000",
+			BusinessCloseTime:  "1800",
+			HostPostalCode:     "5220061",
+			HostPrefecture:     "滋賀県",
+			HostPrefectureCode: 25,
+			HostCity:           "彦根市",
+			HostAddressLine1:   "金亀町１−１",
+			HostAddressLine2:   "",
+			HostLongitude:      136.251739,
+			HostLatitude:       35.276833,
+			StartAt:            now.AddDate(0, -1, 0),
+			EndAt:              now.AddDate(0, 1, 0),
+			ExperienceRevision: *testExperienceRevision(revisionID, experienceID, now),
+			CreatedAt:          now,
+			UpdatedAt:          now,
 		},
-		RecommendedPoints: []string{
-			"じゃがいもを収穫する",
-			"じゃがいもを食べる",
-			"じゃがいもを持ち帰る",
-		},
-		PromotionVideoURL:  "http://example.com/promotion.mp4",
-		Duration:           60,
-		Direction:          "彦根駅から徒歩10分",
-		BusinessOpenTime:   "1000",
-		BusinessCloseTime:  "1800",
-		HostPostalCode:     "5220061",
-		HostPrefecture:     "滋賀県",
-		HostPrefectureCode: 25,
-		HostCity:           "彦根市",
-		HostAddressLine1:   "金亀町１−１",
-		HostAddressLine2:   "",
-		HostLongitude:      136.251739,
-		HostLatitude:       35.276833,
-		StartAt:            now.AddDate(0, -1, 0),
-		EndAt:              now.AddDate(0, 1, 0),
-		ExperienceRevision: *testExperienceRevision(revisionID, experienceID, now),
-		CreatedAt:          now,
-		UpdatedAt:          now,
+		HostGeolocation: newExperienceHostGeolocation(136.251739, 35.276833),
+		HostLongitude:   136.251739,
+		HostLatitude:    35.276833,
 	}
-	_ = e.FillJSON()
-	return e
+	_ = internal.FillJSON()
+	return internal
 }
 
 func testExperienceRevision(revisionID int64, experienceID string, now time.Time) *entity.ExperienceRevision {

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -165,9 +165,9 @@ func TestOrder_ListUserIDs(t *testing.T) {
 	experienceTypes[0] = testExperienceType("experience-type-id", "体験", now())
 	err = db.DB.Create(&experienceTypes).Error
 	require.NoError(t, err)
-	experiences := make(entity.Experiences, 1)
+	experiences := make(internalExperiences, 1)
 	experiences[0] = testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-	err = db.DB.Create(&experiences).Error
+	err = db.DB.Table(experienceTable).Create(&experiences).Error
 	require.NoError(t, err)
 	for i := range experiences {
 		err = db.DB.Create(&experiences[i].ExperienceRevision).Error

--- a/api/internal/store/database/mysql/order_test.go
+++ b/api/internal/store/database/mysql/order_test.go
@@ -754,7 +754,7 @@ func TestOrder_Create(t *testing.T) {
 	err = db.DB.Create(&experienceType).Error
 	require.NoError(t, err)
 	experience := testExperience("experience-id", "experience-type-id", "coordinator-id", "producer-id", 1, now())
-	err = db.DB.Create(&experience).Error
+	err = db.DB.Table(experienceTable).Create(&experience).Error
 	require.NoError(t, err)
 	err = db.DB.Create(&experience.ExperienceRevision).Error
 	require.NoError(t, err)

--- a/api/internal/store/database/tidb/experience.go
+++ b/api/internal/store/database/tidb/experience.go
@@ -2,6 +2,8 @@ package tidb
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/and-period/furumaru/api/internal/store/database"
@@ -17,16 +19,14 @@ const (
 )
 
 type experience struct {
-	database.Experience
 	db  *mysql.Client
 	now func() time.Time
 }
 
-func newExperience(db *mysql.Client, mysql database.Experience) database.Experience {
+func newExperience(db *mysql.Client) database.Experience {
 	return &experience{
-		Experience: mysql,
-		db:         db,
-		now:        jst.Now,
+		db:  db,
+		now: jst.Now,
 	}
 }
 
@@ -69,7 +69,7 @@ func (p listExperiencesParams) pagination(stmt *gorm.DB) *gorm.DB {
 }
 
 func (e *experience) List(ctx context.Context, params *database.ListExperiencesParams, fields ...string) (entity.Experiences, error) {
-	var experiences entity.Experiences
+	var internal internalExperiences
 
 	p := listExperiencesParams(*params)
 
@@ -77,9 +77,11 @@ func (e *experience) List(ctx context.Context, params *database.ListExperiencesP
 	stmt = p.stmt(stmt)
 	stmt = p.pagination(stmt)
 
-	if err := stmt.Find(&experiences).Error; err != nil {
+	if err := stmt.Find(&internal).Error; err != nil {
 		return nil, dbError(err)
 	}
+	experiences := internal.entities()
+
 	if err := e.fill(ctx, e.db.DB, experiences...); err != nil {
 		return nil, dbError(err)
 	}
@@ -91,6 +93,180 @@ func (e *experience) Count(ctx context.Context, params *database.ListExperiences
 
 	total, err := e.db.Count(ctx, e.db.DB, &entity.Experience{}, p.stmt)
 	return total, dbError(err)
+}
+
+func (e *experience) MultiGet(ctx context.Context, experienceIDs []string, fields ...string) (entity.Experiences, error) {
+	experiences, err := e.multiGet(ctx, e.db.DB, experienceIDs, fields...)
+	return experiences, dbError(err)
+}
+
+func (e *experience) MultiGetByRevision(ctx context.Context, revisionIDs []int64, fields ...string) (entity.Experiences, error) {
+	var revisions entity.ExperienceRevisions
+
+	stmt := e.db.Statement(ctx, e.db.DB, experienceRevisionTable).
+		Where("id IN (?)", revisionIDs)
+
+	if err := stmt.Find(&revisions).Error; err != nil {
+		return nil, dbError(err)
+	}
+	if len(revisions) == 0 {
+		return entity.Experiences{}, nil
+	}
+
+	experiences, err := e.multiGet(ctx, e.db.DB, revisions.ExperienceIDs(), fields...)
+	if err != nil {
+		return nil, err
+	}
+	if len(experiences) == 0 {
+		return entity.Experiences{}, nil
+	}
+
+	res, err := revisions.Merge(experiences.Map())
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (e *experience) Get(ctx context.Context, experienceID string, fields ...string) (*entity.Experience, error) {
+	experience, err := e.get(ctx, e.db.DB, experienceID, fields...)
+	return experience, dbError(err)
+}
+
+func (e *experience) Create(ctx context.Context, experience *entity.Experience) error {
+	err := e.db.Transaction(ctx, func(tx *gorm.DB) error {
+		if err := experience.FillJSON(); err != nil {
+			return err
+		}
+
+		now := e.now()
+
+		experience.CreatedAt, experience.UpdatedAt = now, now
+		experience.ExperienceRevision.CreatedAt, experience.ExperienceRevision.UpdatedAt = now, now
+
+		internal := newInternalExperience(experience)
+
+		if err := tx.WithContext(ctx).Table(experienceTable).Create(&internal).Error; err != nil {
+			return err
+		}
+		return tx.WithContext(ctx).Table(experienceRevisionTable).Create(&internal.ExperienceRevision).Error
+	})
+	return dbError(err)
+}
+
+func (e *experience) Update(ctx context.Context, experienceID string, params *database.UpdateExperienceParams) error {
+	now := e.now()
+	rparams := &entity.NewExperienceRevisionParams{
+		ExperienceID:          experienceID,
+		PriceAdult:            params.PriceAdult,
+		PriceJuniorHighSchool: params.PriceJuniorHighSchool,
+		PriceElementarySchool: params.PriceElementarySchool,
+		PricePreschool:        params.PricePreschool,
+		PriceSenior:           params.PriceSenior,
+	}
+	revision := entity.NewExperienceRevision(rparams)
+
+	err := e.db.Transaction(ctx, func(tx *gorm.DB) error {
+		media, err := params.Media.Marshal()
+		if err != nil {
+			return fmt.Errorf("database: %w: %s", database.ErrInvalidArgument, err.Error())
+		}
+		points, err := entity.ExperienceMarshalRecommendedPoints(params.RecommendedPoints)
+		if err != nil {
+			return fmt.Errorf("database: %w: %s", database.ErrInvalidArgument, err.Error())
+		}
+		openTime, err := jst.ParseFromHHMM(params.BusinessOpenTime)
+		if err != nil {
+			return fmt.Errorf("entity: invalid business open time: %w", err)
+		}
+		closeTime, err := jst.ParseFromHHMM(params.BusinessCloseTime)
+		if err != nil {
+			return fmt.Errorf("entity: invalid business close time: %w", err)
+		}
+		if !openTime.Before(closeTime) {
+			return errors.New("entity: invalid business time")
+		}
+
+		updates := map[string]interface{}{
+			"experience_type_id":  params.TypeID,
+			"title":               params.Title,
+			"description":         params.Description,
+			"public":              params.Public,
+			"sold_out":            params.SoldOut,
+			"media":               nil,
+			"recommended_points":  points,
+			"promotion_video_url": params.PromotionVideoURL,
+			"duration":            params.Duration,
+			"direction":           params.Direction,
+			"business_open_time":  params.BusinessOpenTime,
+			"business_close_time": params.BusinessCloseTime,
+			"host_postal_code":    params.HostPostalCode,
+			"host_prefecture":     params.HostPrefectureCode,
+			"host_city":           params.HostCity,
+			"host_address_line1":  params.HostAddressLine1,
+			"host_address_line2":  params.HostAddressLine2,
+			"host_longitude":      params.HostLongitude,
+			"host_latitude":       params.HostLatitude,
+			"start_at":            params.StartAt,
+			"end_at":              params.EndAt,
+			"updated_at":          now,
+		}
+		if len(media) > 0 {
+			updates["media"] = media
+		}
+
+		stmt := tx.WithContext(ctx).Table(experienceTable).Where("id = ?", experienceID)
+		if err := stmt.Updates(updates).Error; err != nil {
+			return err
+		}
+
+		revision.CreatedAt, revision.UpdatedAt = now, now
+		return tx.WithContext(ctx).Table(experienceRevisionTable).Create(&revision).Error
+	})
+	return dbError(err)
+}
+
+func (e *experience) Delete(ctx context.Context, experienceID string) error {
+	params := map[string]interface{}{
+		"deleted_at": e.now(),
+	}
+	stmt := e.db.DB.WithContext(ctx).Table(experienceTable).Where("id = ?", experienceID)
+	err := stmt.Updates(params).Error
+	return dbError(err)
+}
+
+func (e *experience) multiGet(ctx context.Context, tx *gorm.DB, experienceIDs []string, fields ...string) (entity.Experiences, error) {
+	var internal internalExperiences
+
+	stmt := e.db.Statement(ctx, tx, experienceTable, fields...).
+		Where("id IN (?)", experienceIDs)
+
+	if err := stmt.Find(&internal).Error; err != nil {
+		return nil, err
+	}
+	experiences := internal.entities()
+
+	if err := e.fill(ctx, tx, experiences...); err != nil {
+		return nil, err
+	}
+	return experiences, nil
+}
+
+func (e *experience) get(ctx context.Context, tx *gorm.DB, experienceID string, fields ...string) (*entity.Experience, error) {
+	var internal *internalExperience
+
+	stmt := e.db.Statement(ctx, tx, experienceTable, fields...).
+		Where("id = ?", experienceID)
+
+	if err := stmt.First(&internal).Error; err != nil {
+		return nil, err
+	}
+	experience := internal.entity()
+
+	if err := e.fill(ctx, tx, experience); err != nil {
+		return nil, err
+	}
+	return experience, nil
 }
 
 func (e *experience) fill(ctx context.Context, tx *gorm.DB, experiences ...*entity.Experience) error {
@@ -115,4 +291,37 @@ func (e *experience) fill(ctx context.Context, tx *gorm.DB, experiences ...*enti
 		return nil
 	}
 	return entity.Experiences(experiences).Fill(revisions.MapByExperienceID(), e.now())
+}
+
+type internalExperience struct {
+	entity.Experience `gorm:"embedded"`
+	HostLongitude     float64 `gorm:""` // 開催場所(座標情報:経度)
+	HostLatitude      float64 `gorm:""` // 開催場所(座標情報:緯度)
+}
+
+type internalExperiences []*internalExperience
+
+func newInternalExperience(experience *entity.Experience) *internalExperience {
+	return &internalExperience{
+		Experience:    *experience,
+		HostLongitude: experience.HostLongitude,
+		HostLatitude:  experience.HostLatitude,
+	}
+}
+
+func (e *internalExperience) entity() *entity.Experience {
+	if e == nil {
+		return nil
+	}
+	e.Experience.HostLongitude = e.HostLongitude
+	e.Experience.HostLatitude = e.HostLatitude
+	return &e.Experience
+}
+
+func (es internalExperiences) entities() entity.Experiences {
+	res := make(entity.Experiences, len(es))
+	for i := range es {
+		res[i] = es[i].entity()
+	}
+	return res
 }

--- a/api/internal/store/database/tidb/tidb.go
+++ b/api/internal/store/database/tidb/tidb.go
@@ -16,7 +16,7 @@ func NewDatabase(db *apmysql.Client) *database.Database {
 	client := mysql.NewDatabase(db)
 	return &database.Database{
 		Category:       newCategory(db, client.Category),
-		Experience:     newExperience(db, client.Experience),
+		Experience:     newExperience(db),
 		ExperienceType: newExperienceType(db, client.ExperienceType),
 		Live:           client.Live,
 		Order:          client.Order,

--- a/api/internal/store/entity/experience.go
+++ b/api/internal/store/entity/experience.go
@@ -55,8 +55,8 @@ type Experience struct {
 	HostCity              string               `gorm:""`                                       // 開催場所(市区町村)
 	HostAddressLine1      string               `gorm:""`                                       // 開催場所(町名・番地)
 	HostAddressLine2      string               `gorm:""`                                       // 開催場所(ビル名・号室など)
-	HostLongitude         float64              `gorm:""`                                       // 開催場所(座標情報:経度)
-	HostLatitude          float64              `gorm:""`                                       // 開催場所(座標情報:緯度)
+	HostLongitude         float64              `gorm:"-"`                                      // 開催場所(座標情報:経度) FIXME: MySQLに存在しないカラム
+	HostLatitude          float64              `gorm:"-"`                                      // 開催場所(座標情報:緯度) FIXME: MySQLに存在しないカラム
 	StartAt               time.Time            `gorm:""`                                       // 募集開始日時
 	EndAt                 time.Time            `gorm:""`                                       // 募集終了日時
 	CreatedAt             time.Time            `gorm:"<-:create"`                              // 登録日時

--- a/api/internal/store/entity/experience_test.go
+++ b/api/internal/store/entity/experience_test.go
@@ -334,8 +334,8 @@ func TestExperience_Fill(t *testing.T) {
 					HostCity:              "彦根市",
 					HostAddressLine1:      "金亀町１−１",
 					HostAddressLine2:      "",
-					HostLongitude:         136.251739,
-					HostLatitude:          35.276833,
+					HostLongitude:         0,
+					HostLatitude:          0,
 					ExperienceRevision:    ExperienceRevision{ExperienceID: "experience-id"},
 					StartAt:               now.AddDate(0, 0, -1),
 					EndAt:                 now.AddDate(0, 0, 1),
@@ -352,7 +352,7 @@ func TestExperience_Fill(t *testing.T) {
 			t.Parallel()
 			err := tt.experiences.Fill(tt.revisions, tt.now)
 			assert.Equal(t, err != nil, tt.hasErr)
-			assert.Equal(t, tt.experiences, tt.expect)
+			assert.Equal(t, tt.expect, tt.experiences)
 		})
 	}
 }


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- 経験データの内部表現を改善し、データベースでの処理を簡素化しました。
	- 複数の経験を取得、作成、更新、削除するための新しいメソッドを追加しました。

- **バグ修正**
	- `newInternelExperience` 関数の名称を `newInternalExperience` に修正しました。
	- 経験の作成時にデータベーストランザクションを適切に処理するように変更しました。

- **ドキュメント**
	- 経験構造体の地理座標フィールドに関するコメントを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->