### PR TITLE
Release for v3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v3.2.3](https://github.com/and-period/furumaru/compare/v3.2.2...v3.2.3) - 2024-12-07
+- fix(admin): ファイルアップロード周りの処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2547
+
 ## [v3.2.2](https://github.com/and-period/furumaru/compare/v3.2.1...v3.2.2) - 2024-12-05
 - build(deps): bump the dependencies group in /api with 28 updates by @dependabot in https://github.com/and-period/furumaru/pull/2540
 - feat(store): カート操作ログをDB管理するように by @taba2424 in https://github.com/and-period/furumaru/pull/2544


### PR DESCRIPTION
This pull request is for the next release as v3.2.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.2.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(admin): ファイルアップロード周りの処理を修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2547


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.2.2...v3.2.3