### PR TITLE
Release for v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v3.1.2](https://github.com/and-period/furumaru/compare/v3.1.1...v3.1.2) - 2024-11-27
+- feat(serverless): regionを直で指定する by @sea-kai in https://github.com/and-period/furumaru/pull/2520
+- Upgrade serveless v4 by @sea-kai in https://github.com/and-period/furumaru/pull/2522
+- fix(store): プロモーション公開日時を埋める処理を追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2523
+
 ## [v3.1.1](https://github.com/and-period/furumaru/compare/v3.1.0...v3.1.1) - 2024-11-24
 - fix: 位置情報取得クライアントの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2517
 - feat: 画像加工時の背景を透過させるように by @taba2424 in https://github.com/and-period/furumaru/pull/2519


### PR DESCRIPTION
This pull request is for the next release as v3.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(serverless): regionを直で指定する by @sea-kai in https://github.com/and-period/furumaru/pull/2520
* Upgrade serveless v4 by @sea-kai in https://github.com/and-period/furumaru/pull/2522
* fix(store): プロモーション公開日時を埋める処理を追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2523


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.1.1...v3.1.2