### PR TITLE
Release for v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v3.0.2](https://github.com/and-period/furumaru/compare/v3.0.1...v3.0.2) - 2024-11-04
+- Feat/experience by @hamachans in https://github.com/and-period/furumaru/pull/2423
+- feat(web): ヘルスチェック用のページを作成 by @taba2424 in https://github.com/and-period/furumaru/pull/2477
+- fix(media): メディア配信周りの改善 by @taba2424 in https://github.com/and-period/furumaru/pull/2478
+
 ## [v3.0.1](https://github.com/and-period/furumaru/compare/v3.0.0...v3.0.1) - 2024-11-02
 - build(deps): bump the dependencies group in /api with 35 updates by @dependabot in https://github.com/and-period/furumaru/pull/2472
 - build(deps): bump the dependencies group in /docs/swagger with 2 updates by @dependabot in https://github.com/and-period/furumaru/pull/2471


### PR DESCRIPTION
This pull request is for the next release as v3.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Feat/experience by @hamachans in https://github.com/and-period/furumaru/pull/2423
* feat(web): ヘルスチェック用のページを作成 by @taba2424 in https://github.com/and-period/furumaru/pull/2477
* fix(media): メディア配信周りの改善 by @taba2424 in https://github.com/and-period/furumaru/pull/2478


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.0.1...v3.0.2