### PR TITLE
fix(api): オンデマンド配信に紐づいている商品・体験が削除できないように

### DIFF
--- a/api/internal/media/database/database.go
+++ b/api/internal/media/database/database.go
@@ -131,6 +131,8 @@ type AggregateBroadcastViewerLogsParams struct {
 
 type Video interface {
 	List(ctx context.Context, params *ListVideosParams, fields ...string) (entity.Videos, error)
+	ListByProductID(ctx context.Context, productID string, fields ...string) (entity.Videos, error)
+	ListByExperienceID(ctx context.Context, experienceID string, fields ...string) (entity.Videos, error)
 	Count(ctx context.Context, params *ListVideosParams) (int64, error)
 	Get(ctx context.Context, videoID string, fields ...string) (*entity.Video, error)
 	Create(ctx context.Context, video *entity.Video) error

--- a/api/internal/media/database/mysql/video.go
+++ b/api/internal/media/database/mysql/video.go
@@ -82,6 +82,46 @@ func (v *video) List(ctx context.Context, params *database.ListVideosParams, fie
 	return videos, nil
 }
 
+func (v *video) ListByProductID(ctx context.Context, productID string, fields ...string) (entity.Videos, error) {
+	var videos entity.Videos
+
+	sub := v.db.DB.
+		Table(videoProductTable).
+		Select("video_id").
+		Where("product_id = ?", productID)
+	stmt := v.db.DB.WithContext(ctx).
+		Table(videoTable).
+		Where("video_id IN (?)", sub)
+
+	if err := stmt.Find(&videos).Error; err != nil {
+		return nil, dbError(err)
+	}
+	if err := v.fill(ctx, v.db.DB, videos...); err != nil {
+		return nil, dbError(err)
+	}
+	return videos, nil
+}
+
+func (v *video) ListByExperienceID(ctx context.Context, experienceID string, fields ...string) (entity.Videos, error) {
+	var videos entity.Videos
+
+	sub := v.db.DB.
+		Table(videoExperienceTable).
+		Select("video_id").
+		Where("experience_id = ?", experienceID)
+	stmt := v.db.DB.WithContext(ctx).
+		Table(videoTable).
+		Where("video_id IN (?)", sub)
+
+	if err := stmt.Find(&videos).Error; err != nil {
+		return nil, dbError(err)
+	}
+	if err := v.fill(ctx, v.db.DB, videos...); err != nil {
+		return nil, dbError(err)
+	}
+	return videos, nil
+}
+
 func (v *video) Count(ctx context.Context, params *database.ListVideosParams) (int64, error) {
 	p := listVideosParams(*params)
 

--- a/api/internal/media/database/mysql/video.go
+++ b/api/internal/media/database/mysql/video.go
@@ -91,7 +91,7 @@ func (v *video) ListByProductID(ctx context.Context, productID string, fields ..
 		Where("product_id = ?", productID)
 	stmt := v.db.DB.WithContext(ctx).
 		Table(videoTable).
-		Where("video_id IN (?)", sub)
+		Where("id IN (?)", sub)
 
 	if err := stmt.Find(&videos).Error; err != nil {
 		return nil, dbError(err)
@@ -111,7 +111,7 @@ func (v *video) ListByExperienceID(ctx context.Context, experienceID string, fie
 		Where("experience_id = ?", experienceID)
 	stmt := v.db.DB.WithContext(ctx).
 		Table(videoTable).
-		Where("video_id IN (?)", sub)
+		Where("id IN (?)", sub)
 
 	if err := stmt.Find(&videos).Error; err != nil {
 		return nil, dbError(err)

--- a/api/internal/media/database/mysql/video_test.go
+++ b/api/internal/media/database/mysql/video_test.go
@@ -91,6 +91,152 @@ func TestVideo_List(t *testing.T) {
 	}
 }
 
+func TestVideo_ListByProductID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	videos := make(entity.Videos, 3)
+	videos[0] = testVideo("video-id01", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[0].PublishedAt = now().AddDate(0, 0, -1)
+	videos[1] = testVideo("video-id02", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[1].PublishedAt = now().AddDate(0, 0, -2)
+	videos[2] = testVideo("video-id03", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[2].PublishedAt = now().AddDate(0, -1, 0)
+	err = db.DB.Create(&videos).Error
+	require.NoError(t, err)
+	for _, video := range videos {
+		err = db.DB.Create(&video.VideoProducts).Error
+		require.NoError(t, err)
+		err = db.DB.Create(&video.VideoExperiences).Error
+		require.NoError(t, err)
+	}
+
+	type args struct {
+		productID string
+	}
+	type want struct {
+		videos entity.Videos
+		err    error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				productID: "product-id",
+			},
+			want: want{
+				videos: videos,
+				err:    nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &video{db: db, now: now}
+			actual, err := db.ListByProductID(ctx, tt.args.productID)
+			assert.ErrorIs(t, err, tt.want.err)
+			assert.ElementsMatch(t, tt.want.videos, actual)
+		})
+	}
+}
+
+func TestVideo_ListByExperienceID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	videos := make(entity.Videos, 3)
+	videos[0] = testVideo("video-id01", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[0].PublishedAt = now().AddDate(0, 0, -1)
+	videos[1] = testVideo("video-id02", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[1].PublishedAt = now().AddDate(0, 0, -2)
+	videos[2] = testVideo("video-id03", "coordinator-id", []string{"product-id"}, []string{"experience-id"}, now())
+	videos[2].PublishedAt = now().AddDate(0, -1, 0)
+	err = db.DB.Create(&videos).Error
+	require.NoError(t, err)
+	for _, video := range videos {
+		err = db.DB.Create(&video.VideoProducts).Error
+		require.NoError(t, err)
+		err = db.DB.Create(&video.VideoExperiences).Error
+		require.NoError(t, err)
+	}
+
+	type args struct {
+		experienceID string
+	}
+	type want struct {
+		videos entity.Videos
+		err    error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				experienceID: "product-id",
+			},
+			want: want{
+				videos: videos,
+				err:    nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &video{db: db, now: now}
+			actual, err := db.ListByExperienceID(ctx, tt.args.experienceID)
+			assert.ErrorIs(t, err, tt.want.err)
+			assert.ElementsMatch(t, tt.want.videos, actual)
+		})
+	}
+}
+
 func TestVideo_Count(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/internal/media/database/mysql/video_test.go
+++ b/api/internal/media/database/mysql/video_test.go
@@ -211,7 +211,7 @@ func TestVideo_ListByExperienceID(t *testing.T) {
 			name:  "success",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
-				experienceID: "product-id",
+				experienceID: "experience-id",
 			},
 			want: want{
 				videos: videos,
@@ -232,7 +232,7 @@ func TestVideo_ListByExperienceID(t *testing.T) {
 			db := &video{db: db, now: now}
 			actual, err := db.ListByExperienceID(ctx, tt.args.experienceID)
 			assert.ErrorIs(t, err, tt.want.err)
-			assert.ElementsMatch(t, tt.want.videos, actual)
+			assert.Equal(t, tt.want.videos, actual)
 		})
 	}
 }

--- a/api/internal/media/input.go
+++ b/api/internal/media/input.go
@@ -152,6 +152,14 @@ type ListVideosInput struct {
 	NoLimit               bool   `validate:""`
 }
 
+type ListProductVideosInput struct {
+	ProductID string `validate:"required"`
+}
+
+type ListExperienceVideosInput struct {
+	ExperienceID string `validate:"required"`
+}
+
 type GetVideoInput struct {
 	VideoID string `validate:"required"`
 }

--- a/api/internal/media/service.go
+++ b/api/internal/media/service.go
@@ -37,6 +37,8 @@ type Service interface {
 	AggregateBroadcastViewerLogs(ctx context.Context, in *AggregateBroadcastViewerLogsInput) (entity.AggregatedBroadcastViewerLogs, int64, error) // ライブ配信視聴履歴集計
 	// オンデマンド配信
 	ListVideos(ctx context.Context, in *ListVideosInput) (entity.Videos, int64, error)                       // 一覧取得
+	ListProductVideos(ctx context.Context, in *ListProductVideosInput) (entity.Videos, error)                // 一覧取得（商品別）
+	ListExperienceVideos(ctx context.Context, in *ListExperienceVideosInput) (entity.Videos, error)          // 一覧取得（体験別）
 	GetVideo(ctx context.Context, in *GetVideoInput) (*entity.Video, error)                                  // １件取得
 	CreateVideo(ctx context.Context, in *CreateVideoInput) (*entity.Video, error)                            // 登録
 	UpdateVideo(ctx context.Context, in *UpdateVideoInput) error                                             // 更新

--- a/api/internal/media/service/video.go
+++ b/api/internal/media/service/video.go
@@ -47,6 +47,22 @@ func (s *service) ListVideos(ctx context.Context, in *media.ListVideosInput) (en
 	return videos, total, nil
 }
 
+func (s *service) ListProductVideos(ctx context.Context, in *media.ListProductVideosInput) (entity.Videos, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, internalError(err)
+	}
+	videos, err := s.db.Video.ListByProductID(ctx, in.ProductID)
+	return videos, internalError(err)
+}
+
+func (s *service) ListExperienceVideos(ctx context.Context, in *media.ListExperienceVideosInput) (entity.Videos, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, internalError(err)
+	}
+	videos, err := s.db.Video.ListByExperienceID(ctx, in.ExperienceID)
+	return videos, internalError(err)
+}
+
 func (s *service) GetVideo(ctx context.Context, in *media.GetVideoInput) (*entity.Video, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return nil, internalError(err)

--- a/api/internal/media/service/video_test.go
+++ b/api/internal/media/service/video_test.go
@@ -154,6 +154,174 @@ func TestListVideos(t *testing.T) {
 	}
 }
 
+func TestListProductVideos(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2023, 10, 20, 18, 30, 0, 0)
+	videos := entity.Videos{
+		{
+			ID:            "video-id",
+			CoordinatorID: "coordinator-id",
+			ProductIDs:    []string{"product-id"},
+			ExperienceIDs: []string{"experience-id"},
+			Title:         "じゃがいも収穫",
+			Description:   "じゃがいも収穫の説明",
+			Status:        entity.VideoStatusPublished,
+			ThumbnailURL:  "https://example.com/thumbnail.jpg",
+			VideoURL:      "https://example.com/video.mp4",
+			Public:        true,
+			Limited:       false,
+			VideoProducts: []*entity.VideoProduct{{
+				VideoID:   "video-id",
+				ProductID: "product-id",
+				Priority:  1,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}},
+			VideoExperiences: []*entity.VideoExperience{{
+				VideoID:      "video-id",
+				ExperienceID: "experience-id",
+				Priority:     1,
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}},
+			PublishedAt: now.AddDate(0, 0, -1),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(ctx context.Context, mocks *mocks)
+		input     *media.ListProductVideosInput
+		expect    entity.Videos
+		expectErr error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().ListByProductID(gomock.Any(), "product-id").Return(videos, nil)
+			},
+			input: &media.ListProductVideosInput{
+				ProductID: "product-id",
+			},
+			expect:    videos,
+			expectErr: nil,
+		},
+		{
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &media.ListProductVideosInput{},
+			expect:    nil,
+			expectErr: exception.ErrInvalidArgument,
+		},
+		{
+			name: "failed to list videos",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().ListByProductID(gomock.Any(), "product-id").Return(nil, assert.AnError)
+			},
+			input: &media.ListProductVideosInput{
+				ProductID: "product-id",
+			},
+			expect:    nil,
+			expectErr: exception.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			actual, err := service.ListProductVideos(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expectErr)
+			assert.Equal(t, tt.expect, actual)
+		}))
+	}
+}
+
+func TestListExperienceVideos(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2023, 10, 20, 18, 30, 0, 0)
+	videos := entity.Videos{
+		{
+			ID:            "video-id",
+			CoordinatorID: "coordinator-id",
+			ProductIDs:    []string{"product-id"},
+			ExperienceIDs: []string{"experience-id"},
+			Title:         "じゃがいも収穫",
+			Description:   "じゃがいも収穫の説明",
+			Status:        entity.VideoStatusPublished,
+			ThumbnailURL:  "https://example.com/thumbnail.jpg",
+			VideoURL:      "https://example.com/video.mp4",
+			Public:        true,
+			Limited:       false,
+			VideoProducts: []*entity.VideoProduct{{
+				VideoID:   "video-id",
+				ProductID: "product-id",
+				Priority:  1,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}},
+			VideoExperiences: []*entity.VideoExperience{{
+				VideoID:      "video-id",
+				ExperienceID: "experience-id",
+				Priority:     1,
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}},
+			PublishedAt: now.AddDate(0, 0, -1),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(ctx context.Context, mocks *mocks)
+		input     *media.ListExperienceVideosInput
+		expect    entity.Videos
+		expectErr error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().ListByExperienceID(gomock.Any(), "experience-id").Return(videos, nil)
+			},
+			input: &media.ListExperienceVideosInput{
+				ExperienceID: "experience-id",
+			},
+			expect:    videos,
+			expectErr: nil,
+		},
+		{
+			name:      "invalid argument",
+			setup:     func(ctx context.Context, mocks *mocks) {},
+			input:     &media.ListExperienceVideosInput{},
+			expect:    nil,
+			expectErr: exception.ErrInvalidArgument,
+		},
+		{
+			name: "failed to list videos",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Video.EXPECT().ListByExperienceID(gomock.Any(), "experience-id").Return(nil, assert.AnError)
+			},
+			input: &media.ListExperienceVideosInput{
+				ExperienceID: "experience-id",
+			},
+			expect:    nil,
+			expectErr: exception.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			actual, err := service.ListExperienceVideos(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expectErr)
+			assert.Equal(t, tt.expect, actual)
+		}))
+	}
+}
+
 func TestGetVideo(t *testing.T) {
 	t.Parallel()
 

--- a/api/internal/store/service/experience.go
+++ b/api/internal/store/service/experience.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/and-period/furumaru/api/internal/codes"
 	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/media"
 	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/and-period/furumaru/api/internal/store/database"
 	"github.com/and-period/furumaru/api/internal/store/entity"
@@ -234,6 +235,16 @@ func (s *service) DeleteExperience(ctx context.Context, in *store.DeleteExperien
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
-	err := s.db.Experience.Delete(ctx, in.ExperienceID)
+	videosIn := &media.ListExperienceVideosInput{
+		ExperienceID: in.ExperienceID,
+	}
+	videos, err := s.media.ListExperienceVideos(ctx, videosIn)
+	if err != nil {
+		return internalError(err)
+	}
+	if len(videos) > 0 {
+		return fmt.Errorf("service: experience has videos: %w", exception.ErrFailedPrecondition)
+	}
+	err = s.db.Experience.Delete(ctx, in.ExperienceID)
 	return internalError(err)
 }

--- a/api/internal/store/service/product.go
+++ b/api/internal/store/service/product.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/and-period/furumaru/api/internal/codes"
 	"github.com/and-period/furumaru/api/internal/exception"
+	"github.com/and-period/furumaru/api/internal/media"
 	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/and-period/furumaru/api/internal/store/database"
 	"github.com/and-period/furumaru/api/internal/store/entity"
@@ -240,6 +241,16 @@ func (s *service) DeleteProduct(ctx context.Context, in *store.DeleteProductInpu
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
-	err := s.db.Product.Delete(ctx, in.ProductID)
+	videosIn := &media.ListProductVideosInput{
+		ProductID: in.ProductID,
+	}
+	videos, err := s.media.ListProductVideos(ctx, videosIn)
+	if err != nil {
+		return internalError(err)
+	}
+	if len(videos) > 0 {
+		return fmt.Errorf("service: product has videos: %w", exception.ErrFailedPrecondition)
+	}
+	err = s.db.Product.Delete(ctx, in.ProductID)
 	return internalError(err)
 }

--- a/docs/swagger/admin/paths/v1/experiences/_experienceId/index.yaml
+++ b/docs/swagger/admin/paths/v1/experiences/_experienceId/index.yaml
@@ -110,3 +110,9 @@ delete:
         application/json:
           schema:
             $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'
+    412:
+      description: 関連付けられている箇所があるため削除できない
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/admin/paths/v1/products/_productId/index.yaml
+++ b/docs/swagger/admin/paths/v1/products/_productId/index.yaml
@@ -110,3 +110,9 @@ delete:
         application/json:
           schema:
             $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'
+    412:
+      description: 関連付けられている箇所があるため削除できない
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../openapi.yaml#/components/schemas/errorResponse'


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 特定の製品IDおよび体験IDに基づいて動画を取得するための新しいメソッドを追加しました。
	- 動画管理機能を拡張するための新しい入力タイプを導入しました。
- **バグ修正**
	- 動画が関連付けられている場合、製品または体験を削除できないようにするロジックを強化しました。
- **テスト**
	- 新しい動画リスト機能に対するテストケースを追加し、既存のテストを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->