### PR TITLE
Release for v3.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v3.2.7](https://github.com/and-period/furumaru/compare/v3.2.6...v3.2.7) - 2024-12-14
+- Fix: fixed cart message by @hamachans in https://github.com/and-period/furumaru/pull/2558
+
 ## [v3.2.6](https://github.com/and-period/furumaru/compare/v3.2.5...v3.2.6) - 2024-12-14
 - 買い物カゴに追加したときの挙動を変更 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2556
 


### PR DESCRIPTION
This pull request is for the next release as v3.2.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.2.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.2.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix: fixed cart message by @hamachans in https://github.com/and-period/furumaru/pull/2558


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.2.6...v3.2.7