### PR TITLE
Release for v3.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.2.8](https://github.com/and-period/furumaru/compare/v3.2.7...v3.2.8) - 2024-12-20
+- build(deps-dev): bump npm-run-all2 from 7.0.1 to 7.0.2 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2560
+- feat(api): 商品レビュー機能の定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2563
+- build(deps): bump the dependencies group in /api with 23 updates by @dependabot in https://github.com/and-period/furumaru/pull/2561
+- fix(user): コーディネータの追加情報を詰める処理が漏れてたので修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2565
+
 ## [v3.2.7](https://github.com/and-period/furumaru/compare/v3.2.6...v3.2.7) - 2024-12-14
 - Fix: fixed cart message by @hamachans in https://github.com/and-period/furumaru/pull/2558
 


### PR DESCRIPTION
This pull request is for the next release as v3.2.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.2.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.2.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps-dev): bump npm-run-all2 from 7.0.1 to 7.0.2 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2560
* feat(api): 商品レビュー機能の定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2563
* build(deps): bump the dependencies group in /api with 23 updates by @dependabot in https://github.com/and-period/furumaru/pull/2561
* fix(user): コーディネータの追加情報を詰める処理が漏れてたので修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2565


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.2.7...v3.2.8