### PR TITLE
fix(media): MediaStore廃止にあたってライブ配信用のURLを変更

### DIFF
--- a/api/internal/media/broadcast/updater/updater.go
+++ b/api/internal/media/broadcast/updater/updater.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"net/url"
 	"sync"
 
 	"github.com/and-period/furumaru/api/internal/media/database"
@@ -13,8 +14,9 @@ type Updater interface {
 }
 
 type Params struct {
-	WaitGroup *sync.WaitGroup
-	Database  *database.Database
+	WaitGroup  *sync.WaitGroup
+	Database   *database.Database
+	StorageURL *url.URL
 }
 
 type options struct {

--- a/api/internal/media/cmd/updater/registry.go
+++ b/api/internal/media/cmd/updater/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
@@ -67,10 +68,17 @@ func (a *app) inject(ctx context.Context) error {
 		return fmt.Errorf("cmd: failed to create database client: %w", err)
 	}
 
+	// CDNのURL設定
+	storageURL, err := url.Parse(a.CDNURL)
+	if err != nil {
+		return fmt.Errorf("cmd: failed to parse cdn url: %w", err)
+	}
+
 	// Jobの設定
 	jobParams := &updater.Params{
-		WaitGroup: params.waitGroup,
-		Database:  mediadb.NewDatabase(dbClient),
+		WaitGroup:  params.waitGroup,
+		Database:   mediadb.NewDatabase(dbClient),
+		StorageURL: storageURL,
 	}
 	switch a.RunType {
 	case "START":

--- a/api/internal/media/cmd/updater/updater.go
+++ b/api/internal/media/cmd/updater/updater.go
@@ -33,6 +33,7 @@ type app struct {
 	SentryDsn        string `default:""                envconfig:"SENTRY_DSN"`
 	SentrySecretName string `default:""                envconfig:"SENTRY_SECRET_NAME"`
 	AWSRegion        string `default:"ap-northeast-1"  envconfig:"AWS_REGION"`
+	CDNURL           string `default:""                envconfig:"CDN_URL"`
 }
 
 //nolint:revive


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->
https://github.com/and-period/infra/pull/92

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `Params` 構造体に `StorageURL` フィールドを追加し、ストレージ関連機能をサポート。
	- `app` 構造体に `CDNURL` フィールドを追加し、環境変数からの設定を可能に。

- **変更**
	- `starter` 構造体に `storageURL` 関数を追加し、URL 構築を動的に処理。
	- `inject` メソッドで CDN URL を解析し、`jobParams` に `StorageURL` フィールドを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->