### PR TITLE
Release for v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v3.2.0](https://github.com/and-period/furumaru/compare/v3.1.3...v3.2.0) - 2024-11-29
+- feat(admin): 体験種別管理ページの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2533
+- feat(admin): スポット種別管理ページの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2534
+- fix(store): プロモーション一覧APIのソート修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2536
+- fix(admin): バリデーションルールの定義忘れがあった箇所の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2537
+- feat(workflow): バックエンドCDのキャッシュ設定 by @taba2424 in https://github.com/and-period/furumaru/pull/2538
+
 ## [v3.1.3](https://github.com/and-period/furumaru/compare/v3.1.2...v3.1.3) - 2024-11-28
 - feat(store): スポット住所を管理できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2527
 - feat(store): TiDB用のDDL追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2529


### PR DESCRIPTION
This pull request is for the next release as v3.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(admin): 体験種別管理ページの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2533
* feat(admin): スポット種別管理ページの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2534
* fix(store): プロモーション一覧APIのソート修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2536
* fix(admin): バリデーションルールの定義忘れがあった箇所の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2537
* feat(workflow): バックエンドCDのキャッシュ設定 by @taba2424 in https://github.com/and-period/furumaru/pull/2538


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.1.3...v3.2.0