### PR TITLE
Release for v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.0.5](https://github.com/and-period/furumaru/compare/v3.0.4...v3.0.5) - 2024-11-10
+- build(deps): bump the dependencies group in /api with 12 updates by @dependabot in https://github.com/and-period/furumaru/pull/2480
+- feat(api): アクセスログにrefererを含める by @taba2424 in https://github.com/and-period/furumaru/pull/2488
+
 ## [v3.0.4](https://github.com/and-period/furumaru/compare/v3.0.3...v3.0.4) - 2024-11-06
 - fix(user): 外形監視用のページのscriptを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2485
 


### PR DESCRIPTION
This pull request is for the next release as v3.0.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.0.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.0.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump the dependencies group in /api with 12 updates by @dependabot in https://github.com/and-period/furumaru/pull/2480
* feat(api): アクセスログにrefererを含める by @taba2424 in https://github.com/and-period/furumaru/pull/2488


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.0.4...v3.0.5