### PR TITLE
Release for v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.0.3](https://github.com/and-period/furumaru/compare/v3.0.2...v3.0.3) - 2024-11-06
+- fix(user): 外形監視用のページではcart情報を取らない by @taba2424 in https://github.com/and-period/furumaru/pull/2482
+- fix(api): オンデマンド配信に紐づいている商品・体験が削除できないように by @taba2424 in https://github.com/and-period/furumaru/pull/2479
+
 ## [v3.0.2](https://github.com/and-period/furumaru/compare/v3.0.1...v3.0.2) - 2024-11-04
 - Feat/experience by @hamachans in https://github.com/and-period/furumaru/pull/2423
 - feat(web): ヘルスチェック用のページを作成 by @taba2424 in https://github.com/and-period/furumaru/pull/2477


### PR DESCRIPTION
This pull request is for the next release as v3.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(user): 外形監視用のページではcart情報を取らない by @taba2424 in https://github.com/and-period/furumaru/pull/2482
* fix(api): オンデマンド配信に紐づいている商品・体験が削除できないように by @taba2424 in https://github.com/and-period/furumaru/pull/2479


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.0.2...v3.0.3