### PR TITLE
fix(api): 500エラー時に本番環境でもレスポンスを返すように

### DIFF
--- a/api/internal/gateway/admin/v1/handler/api.go
+++ b/api/internal/gateway/admin/v1/handler/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -181,7 +180,6 @@ func (h *handler) Routes(rg *gin.RouterGroup) {
 func (h *handler) httpError(ctx *gin.Context, err error) {
 	res, code := util.NewErrorResponse(err)
 	h.reportError(ctx, err, res)
-	h.filterResponse(res)
 	ctx.JSON(code, res)
 	ctx.Abort()
 }
@@ -196,14 +194,6 @@ func (h *handler) unauthorized(ctx *gin.Context, err error) {
 
 func (h *handler) forbidden(ctx *gin.Context, err error) {
 	h.httpError(ctx, status.Error(codes.PermissionDenied, err.Error()))
-}
-
-func (h *handler) filterResponse(res *util.ErrorResponse) {
-	if res == nil || !strings.Contains(h.env, "prd") {
-		return
-	}
-	// 本番環境の場合、エラーメッセージは返却しない
-	res.Detail = ""
 }
 
 func (h *handler) reportError(ctx *gin.Context, err error, res *util.ErrorResponse) {

--- a/api/internal/gateway/komoju/handler/api.go
+++ b/api/internal/gateway/komoju/handler/api.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -107,21 +106,12 @@ func (h *handler) Routes(rg *gin.RouterGroup) {
 func (h *handler) httpError(ctx *gin.Context, err error) {
 	res, code := util.NewErrorResponse(err)
 	h.reportError(ctx, err, res)
-	h.filterResponse(res)
 	ctx.JSON(code, res)
 	ctx.Abort()
 }
 
 func (h *handler) badRequest(ctx *gin.Context, err error) {
 	h.httpError(ctx, status.Error(codes.InvalidArgument, err.Error()))
-}
-
-func (h *handler) filterResponse(res *util.ErrorResponse) {
-	if res == nil || !strings.Contains(h.env, "prd") {
-		return
-	}
-	// 本番環境の場合、エラーメッセージは返却しない
-	res.Detail = ""
 }
 
 func (h *handler) reportError(ctx *gin.Context, err error, res *util.ErrorResponse) {

--- a/api/internal/gateway/user/v1/handler/api.go
+++ b/api/internal/gateway/user/v1/handler/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -171,7 +170,6 @@ func (h *handler) Routes(rg *gin.RouterGroup) {
 func (h *handler) httpError(ctx *gin.Context, err error) {
 	res, code := util.NewErrorResponse(err)
 	h.reportError(ctx, err, res)
-	h.filterResponse(res)
 	ctx.JSON(code, res)
 	ctx.Abort()
 }
@@ -190,14 +188,6 @@ func (h *handler) forbidden(ctx *gin.Context, err error) {
 
 func (h *handler) notFound(ctx *gin.Context, err error) {
 	h.httpError(ctx, status.Error(codes.NotFound, err.Error()))
-}
-
-func (h *handler) filterResponse(res *util.ErrorResponse) {
-	if res == nil || !strings.Contains(h.env, "prd") {
-		return
-	}
-	// 本番環境の場合、エラーメッセージは返却しない
-	res.Detail = ""
 }
 
 func (h *handler) reportError(ctx *gin.Context, err error, res *util.ErrorResponse) {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- エラーハンドリングの改善により、環境に関係なくエラー詳細が常に返されるようになりました。

- **バグ修正**
	- `filterResponse`メソッドが削除され、エラーレスポンスのフィルタリングが簡素化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->