### PR TITLE
Release for v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.1.1](https://github.com/and-period/furumaru/compare/v3.1.0...v3.1.1) - 2024-11-24
+- fix: 位置情報取得クライアントの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2517
+- feat: 画像加工時の背景を透過させるように by @taba2424 in https://github.com/and-period/furumaru/pull/2519
+
 ## [v3.1.0](https://github.com/and-period/furumaru/compare/v3.0.8...v3.1.0) - 2024-11-24
 - build(deps): bump the dependencies group in /api with 45 updates by @dependabot in https://github.com/and-period/furumaru/pull/2496
 - feat(api): スポット関連APIの定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2499


### PR DESCRIPTION
This pull request is for the next release as v3.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: 位置情報取得クライアントの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2517
* feat: 画像加工時の背景を透過させるように by @taba2424 in https://github.com/and-period/furumaru/pull/2519


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.1.0...v3.1.1