### PR TITLE
Release for v3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.0.8](https://github.com/and-period/furumaru/compare/v3.0.7...v3.0.8) - 2024-11-13
+- build(deps): bump cross-spawn from 7.0.3 to 7.0.5 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2494
+- setup: 本番環境向けのGoogle Tag Managerを仕込む by @wf-yamaday in https://github.com/and-period/furumaru/pull/2497
+
 ## [v3.0.7](https://github.com/and-period/furumaru/compare/v3.0.6...v3.0.7) - 2024-11-12
 - 動画管理画面の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2385
 - fix(api): Sentryのトレーシング機能を無効に by @taba2424 in https://github.com/and-period/furumaru/pull/2492


### PR DESCRIPTION
This pull request is for the next release as v3.0.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.0.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.0.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump cross-spawn from 7.0.3 to 7.0.5 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2494
* setup: 本番環境向けのGoogle Tag Managerを仕込む by @wf-yamaday in https://github.com/and-period/furumaru/pull/2497


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.0.7...v3.0.8