### PR TITLE
fix(store): プロモーション公開日時を埋める処理を追加

### DIFF
--- a/api/internal/store/database/mysql/promotion.go
+++ b/api/internal/store/database/mysql/promotion.go
@@ -124,7 +124,7 @@ func (p *promotion) Update(ctx context.Context, promotionID string, params *data
 		"title":         params.Title,
 		"description":   params.Description,
 		"public":        params.Public,
-		"published_at":  params.PublishedAt,
+		"published_at":  nil,
 		"discount_type": params.DiscountType,
 		"discount_rate": params.DiscountRate,
 		"code":          params.Code,
@@ -132,6 +132,9 @@ func (p *promotion) Update(ctx context.Context, promotionID string, params *data
 		"start_at":      params.StartAt,
 		"end_at":        params.EndAt,
 		"updated_at":    p.now(),
+	}
+	if !params.PublishedAt.IsZero() {
+		updates["published_at"] = params.PublishedAt
 	}
 	stmt := p.db.DB.WithContext(ctx).
 		Table(promotionTable).

--- a/api/internal/store/entity/promotion.go
+++ b/api/internal/store/entity/promotion.go
@@ -47,7 +47,7 @@ type Promotion struct {
 	Status       PromotionStatus   `gorm:"-"`                    // 状態
 	Title        string            `gorm:""`                     // タイトル
 	Description  string            `gorm:""`                     // 詳細説明
-	Public       bool              `gorm:""`                     // 公開フラグ
+	Public       bool              `gorm:""`                     // Deprecated: 公開フラグ
 	PublishedAt  time.Time         `gorm:"default:null"`         // 公開日時
 	DiscountType DiscountType      `gorm:""`                     // 割引計算方法
 	DiscountRate int64             `gorm:""`                     // 割引額(%/円)

--- a/api/internal/store/entity/promotion.go
+++ b/api/internal/store/entity/promotion.go
@@ -48,7 +48,7 @@ type Promotion struct {
 	Title        string            `gorm:""`                     // タイトル
 	Description  string            `gorm:""`                     // 詳細説明
 	Public       bool              `gorm:""`                     // 公開フラグ
-	PublishedAt  time.Time         `gorm:""`                     // 公開日時
+	PublishedAt  time.Time         `gorm:"default:null"`         // 公開日時
 	DiscountType DiscountType      `gorm:""`                     // 割引計算方法
 	DiscountRate int64             `gorm:""`                     // 割引額(%/円)
 	Code         string            `gorm:"<-:create"`            // クーポンコード

--- a/api/internal/store/entity/spot.go
+++ b/api/internal/store/entity/spot.go
@@ -29,6 +29,11 @@ type Spot struct {
 	ThumbnailURL    string       `gorm:""`                                 // サムネイル画像URL
 	Longitude       float64      `gorm:""`                                 // 座標情報:経度
 	Latitude        float64      `gorm:""`                                 // 座標情報:緯度
+	PostalCode      string       `gorm:""`                                 // 郵便番号
+	Prefecture      string       `gorm:""`                                 // 都道府県
+	City            string       `gorm:""`                                 // 市区町村
+	AddressLine1    string       `gorm:""`                                 // 町名・番地
+	AddressLine2    string       `gorm:""`                                 // ビル名・号室など
 	Approved        bool         `gorm:""`                                 // 承認フラグ
 	ApprovedAdminID string       `gorm:""`                                 // 承認した管理者ID
 	CreatedAt       time.Time    `gorm:"<-:create"`                        // 登録日時

--- a/api/internal/store/service/promotion.go
+++ b/api/internal/store/service/promotion.go
@@ -120,6 +120,7 @@ func (s *service) CreatePromotion(ctx context.Context, in *store.CreatePromotion
 	if err := s.validator.Struct(in); err != nil {
 		return nil, internalError(err)
 	}
+	// TODO: クライアントから受け取るように
 	var publishedAt time.Time
 	if in.Public {
 		publishedAt = s.now()
@@ -150,6 +151,7 @@ func (s *service) UpdatePromotion(ctx context.Context, in *store.UpdatePromotion
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
+	// TODO: クライアントから受け取るように
 	var publishedAt time.Time
 	if in.Public {
 		publishedAt = s.now()

--- a/api/internal/store/service/promotion.go
+++ b/api/internal/store/service/promotion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/and-period/furumaru/api/internal/exception"
 	"github.com/and-period/furumaru/api/internal/store"
@@ -119,10 +120,15 @@ func (s *service) CreatePromotion(ctx context.Context, in *store.CreatePromotion
 	if err := s.validator.Struct(in); err != nil {
 		return nil, internalError(err)
 	}
+	var publishedAt time.Time
+	if in.Public {
+		publishedAt = s.now()
+	}
 	params := &entity.NewPromotionParams{
 		Title:        in.Title,
 		Description:  in.Description,
 		Public:       in.Public,
+		PublishedAt:  publishedAt,
 		DiscountType: in.DiscountType,
 		DiscountRate: in.DiscountRate,
 		Code:         in.Code,
@@ -144,10 +150,15 @@ func (s *service) UpdatePromotion(ctx context.Context, in *store.UpdatePromotion
 	if err := s.validator.Struct(in); err != nil {
 		return internalError(err)
 	}
+	var publishedAt time.Time
+	if in.Public {
+		publishedAt = s.now()
+	}
 	params := &database.UpdatePromotionParams{
 		Title:        in.Title,
 		Description:  in.Description,
 		Public:       in.Public,
+		PublishedAt:  publishedAt,
 		DiscountType: in.DiscountType,
 		DiscountRate: in.DiscountRate,
 		Code:         in.Code,

--- a/api/internal/store/service/promotion_test.go
+++ b/api/internal/store/service/promotion_test.go
@@ -359,6 +359,7 @@ func TestGetPromotionByCode(t *testing.T) {
 func TestCreatePromotion(t *testing.T) {
 	t.Parallel()
 
+	now := jst.Date(2022, 8, 1, 0, 0, 0, 0)
 	tests := []struct {
 		name      string
 		setup     func(ctx context.Context, mocks *mocks)
@@ -377,6 +378,7 @@ func TestCreatePromotion(t *testing.T) {
 							Title:        "プロモーションタイトル",
 							Description:  "プロモーションの詳細です。",
 							Public:       true,
+							PublishedAt:  now,
 							DiscountType: entity.DiscountTypeRate,
 							DiscountRate: 10,
 							Code:         "excode01",
@@ -432,17 +434,19 @@ func TestCreatePromotion(t *testing.T) {
 		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
 			_, err := service.CreatePromotion(ctx, tt.input)
 			assert.ErrorIs(t, err, tt.expectErr)
-		}))
+		}, withNow(now)))
 	}
 }
 
 func TestUpdatePromotion(t *testing.T) {
 	t.Parallel()
 
+	now := jst.Date(2022, 8, 1, 0, 0, 0, 0)
 	params := &database.UpdatePromotionParams{
 		Title:        "プロモーションタイトル",
 		Description:  "プロモーションの詳細です。",
 		Public:       true,
+		PublishedAt:  now,
 		DiscountType: entity.DiscountTypeRate,
 		DiscountRate: 10,
 		Code:         "excode01",
@@ -508,7 +512,7 @@ func TestUpdatePromotion(t *testing.T) {
 		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
 			err := service.UpdatePromotion(ctx, tt.input)
 			assert.ErrorIs(t, err, tt.expectErr)
-		}))
+		}, withNow(now)))
 	}
 }
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロモーションの公開日時を条件に基づいて更新するロジックを改善しました。
  - プロモーションが公開されている場合、現在の時刻を使用して公開日時を設定する機能を追加しました。

- **変更点**
  - `Public`フィールドが非推奨としてマークされました。
  - `PublishedAt`フィールドのデフォルト値を`null`に設定しました。

- **バグ修正**
  - プロモーションリストのエラーハンドリングを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->