### PR TITLE
Release for v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v3.3.0](https://github.com/and-period/furumaru/compare/v3.2.8...v3.3.0) - 2024-12-23
+- feat(store): 商品レビュー機能の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2566
+- feat(store): 商品レビューの集計ロジック実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2568
+- feat(gateway): 購入者向けの商品レビュー一覧APIの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2569
+- feat(docs): 商品レビュー関連APIのドキュメント追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2570
+- fix(gateway): 商品レビュー一覧が404になる問題の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2571
+- fix(docs): api docsのtypo修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2573
+- fix(gateway): SpotTypeIdが渡せていなかったので修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2574
+- fix(gateway): user-gatewayでGoogle Map APIが利用できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2575
+- fix(gateway): スポット登録APIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2576
+- feat(store): 商品レビューのリアクション機能を実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2577
+- fix(docs): api docsの漏れを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2578
+- feat(gateway): 商品レビューへのリアクション実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2579
+- fix(gateway): pathの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2580
+- fix(store): 体験レビュー関連の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2581
+
 ## [v3.2.8](https://github.com/and-period/furumaru/compare/v3.2.7...v3.2.8) - 2024-12-20
 - build(deps-dev): bump npm-run-all2 from 7.0.1 to 7.0.2 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2560
 - feat(api): 商品レビュー機能の定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2563


### PR DESCRIPTION
This pull request is for the next release as v3.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.2.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(store): 商品レビュー機能の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2566
* feat(store): 商品レビューの集計ロジック実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2568
* feat(gateway): 購入者向けの商品レビュー一覧APIの実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2569
* feat(docs): 商品レビュー関連APIのドキュメント追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2570
* fix(gateway): 商品レビュー一覧が404になる問題の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2571
* fix(docs): api docsのtypo修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2573
* fix(gateway): SpotTypeIdが渡せていなかったので修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2574
* fix(gateway): user-gatewayでGoogle Map APIが利用できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2575
* fix(gateway): スポット登録APIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2576
* feat(store): 商品レビューのリアクション機能を実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2577
* fix(docs): api docsの漏れを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2578
* feat(gateway): 商品レビューへのリアクション実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2579
* fix(gateway): pathの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2580
* fix(store): 体験レビュー関連の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2581


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.2.8...v3.3.0