### PR TITLE
Release for v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.0.1](https://github.com/and-period/furumaru/compare/v3.0.0...v3.0.1) - 2024-11-02
+- build(deps): bump the dependencies group in /api with 35 updates by @dependabot in https://github.com/and-period/furumaru/pull/2472
+- build(deps): bump the dependencies group in /docs/swagger with 2 updates by @dependabot in https://github.com/and-period/furumaru/pull/2471
+- refactor(api): 検証用にいれていたloggerの削除 by @taba2424 in https://github.com/and-period/furumaru/pull/2474
+- fix(api): DBのorderロジックを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2475
+
 ## [v3.0.0](https://github.com/and-period/furumaru/compare/v2.0.1...v3.0.0) - 2024-10-29
 - feat(user): DBクライアントの詰め替え by @taba2424 in https://github.com/and-period/furumaru/pull/2457
 - fix(user): cognito idの管理方法を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2459


### PR DESCRIPTION
This pull request is for the next release as v3.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump the dependencies group in /api with 35 updates by @dependabot in https://github.com/and-period/furumaru/pull/2472
* build(deps): bump the dependencies group in /docs/swagger with 2 updates by @dependabot in https://github.com/and-period/furumaru/pull/2471
* refactor(api): 検証用にいれていたloggerの削除 by @taba2424 in https://github.com/and-period/furumaru/pull/2474
* fix(api): DBのorderロジックを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2475


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.0.0...v3.0.1