### PR TITLE
refactor(user): 管理者種別のフィールド名を置き換え

### DIFF
--- a/api/internal/gateway/admin/v1/handler/api_test.go
+++ b/api/internal/gateway/admin/v1/handler/api_test.go
@@ -31,9 +31,9 @@ func TestSetAuth(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
 	ctx.Request = &http.Request{Header: http.Header{}}
-	setAuth(ctx, "admin-id", service.AdminRoleAdministrator)
+	setAuth(ctx, "admin-id", service.AdminTypeAdministrator)
 	assert.Equal(t, "admin-id", getAdminID(ctx))
-	assert.Equal(t, service.AdminRoleAdministrator, getRole(ctx))
+	assert.Equal(t, service.AdminTypeAdministrator, getAdminType(ctx))
 	assert.True(t, currentAdmin(ctx, "admin-id"))
 	assert.False(t, currentAdmin(ctx, "other-id"))
 }
@@ -43,19 +43,19 @@ func TestFilterAccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
 		name   string
-		role   service.AdminRole
+		role   service.AdminType
 		params *filterAccessParams
 		expect error
 	}{
 		{
 			name:   "success administrator",
-			role:   service.AdminRoleAdministrator,
+			role:   service.AdminTypeAdministrator,
 			params: &filterAccessParams{},
 			expect: nil,
 		},
 		{
 			name: "success coordinator",
-			role: service.AdminRoleCoordinator,
+			role: service.AdminTypeCoordinator,
 			params: &filterAccessParams{
 				coordinator: func(_ *gin.Context) (bool, error) {
 					return true, nil
@@ -65,13 +65,13 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name:   "success coordinator for no filter",
-			role:   service.AdminRoleCoordinator,
+			role:   service.AdminTypeCoordinator,
 			params: &filterAccessParams{},
 			expect: nil,
 		},
 		{
 			name: "failed coordinator for failed to execute function",
-			role: service.AdminRoleCoordinator,
+			role: service.AdminTypeCoordinator,
 			params: &filterAccessParams{
 				coordinator: func(_ *gin.Context) (bool, error) {
 					return false, assert.AnError
@@ -81,7 +81,7 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name: "failed coordinator for invalid coordinator",
-			role: service.AdminRoleCoordinator,
+			role: service.AdminTypeCoordinator,
 			params: &filterAccessParams{
 				coordinator: func(_ *gin.Context) (bool, error) {
 					return false, nil
@@ -91,7 +91,7 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name: "success producer",
-			role: service.AdminRoleProducer,
+			role: service.AdminTypeProducer,
 			params: &filterAccessParams{
 				producer: func(_ *gin.Context) (bool, error) {
 					return true, nil
@@ -101,13 +101,13 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name:   "success producer for no filter",
-			role:   service.AdminRoleProducer,
+			role:   service.AdminTypeProducer,
 			params: &filterAccessParams{},
 			expect: nil,
 		},
 		{
 			name: "failed producer for failed to execute function",
-			role: service.AdminRoleProducer,
+			role: service.AdminTypeProducer,
 			params: &filterAccessParams{
 				producer: func(_ *gin.Context) (bool, error) {
 					return false, assert.AnError
@@ -117,7 +117,7 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name: "failed producer for invalid producer",
-			role: service.AdminRoleProducer,
+			role: service.AdminTypeProducer,
 			params: &filterAccessParams{
 				producer: func(_ *gin.Context) (bool, error) {
 					return false, nil
@@ -127,7 +127,7 @@ func TestFilterAccess(t *testing.T) {
 		},
 		{
 			name:   "failed unknown admin role",
-			role:   service.AdminRoleUnknown,
+			role:   service.AdminTypeUnknown,
 			params: &filterAccessParams{},
 			expect: exception.ErrForbidden,
 		},

--- a/api/internal/gateway/admin/v1/handler/auth.go
+++ b/api/internal/gateway/admin/v1/handler/auth.go
@@ -66,12 +66,12 @@ func (h *handler) GetAuthUser(ctx *gin.Context) {
 		auth authUser
 		err  error
 	)
-	switch getRole(ctx) {
-	case service.AdminRoleAdministrator:
+	switch getAdminType(ctx) {
+	case service.AdminTypeAdministrator:
 		auth, err = h.getAdministrator(ctx, adminID)
-	case service.AdminRoleCoordinator:
+	case service.AdminTypeCoordinator:
 		auth, err = h.getCoordinator(ctx, adminID)
-	case service.AdminRoleProducer:
+	case service.AdminTypeProducer:
 		auth, err = h.getProducer(ctx, adminID)
 	default:
 		h.forbidden(ctx, errors.New("handler: unknown admin role"))
@@ -283,7 +283,7 @@ func (h *handler) ResetAuthPassword(ctx *gin.Context) {
 }
 
 func (h *handler) GetAuthCoordinator(ctx *gin.Context) {
-	if getRole(ctx) != service.AdminRoleCoordinator {
+	if getAdminType(ctx) != service.AdminTypeCoordinator {
 		h.forbidden(ctx, errors.New("this user is not coordinator"))
 		return
 	}
@@ -310,7 +310,7 @@ func (h *handler) GetAuthCoordinator(ctx *gin.Context) {
 }
 
 func (h *handler) UpdateAuthCoordinator(ctx *gin.Context) {
-	if getRole(ctx) != service.AdminRoleCoordinator {
+	if getAdminType(ctx) != service.AdminTypeCoordinator {
 		h.forbidden(ctx, errors.New("this user is not coordinator"))
 		return
 	}
@@ -363,7 +363,7 @@ func (h *handler) UpdateAuthCoordinator(ctx *gin.Context) {
 }
 
 func (h *handler) GetAuthShipping(ctx *gin.Context) {
-	if getRole(ctx) != service.AdminRoleCoordinator {
+	if getAdminType(ctx) != service.AdminTypeCoordinator {
 		h.forbidden(ctx, errors.New("this user is not coordinator"))
 		return
 	}
@@ -388,7 +388,7 @@ func (h *handler) GetAuthShipping(ctx *gin.Context) {
 }
 
 func (h *handler) UpsertAuthShipping(ctx *gin.Context) {
-	if getRole(ctx) != service.AdminRoleCoordinator {
+	if getAdminType(ctx) != service.AdminTypeCoordinator {
 		h.forbidden(ctx, errors.New("this user is not coordinator"))
 		return
 	}

--- a/api/internal/gateway/admin/v1/handler/experience.go
+++ b/api/internal/gateway/admin/v1/handler/experience.go
@@ -78,7 +78,7 @@ func (h *handler) ListExperiences(ctx *gin.Context) {
 		Offset:     offset,
 		NoLimit:    false,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		producers, err := h.getProducersByCoordinatorID(ctx, getAdminID(ctx))
 		if err != nil {
 			h.httpError(ctx, err)
@@ -191,7 +191,7 @@ func (h *handler) CreateExperience(ctx *gin.Context) {
 		h.badRequest(ctx, err)
 		return
 	}
-	if getRole(ctx).IsCoordinator() {
+	if getAdminType(ctx).IsCoordinator() {
 		if req.CoordinatorID != getAdminID(ctx) {
 			h.forbidden(ctx, errors.New("handler: not allowed to create experience"))
 			return

--- a/api/internal/gateway/admin/v1/handler/live.go
+++ b/api/internal/gateway/admin/v1/handler/live.go
@@ -150,7 +150,7 @@ func (h *handler) CreateLive(ctx *gin.Context) {
 		return
 	}
 
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		if !currentAdmin(ctx, producer.CoordinatorID) {
 			h.forbidden(ctx, errors.New("handler: invalid coordinator id"))
 			return

--- a/api/internal/gateway/admin/v1/handler/order.go
+++ b/api/internal/gateway/admin/v1/handler/order.go
@@ -80,7 +80,7 @@ func (h *handler) ListOrders(ctx *gin.Context) {
 		Statuses: statuses,
 		Types:    types,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	orders, total, err := h.store.ListOrders(ctx, in)
@@ -341,7 +341,7 @@ func (h *handler) ExportOrders(ctx *gin.Context) {
 		ShippingCarrier: sentity.ShippingCarrier(req.ShippingCarrier),
 		EncodingType:    codes.CharacterEncodingType(req.CharacterEncodingType),
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	value, err := h.store.ExportOrders(ctx, in)

--- a/api/internal/gateway/admin/v1/handler/producer.go
+++ b/api/internal/gateway/admin/v1/handler/producer.go
@@ -62,7 +62,7 @@ func (h *handler) ListProducers(ctx *gin.Context) {
 		Limit:  limit,
 		Offset: offset,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	producers, total, err := h.user.ListProducers(ctx, in)
@@ -109,7 +109,7 @@ func (h *handler) CreateProducer(ctx *gin.Context) {
 		h.badRequest(ctx, err)
 		return
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		if !currentAdmin(ctx, req.CoordinatorID) {
 			h.forbidden(ctx, errors.New("handler: invalid coordinator id"))
 			return

--- a/api/internal/gateway/admin/v1/handler/product.go
+++ b/api/internal/gateway/admin/v1/handler/product.go
@@ -85,7 +85,7 @@ func (h *handler) ListProducts(ctx *gin.Context) {
 		Offset:         offset,
 		Orders:         orders,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		producers, err := h.getProducersByCoordinatorID(ctx, getAdminID(ctx))
 		if err != nil {
 			h.httpError(ctx, err)
@@ -251,7 +251,7 @@ func (h *handler) CreateProduct(ctx *gin.Context) {
 		h.badRequest(ctx, err)
 		return
 	}
-	if getRole(ctx).IsCoordinator() {
+	if getAdminType(ctx).IsCoordinator() {
 		if req.CoordinatorID != getAdminID(ctx) {
 			h.forbidden(ctx, errors.New("handler: not authorized this coordinator"))
 			return

--- a/api/internal/gateway/admin/v1/handler/schedule.go
+++ b/api/internal/gateway/admin/v1/handler/schedule.go
@@ -67,7 +67,7 @@ func (h *handler) ListSchedules(ctx *gin.Context) {
 		Limit:  limit,
 		Offset: offset,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	schedules, total, err := h.store.ListSchedules(ctx, in)
@@ -125,7 +125,7 @@ func (h *handler) CreateSchedule(ctx *gin.Context) {
 		h.badRequest(ctx, err)
 		return
 	}
-	if getRole(ctx).IsCoordinator() {
+	if getAdminType(ctx).IsCoordinator() {
 		if !currentAdmin(ctx, req.CoordinatorID) {
 			h.forbidden(ctx, errors.New("handler: invalid coordinator id"))
 			return

--- a/api/internal/gateway/admin/v1/handler/shipping.go
+++ b/api/internal/gateway/admin/v1/handler/shipping.go
@@ -112,7 +112,7 @@ func (h *handler) UpsertShipping(ctx *gin.Context) {
 		return
 	}
 	coordinatorID := util.GetParam(ctx, "coordinatorId")
-	if getRole(ctx).IsCoordinator() && getAdminID(ctx) != coordinatorID {
+	if getAdminType(ctx).IsCoordinator() && getAdminID(ctx) != coordinatorID {
 		h.forbidden(ctx, errors.New("handler: not authorized this coordinator"))
 		return
 	}

--- a/api/internal/gateway/admin/v1/handler/spot.go
+++ b/api/internal/gateway/admin/v1/handler/spot.go
@@ -190,15 +190,15 @@ func (h *handler) CreateSpot(ctx *gin.Context) {
 	adminID := getAdminID(ctx)
 
 	res := &response.SpotResponse{}
-	switch getRole(ctx) {
-	case service.AdminRoleCoordinator:
+	switch getAdminType(ctx) {
+	case service.AdminTypeCoordinator:
 		coordinator, err := h.getCoordinator(ctx, adminID)
 		if err != nil {
 			h.httpError(ctx, err)
 			return
 		}
 		res.Coordinator = coordinator.Response()
-	case service.AdminRoleProducer:
+	case service.AdminTypeProducer:
 		producer, err := h.getProducer(ctx, adminID)
 		if err != nil {
 			h.httpError(ctx, err)

--- a/api/internal/gateway/admin/v1/handler/user.go
+++ b/api/internal/gateway/admin/v1/handler/user.go
@@ -47,8 +47,8 @@ func (h *handler) ListUsers(ctx *gin.Context) {
 		users service.Users
 		total int64
 	)
-	switch getRole(ctx) {
-	case service.AdminRoleAdministrator:
+	switch getAdminType(ctx) {
+	case service.AdminTypeAdministrator:
 		// 管理者の場合、すべての購入者情報を取得する
 		usersIn := &user.ListUsersInput{
 			Limit:       limit,
@@ -73,7 +73,7 @@ func (h *handler) ListUsers(ctx *gin.Context) {
 			return
 		}
 		users = service.NewUsers(us, addresses.MapByUserID())
-	case service.AdminRoleCoordinator:
+	case service.AdminTypeCoordinator:
 		// コーディネータの場合、注文した購入者のみを取得する
 		in := &store.ListOrderUserIDsInput{
 			CoordinatorID: getAdminID(ctx),
@@ -109,7 +109,7 @@ func (h *handler) ListUsers(ctx *gin.Context) {
 	in := &store.AggregateOrdersInput{
 		UserIDs: users.IDs(),
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	orders, err := h.store.AggregateOrders(ctx, in)
@@ -183,7 +183,7 @@ func (h *handler) ListUserOrders(ctx *gin.Context) {
 			Limit:  limit,
 			Offset: offset,
 		}
-		if getRole(ctx) == service.AdminRoleCoordinator {
+		if getAdminType(ctx) == service.AdminTypeCoordinator {
 			in.CoordinatorID = getAdminID(ctx)
 		}
 		orders, total, err = h.store.ListOrders(ectx, in)
@@ -193,7 +193,7 @@ func (h *handler) ListUserOrders(ctx *gin.Context) {
 		in := &store.AggregateOrdersInput{
 			UserIDs: []string{userID},
 		}
-		if getRole(ctx) == service.AdminRoleCoordinator {
+		if getAdminType(ctx) == service.AdminTypeCoordinator {
 			in.CoordinatorID = getAdminID(ctx)
 		}
 		aggregate, err := h.store.AggregateOrders(ectx, in)

--- a/api/internal/gateway/admin/v1/handler/video.go
+++ b/api/internal/gateway/admin/v1/handler/video.go
@@ -70,7 +70,7 @@ func (h *handler) ListVideos(ctx *gin.Context) {
 		Limit:  limit,
 		Offset: offset,
 	}
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		in.CoordinatorID = getAdminID(ctx)
 	}
 	videos, total, err := h.media.ListVideos(ctx, in)
@@ -202,7 +202,7 @@ func (h *handler) CreateVideo(ctx *gin.Context) {
 		return
 	}
 
-	if getRole(ctx) == service.AdminRoleCoordinator {
+	if getAdminType(ctx) == service.AdminTypeCoordinator {
 		if !currentAdmin(ctx, req.CoordinatorID) {
 			h.httpError(ctx, exception.ErrForbidden)
 			return

--- a/api/internal/gateway/admin/v1/response/admin.go
+++ b/api/internal/gateway/admin/v1/response/admin.go
@@ -1,8 +1,6 @@
 package response
 
 // Admin - 管理者情報
-//
-//nolint:staticcheck
 type Admin struct {
 	ID            string `json:"id"`            // 管理者ID
 	Type          int32  `json:"role"`          // 管理者種別

--- a/api/internal/gateway/admin/v1/response/admin.go
+++ b/api/internal/gateway/admin/v1/response/admin.go
@@ -1,20 +1,16 @@
 package response
 
-import (
-	"github.com/and-period/furumaru/api/internal/user/entity"
-)
-
 // Admin - 管理者情報
 //
 //nolint:staticcheck
 type Admin struct {
-	ID            string                 `json:"id"`            // 管理者ID
-	Role          entity.LegacyAdminRole `json:"role"`          // 管理者権限
-	Lastname      string                 `json:"lastname"`      // 姓
-	Firstname     string                 `json:"firstname"`     // 名
-	LastnameKana  string                 `json:"lastnameKana"`  // 姓(かな)
-	FirstnameKana string                 `json:"firstnameKana"` // 名(かな)
-	Email         string                 `json:"email"`         // メールアドレス
-	CreatedAt     int64                  `json:"createdAt"`     // 登録日時
-	UpdatedAt     int64                  `json:"updateAt"`      // 更新日時
+	ID            string `json:"id"`            // 管理者ID
+	Type          int32  `json:"role"`          // 管理者種別
+	Lastname      string `json:"lastname"`      // 姓
+	Firstname     string `json:"firstname"`     // 名
+	LastnameKana  string `json:"lastnameKana"`  // 姓(かな)
+	FirstnameKana string `json:"firstnameKana"` // 名(かな)
+	Email         string `json:"email"`         // メールアドレス
+	CreatedAt     int64  `json:"createdAt"`     // 登録日時
+	UpdatedAt     int64  `json:"updateAt"`      // 更新日時
 }

--- a/api/internal/gateway/admin/v1/response/auth.go
+++ b/api/internal/gateway/admin/v1/response/auth.go
@@ -3,7 +3,7 @@ package response
 // Auth - 認証情報
 type Auth struct {
 	AdminID      string `json:"adminId"`      // 管理者ID
-	Role         int32  `json:"role"`         // 権限
+	Type         int32  `json:"type"`         // 管理者種別
 	AccessToken  string `json:"accessToken"`  // アクセストークン
 	RefreshToken string `json:"refreshToken"` // 更新トークン
 	ExpiresIn    int32  `json:"expiresIn"`    // 有効期限
@@ -13,7 +13,7 @@ type Auth struct {
 // AuthUser - ログイン中管理者情報
 type AuthUser struct {
 	AdminID      string `json:"id"`           // 管理者ID
-	Role         int32  `json:"role"`         // 権限
+	Type         int32  `json:"type"`         // 管理者種別
 	Username     string `json:"username"`     // 表示名
 	Email        string `json:"email"`        // メールアドレス
 	ThumbnailURL string `json:"thumbnailUrl"` // サムネイルURL

--- a/api/internal/gateway/admin/v1/service/admin.go
+++ b/api/internal/gateway/admin/v1/service/admin.go
@@ -7,14 +7,14 @@ import (
 	"github.com/and-period/furumaru/api/internal/user/entity"
 )
 
-// AdminRole - 管理者ロール
-type AdminRole int32
+// AdminType - 管理者ロール
+type AdminType int32
 
 const (
-	AdminRoleUnknown       AdminRole = 0
-	AdminRoleAdministrator AdminRole = 1 // 管理者
-	AdminRoleCoordinator   AdminRole = 2 // コーディネータ
-	AdminRoleProducer      AdminRole = 3 // 生産者
+	AdminTypeUnknown       AdminType = 0
+	AdminTypeAdministrator AdminType = 1 // 管理者
+	AdminTypeCoordinator   AdminType = 2 // コーディネータ
+	AdminTypeProducer      AdminType = 3 // 生産者
 )
 
 // AdminStatus - 管理者ステータス
@@ -34,37 +34,37 @@ type Admin struct {
 type Admins []*Admin
 
 //nolint:staticcheck
-func NewAdminRole(role entity.LegacyAdminRole) AdminRole {
+func NewAdminType(role entity.AdminType) AdminType {
 	switch role {
-	case entity.AdminRoleAdministrator:
-		return AdminRoleAdministrator
-	case entity.AdminRoleCoordinator:
-		return AdminRoleCoordinator
-	case entity.AdminRoleProducer:
-		return AdminRoleProducer
+	case entity.AdminTypeAdministrator:
+		return AdminTypeAdministrator
+	case entity.AdminTypeCoordinator:
+		return AdminTypeCoordinator
+	case entity.AdminTypeProducer:
+		return AdminTypeProducer
 	default:
-		return AdminRoleUnknown
+		return AdminTypeUnknown
 	}
 }
 
-func (r AdminRole) String() string {
+func (r AdminType) String() string {
 	switch r {
-	case AdminRoleAdministrator:
+	case AdminTypeAdministrator:
 		return "administrator"
-	case AdminRoleCoordinator:
+	case AdminTypeCoordinator:
 		return "coordinator"
-	case AdminRoleProducer:
+	case AdminTypeProducer:
 		return "producer"
 	default:
 		return "unknown"
 	}
 }
 
-func (r AdminRole) IsCoordinator() bool {
-	return r == AdminRoleCoordinator
+func (r AdminType) IsCoordinator() bool {
+	return r == AdminTypeCoordinator
 }
 
-func (r AdminRole) Response() int32 {
+func (r AdminType) Response() int32 {
 	return int32(r)
 }
 
@@ -89,7 +89,7 @@ func NewAdmin(admin *entity.Admin) *Admin {
 	return &Admin{
 		Admin: response.Admin{
 			ID:            admin.ID,
-			Role:          admin.Role,
+			Type:          NewAdminType(admin.Type).Response(),
 			Lastname:      admin.Lastname,
 			Firstname:     admin.Firstname,
 			LastnameKana:  admin.LastnameKana,

--- a/api/internal/gateway/admin/v1/service/admin.go
+++ b/api/internal/gateway/admin/v1/service/admin.go
@@ -33,7 +33,6 @@ type Admin struct {
 
 type Admins []*Admin
 
-//nolint:staticcheck
 func NewAdminType(role entity.AdminType) AdminType {
 	switch role {
 	case entity.AdminTypeAdministrator:

--- a/api/internal/gateway/admin/v1/service/admin_test.go
+++ b/api/internal/gateway/admin/v1/service/admin_test.go
@@ -9,44 +9,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAdminRole(t *testing.T) {
+func TestAdminType(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name                string
-		role                entity.LegacyAdminRole
-		expect              AdminRole
+		Type                entity.AdminType
+		expect              AdminType
 		expectString        string
 		expectIsCoordinator bool
 		expectResponse      int32
 	}{
 		{
 			name:                "administrator",
-			role:                entity.AdminRoleAdministrator,
-			expect:              AdminRoleAdministrator,
+			Type:                entity.AdminTypeAdministrator,
+			expect:              AdminTypeAdministrator,
 			expectString:        "administrator",
 			expectIsCoordinator: false,
 			expectResponse:      1,
 		},
 		{
 			name:                "coordinator",
-			role:                entity.AdminRoleCoordinator,
-			expect:              AdminRoleCoordinator,
+			Type:                entity.AdminTypeCoordinator,
+			expect:              AdminTypeCoordinator,
 			expectString:        "coordinator",
 			expectIsCoordinator: true,
 			expectResponse:      2,
 		},
 		{
 			name:                "producer",
-			role:                entity.AdminRoleProducer,
-			expect:              AdminRoleProducer,
+			Type:                entity.AdminTypeProducer,
+			expect:              AdminTypeProducer,
 			expectString:        "producer",
 			expectIsCoordinator: false,
 			expectResponse:      3,
 		},
 		{
 			name:                "unknown",
-			role:                entity.AdminRoleUnknown,
-			expect:              AdminRoleUnknown,
+			Type:                entity.AdminTypeUnknown,
+			expect:              AdminTypeUnknown,
 			expectString:        "unknown",
 			expectIsCoordinator: false,
 			expectResponse:      0,
@@ -56,7 +56,7 @@ func TestAdminRole(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual := NewAdminRole(tt.role)
+			actual := NewAdminType(tt.Type)
 			assert.Equal(t, tt.expect, actual)
 			assert.Equal(t, tt.expectString, actual.String())
 			assert.Equal(t, tt.expectIsCoordinator, actual.IsCoordinator())
@@ -69,31 +69,31 @@ func TestAdminStatus(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name           string
-		role           entity.AdminStatus
+		Type           entity.AdminStatus
 		expect         AdminStatus
 		expectResponse int32
 	}{
 		{
 			name:           "invited",
-			role:           entity.AdminStatusInvited,
+			Type:           entity.AdminStatusInvited,
 			expect:         AdminStatusInvited,
 			expectResponse: 1,
 		},
 		{
 			name:           "activated",
-			role:           entity.AdminStatusActivated,
+			Type:           entity.AdminStatusActivated,
 			expect:         AdminStatusActivated,
 			expectResponse: 2,
 		},
 		{
 			name:           "deactivated",
-			role:           entity.AdminStatusDeactivated,
+			Type:           entity.AdminStatusDeactivated,
 			expect:         AdminStatusDeactivated,
 			expectResponse: 3,
 		},
 		{
 			name:           "unknown",
-			role:           entity.AdminStatusUnknown,
+			Type:           entity.AdminStatusUnknown,
 			expect:         AdminStatusUnknown,
 			expectResponse: 0,
 		},
@@ -102,7 +102,7 @@ func TestAdminStatus(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual := NewAdminStatus(tt.role)
+			actual := NewAdminStatus(tt.Type)
 			assert.Equal(t, tt.expect, actual)
 			assert.Equal(t, tt.expectResponse, actual.Response())
 		})
@@ -120,7 +120,7 @@ func TestAdmin(t *testing.T) {
 			name: "success",
 			admin: &entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleAdministrator,
+				Type:          entity.AdminTypeAdministrator,
 				Lastname:      "&.",
 				Firstname:     "管理者",
 				LastnameKana:  "あんどぴりおど",
@@ -132,7 +132,7 @@ func TestAdmin(t *testing.T) {
 			expect: &Admin{
 				Admin: response.Admin{
 					ID:            "admin-id",
-					Role:          entity.AdminRoleAdministrator,
+					Type:          int32(AdminTypeAdministrator),
 					Lastname:      "&.",
 					Firstname:     "管理者",
 					LastnameKana:  "あんどぴりおど",
@@ -212,7 +212,7 @@ func TestAdmin_Response(t *testing.T) {
 			admin: &Admin{
 				Admin: response.Admin{
 					ID:            "admin-id",
-					Role:          entity.AdminRoleAdministrator,
+					Type:          int32(AdminTypeAdministrator),
 					Lastname:      "&.",
 					Firstname:     "管理者",
 					LastnameKana:  "あんどぴりおど",
@@ -224,7 +224,7 @@ func TestAdmin_Response(t *testing.T) {
 			},
 			expect: &response.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleAdministrator,
+				Type:          int32(AdminTypeAdministrator),
 				Lastname:      "&.",
 				Firstname:     "管理者",
 				LastnameKana:  "あんどぴりおど",
@@ -256,7 +256,7 @@ func TestAdmins(t *testing.T) {
 			admins: entity.Admins{
 				{
 					ID:            "admin-id01",
-					Role:          entity.AdminRoleAdministrator,
+					Type:          entity.AdminTypeAdministrator,
 					Lastname:      "&.",
 					Firstname:     "管理者",
 					LastnameKana:  "あんどぴりおど",
@@ -267,7 +267,7 @@ func TestAdmins(t *testing.T) {
 				},
 				{
 					ID:            "admin-id02",
-					Role:          entity.AdminRoleCoordinator,
+					Type:          entity.AdminTypeCoordinator,
 					Lastname:      "&.",
 					Firstname:     "コーディネータ",
 					LastnameKana:  "あんどぴりおど",
@@ -281,7 +281,7 @@ func TestAdmins(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id01",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          int32(AdminTypeAdministrator),
 						Lastname:      "&.",
 						Firstname:     "管理者",
 						LastnameKana:  "あんどぴりおど",
@@ -294,7 +294,7 @@ func TestAdmins(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          int32(AdminTypeCoordinator),
 						Lastname:      "&.",
 						Firstname:     "コーディネータ",
 						LastnameKana:  "あんどぴりおど",
@@ -329,7 +329,7 @@ func TestAdmins_Map(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id01",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          int32(AdminTypeAdministrator),
 						Lastname:      "&.",
 						Firstname:     "管理者",
 						LastnameKana:  "あんどぴりおど",
@@ -342,7 +342,7 @@ func TestAdmins_Map(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          int32(AdminTypeCoordinator),
 						Lastname:      "&.",
 						Firstname:     "コーディネータ",
 						LastnameKana:  "あんどぴりおど",
@@ -357,7 +357,7 @@ func TestAdmins_Map(t *testing.T) {
 				"admin-id01": {
 					Admin: response.Admin{
 						ID:            "admin-id01",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          int32(AdminTypeAdministrator),
 						Lastname:      "&.",
 						Firstname:     "管理者",
 						LastnameKana:  "あんどぴりおど",
@@ -370,7 +370,7 @@ func TestAdmins_Map(t *testing.T) {
 				"admin-id02": {
 					Admin: response.Admin{
 						ID:            "admin-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          int32(AdminTypeCoordinator),
 						Lastname:      "&.",
 						Firstname:     "コーディネータ",
 						LastnameKana:  "あんどぴりおど",
@@ -405,7 +405,7 @@ func TestAdmins_Response(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id01",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          int32(AdminTypeAdministrator),
 						Lastname:      "&.",
 						Firstname:     "管理者",
 						LastnameKana:  "あんどぴりおど",
@@ -418,7 +418,7 @@ func TestAdmins_Response(t *testing.T) {
 				{
 					Admin: response.Admin{
 						ID:            "admin-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          int32(AdminTypeCoordinator),
 						Lastname:      "&.",
 						Firstname:     "コーディネータ",
 						LastnameKana:  "あんどぴりおど",
@@ -432,7 +432,7 @@ func TestAdmins_Response(t *testing.T) {
 			expect: []*response.Admin{
 				{
 					ID:            "admin-id01",
-					Role:          entity.AdminRoleAdministrator,
+					Type:          int32(AdminTypeAdministrator),
 					Lastname:      "&.",
 					Firstname:     "管理者",
 					LastnameKana:  "あんどぴりおど",
@@ -443,7 +443,7 @@ func TestAdmins_Response(t *testing.T) {
 				},
 				{
 					ID:            "admin-id02",
-					Role:          entity.AdminRoleCoordinator,
+					Type:          int32(AdminTypeCoordinator),
 					Lastname:      "&.",
 					Firstname:     "コーディネータ",
 					LastnameKana:  "あんどぴりおど",

--- a/api/internal/gateway/admin/v1/service/administrator.go
+++ b/api/internal/gateway/admin/v1/service/administrator.go
@@ -34,7 +34,7 @@ func (a *Administrator) AuthUser() *AuthUser {
 	return &AuthUser{
 		AuthUser: response.AuthUser{
 			AdminID:  a.ID,
-			Role:     AdminRoleAdministrator.Response(),
+			Type:     AdminTypeAdministrator.Response(),
 			Username: fmt.Sprintf("%s %s", a.Lastname, a.Firstname),
 			Email:    a.Email,
 		},

--- a/api/internal/gateway/admin/v1/service/administrator_test.go
+++ b/api/internal/gateway/admin/v1/service/administrator_test.go
@@ -21,7 +21,7 @@ func TestAdministrator(t *testing.T) {
 			admin: &entity.Administrator{
 				Admin: entity.Admin{
 					ID:            "admin-id",
-					Role:          entity.AdminRoleAdministrator,
+					Type:          entity.AdminTypeAdministrator,
 					Status:        entity.AdminStatusActivated,
 					Lastname:      "&.",
 					Firstname:     "管理者",
@@ -118,7 +118,7 @@ func TestAdministrators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "admin-id01",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          entity.AdminTypeAdministrator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",
@@ -134,7 +134,7 @@ func TestAdministrators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "admin-id02",
-						Role:          entity.AdminRoleAdministrator,
+						Type:          entity.AdminTypeAdministrator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",

--- a/api/internal/gateway/admin/v1/service/auth.go
+++ b/api/internal/gateway/admin/v1/service/auth.go
@@ -18,7 +18,7 @@ func NewAuth(auth *entity.AdminAuth) *Auth {
 	return &Auth{
 		Auth: response.Auth{
 			AdminID:      auth.AdminID,
-			Role:         NewAdminRole(auth.Role).Response(),
+			Type:         NewAdminType(auth.Type).Response(),
 			AccessToken:  auth.AccessToken,
 			RefreshToken: auth.RefreshToken,
 			ExpiresIn:    auth.ExpiresIn,

--- a/api/internal/gateway/admin/v1/service/auth_test.go
+++ b/api/internal/gateway/admin/v1/service/auth_test.go
@@ -19,7 +19,7 @@ func TestAuth(t *testing.T) {
 			name: "success",
 			auth: &entity.AdminAuth{
 				AdminID:      "admin-id",
-				Role:         entity.AdminRoleAdministrator,
+				Type:         entity.AdminTypeAdministrator,
 				AccessToken:  "access-token",
 				RefreshToken: "refresh-token",
 				ExpiresIn:    3600,
@@ -27,7 +27,7 @@ func TestAuth(t *testing.T) {
 			expect: &Auth{
 				Auth: response.Auth{
 					AdminID:      "admin-id",
-					Role:         int32(AdminRoleAdministrator),
+					Type:         int32(AdminTypeAdministrator),
 					AccessToken:  "access-token",
 					RefreshToken: "refresh-token",
 					ExpiresIn:    3600,
@@ -57,7 +57,7 @@ func TestAuth_Response(t *testing.T) {
 			auth: &Auth{
 				Auth: response.Auth{
 					AdminID:      "admin-id",
-					Role:         int32(AdminRoleAdministrator),
+					Type:         int32(AdminTypeAdministrator),
 					AccessToken:  "access-token",
 					RefreshToken: "refresh-token",
 					ExpiresIn:    3600,
@@ -66,7 +66,7 @@ func TestAuth_Response(t *testing.T) {
 			},
 			expect: &response.Auth{
 				AdminID:      "admin-id",
-				Role:         int32(AdminRoleAdministrator),
+				Type:         int32(AdminTypeAdministrator),
 				AccessToken:  "access-token",
 				RefreshToken: "refresh-token",
 				ExpiresIn:    3600,

--- a/api/internal/gateway/admin/v1/service/coordinator.go
+++ b/api/internal/gateway/admin/v1/service/coordinator.go
@@ -49,7 +49,7 @@ func (c *Coordinator) AuthUser() *AuthUser {
 	return &AuthUser{
 		AuthUser: response.AuthUser{
 			AdminID:      c.ID,
-			Role:         AdminRoleCoordinator.Response(),
+			Type:         AdminTypeCoordinator.Response(),
 			Username:     c.Username,
 			Email:        c.Email,
 			ThumbnailURL: c.ThumbnailURL,

--- a/api/internal/gateway/admin/v1/service/coordinator_test.go
+++ b/api/internal/gateway/admin/v1/service/coordinator_test.go
@@ -23,7 +23,7 @@ func TestCoordinator(t *testing.T) {
 			coordinator: &entity.Coordinator{
 				Admin: entity.Admin{
 					ID:            "coordinator-id",
-					Role:          entity.AdminRoleCoordinator,
+					Type:          entity.AdminTypeCoordinator,
 					Status:        entity.AdminStatusActivated,
 					Lastname:      "&.",
 					Firstname:     "管理者",
@@ -176,7 +176,7 @@ func TestCoordinators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "coordinator-id01",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          entity.AdminTypeCoordinator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",
@@ -206,7 +206,7 @@ func TestCoordinators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "coordinator-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          entity.AdminTypeCoordinator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",

--- a/api/internal/gateway/admin/v1/service/producer.go
+++ b/api/internal/gateway/admin/v1/service/producer.go
@@ -48,7 +48,7 @@ func (p *Producer) AuthUser() *AuthUser {
 	return &AuthUser{
 		AuthUser: response.AuthUser{
 			AdminID:      p.ID,
-			Role:         AdminRoleProducer.Response(),
+			Type:         AdminTypeProducer.Response(),
 			Username:     p.Username,
 			Email:        p.Email,
 			ThumbnailURL: p.ThumbnailURL,

--- a/api/internal/gateway/admin/v1/service/producer_test.go
+++ b/api/internal/gateway/admin/v1/service/producer_test.go
@@ -21,7 +21,7 @@ func TestProducer(t *testing.T) {
 			producer: &entity.Producer{
 				Admin: entity.Admin{
 					ID:            "producer-id",
-					Role:          entity.AdminRoleProducer,
+					Type:          entity.AdminTypeProducer,
 					Status:        entity.AdminStatusActivated,
 					Lastname:      "&.",
 					Firstname:     "管理者",
@@ -192,7 +192,7 @@ func TestProducers(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "producer-id01",
-						Role:          entity.AdminRoleProducer,
+						Type:          entity.AdminTypeProducer,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",
@@ -216,7 +216,7 @@ func TestProducers(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "producer-id02",
-						Role:          entity.AdminRoleProducer,
+						Type:          entity.AdminTypeProducer,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",

--- a/api/internal/gateway/user/v1/service/coordinator_test.go
+++ b/api/internal/gateway/user/v1/service/coordinator_test.go
@@ -22,7 +22,7 @@ func TestCoordinator(t *testing.T) {
 			coordinator: &entity.Coordinator{
 				Admin: entity.Admin{
 					ID:            "coordinator-id",
-					Role:          entity.AdminRoleCoordinator,
+					Type:          entity.AdminTypeCoordinator,
 					Status:        entity.AdminStatusActivated,
 					Lastname:      "&.",
 					Firstname:     "管理者",
@@ -143,7 +143,7 @@ func TestCoordinators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "coordinator-id01",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          entity.AdminTypeCoordinator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",
@@ -174,7 +174,7 @@ func TestCoordinators(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "coordinator-id02",
-						Role:          entity.AdminRoleCoordinator,
+						Type:          entity.AdminTypeCoordinator,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",

--- a/api/internal/gateway/user/v1/service/producer_test.go
+++ b/api/internal/gateway/user/v1/service/producer_test.go
@@ -21,7 +21,7 @@ func TestProducer(t *testing.T) {
 			producer: &entity.Producer{
 				Admin: entity.Admin{
 					ID:            "producer-id",
-					Role:          entity.AdminRoleProducer,
+					Type:          entity.AdminTypeProducer,
 					Status:        entity.AdminStatusActivated,
 					Lastname:      "&.",
 					Firstname:     "管理者",
@@ -117,7 +117,7 @@ func TestProducers(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "producer-id01",
-						Role:          entity.AdminRoleProducer,
+						Type:          entity.AdminTypeProducer,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",
@@ -141,7 +141,7 @@ func TestProducers(t *testing.T) {
 				{
 					Admin: entity.Admin{
 						ID:            "producer-id02",
-						Role:          entity.AdminRoleProducer,
+						Type:          entity.AdminTypeProducer,
 						Status:        entity.AdminStatusActivated,
 						Lastname:      "&.",
 						Firstname:     "管理者",

--- a/api/internal/messenger/service/notify_test.go
+++ b/api/internal/messenger/service/notify_test.go
@@ -294,7 +294,7 @@ func TestNotifyOrderAuthorized(t *testing.T) {
 	coordinator := &uentity.Coordinator{
 		Admin: uentity.Admin{
 			ID:            "coordinator-id",
-			Role:          uentity.AdminRoleCoordinator,
+			Type:          uentity.AdminTypeCoordinator,
 			Status:        uentity.AdminStatusActivated,
 			Lastname:      "&.",
 			Firstname:     "コーディネータ",
@@ -1119,7 +1119,7 @@ func TestNotifyNotification(t *testing.T) {
 	}
 	admin := &uentity.Admin{
 		ID:            "admin-id",
-		Role:          uentity.AdminRoleAdministrator,
+		Type:          uentity.AdminTypeAdministrator,
 		Status:        uentity.AdminStatusActivated,
 		Lastname:      "&.",
 		Firstname:     "管理者",

--- a/api/internal/store/service/spot.go
+++ b/api/internal/store/service/spot.go
@@ -136,13 +136,13 @@ func (s *service) CreateSpotByAdmin(ctx context.Context, in *store.CreateSpotByA
 		return nil, internalError(err)
 	}
 	var userType entity.SpotUserType
-	switch admin.Role {
-	case uentity.AdminRoleCoordinator:
+	switch admin.Type {
+	case uentity.AdminTypeCoordinator:
 		userType = entity.SpotUserTypeCoordinator
-	case uentity.AdminRoleProducer:
+	case uentity.AdminTypeProducer:
 		userType = entity.SpotUserTypeProducer
 	default:
-		return nil, fmt.Errorf("service: unsupported role: %w", exception.ErrFailedPrecondition)
+		return nil, fmt.Errorf("service: unsupported admin type: %w", exception.ErrFailedPrecondition)
 	}
 	addressIn := &geolocation.GetAddressInput{
 		Longitude: in.Longitude,

--- a/api/internal/store/service/spot_test.go
+++ b/api/internal/store/service/spot_test.go
@@ -464,10 +464,10 @@ func TestCreateSpotByAdmin(t *testing.T) {
 	adminIn := &user.GetAdminInput{
 		AdminID: "admin-id",
 	}
-	admin := func(role uentity.LegacyAdminRole) *uentity.Admin {
+	admin := func(role uentity.AdminType) *uentity.Admin {
 		return &uentity.Admin{
 			ID:   "admin-id",
-			Role: role,
+			Type: role,
 		}
 	}
 	addressIn := &geolocation.GetAddressInput{
@@ -494,7 +494,7 @@ func TestCreateSpotByAdmin(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.SpotType.EXPECT().Get(ctx, "type-id").Return(spotType, nil)
-				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminRoleCoordinator), nil)
+				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminTypeCoordinator), nil)
 				mocks.geolocation.EXPECT().GetAddress(ctx, addressIn).Return(addressOut, nil)
 				mocks.db.Spot.EXPECT().
 					Create(ctx, gomock.Any()).
@@ -609,7 +609,7 @@ func TestCreateSpotByAdmin(t *testing.T) {
 			name: "failed to unsppoted",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.SpotType.EXPECT().Get(ctx, "type-id").Return(spotType, nil)
-				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminRoleAdministrator), nil)
+				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminTypeAdministrator), nil)
 			},
 			input: &store.CreateSpotByAdminInput{
 				TypeID:       "type-id",
@@ -626,7 +626,7 @@ func TestCreateSpotByAdmin(t *testing.T) {
 			name: "failed to get address",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.SpotType.EXPECT().Get(ctx, "type-id").Return(spotType, nil)
-				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminRoleCoordinator), nil)
+				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminTypeCoordinator), nil)
 				mocks.geolocation.EXPECT().GetAddress(ctx, addressIn).Return(nil, assert.AnError)
 			},
 			input: &store.CreateSpotByAdminInput{
@@ -644,7 +644,7 @@ func TestCreateSpotByAdmin(t *testing.T) {
 			name: "failed to create spot",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.SpotType.EXPECT().Get(ctx, "type-id").Return(spotType, nil)
-				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminRoleCoordinator), nil)
+				mocks.user.EXPECT().GetAdmin(ctx, adminIn).Return(admin(uentity.AdminTypeCoordinator), nil)
 				mocks.geolocation.EXPECT().GetAddress(ctx, addressIn).Return(addressOut, nil)
 				mocks.db.Spot.EXPECT().Create(ctx, gomock.Any()).Return(assert.AnError)
 			},

--- a/api/internal/user/database/mysql/admin_test.go
+++ b/api/internal/user/database/mysql/admin_test.go
@@ -423,7 +423,6 @@ func testAdmin(adminID, cognitoID, email string, now time.Time) *entity.Admin {
 	return &entity.Admin{
 		ID:            adminID,
 		CognitoID:     cognitoID,
-		Role:          entity.AdminRoleAdministrator,
 		Type:          entity.AdminTypeAdministrator,
 		Status:        entity.AdminStatusActivated,
 		Lastname:      "&.",

--- a/api/internal/user/entity/admin.go
+++ b/api/internal/user/entity/admin.go
@@ -12,16 +12,6 @@ import (
 
 var errInvalidAdminRole = errors.New("entity: invalid admin role")
 
-// Deprecated: LegacyAdminRole - 管理者権限
-type LegacyAdminRole int32
-
-const (
-	AdminRoleUnknown       LegacyAdminRole = 0
-	AdminRoleAdministrator LegacyAdminRole = 1 // 管理者
-	AdminRoleCoordinator   LegacyAdminRole = 2 // コーディネータ
-	AdminRoleProducer      LegacyAdminRole = 3 // 生産者
-)
-
 // AdminStatus - 管理者ステータス
 type AdminStatus int32
 
@@ -34,22 +24,21 @@ const (
 
 // Admin - 管理者共通情報
 type Admin struct {
-	ID            string          `gorm:"primaryKey;<-:create"` // 管理者ID
-	CognitoID     string          `gorm:"default:null"`         // 管理者ID (Cognito用)
-	Role          LegacyAdminRole `gorm:"<-:create"`            // Deprecated: 管理者権限
-	Type          AdminType       `gorm:"<-:create"`            // 管理者種別
-	Status        AdminStatus     `gorm:"-"`                    // 管理者ステータス
-	Lastname      string          `gorm:"default:null"`         // 姓
-	Firstname     string          `gorm:"default:null"`         // 名
-	LastnameKana  string          `gorm:"default:null"`         // 姓(かな)
-	FirstnameKana string          `gorm:"default:null"`         // 名(かな)
-	Email         string          `gorm:"default:null"`         // メールアドレス
-	Device        string          `gorm:"default:null"`         // デバイストークン(Push通知用)
-	FirstSignInAt time.Time       `gorm:"default:null"`         // 初回ログイン日時
-	LastSignInAt  time.Time       `gorm:"default:null"`         // 最終ログイン日時
-	CreatedAt     time.Time       `gorm:"<-:create"`            // 登録日時
-	UpdatedAt     time.Time       `gorm:""`                     // 更新日時
-	DeletedAt     gorm.DeletedAt  `gorm:"default:null"`         // 削除日時
+	ID            string         `gorm:"primaryKey;<-:create"` // 管理者ID
+	CognitoID     string         `gorm:"default:null"`         // 管理者ID (Cognito用)
+	Type          AdminType      `gorm:"<-:create"`            // 管理者種別
+	Status        AdminStatus    `gorm:"-"`                    // 管理者ステータス
+	Lastname      string         `gorm:"default:null"`         // 姓
+	Firstname     string         `gorm:"default:null"`         // 名
+	LastnameKana  string         `gorm:"default:null"`         // 姓(かな)
+	FirstnameKana string         `gorm:"default:null"`         // 名(かな)
+	Email         string         `gorm:"default:null"`         // メールアドレス
+	Device        string         `gorm:"default:null"`         // デバイストークン(Push通知用)
+	FirstSignInAt time.Time      `gorm:"default:null"`         // 初回ログイン日時
+	LastSignInAt  time.Time      `gorm:"default:null"`         // 最終ログイン日時
+	CreatedAt     time.Time      `gorm:"<-:create"`            // 登録日時
+	UpdatedAt     time.Time      `gorm:""`                     // 更新日時
+	DeletedAt     gorm.DeletedAt `gorm:"default:null"`         // 削除日時
 }
 
 type Admins []*Admin
@@ -64,17 +53,17 @@ type NewAdminParams struct {
 	Email         string
 }
 
-func NewAdminRole(role int32) (LegacyAdminRole, error) {
-	res := LegacyAdminRole(role)
+func NewAdminType(typ int32) (AdminType, error) {
+	res := AdminType(typ)
 	if err := res.Validate(); err != nil {
-		return AdminRoleUnknown, err
+		return AdminTypeUnknown, err
 	}
 	return res, nil
 }
 
-func (r LegacyAdminRole) Validate() error {
+func (r AdminType) Validate() error {
 	switch r {
-	case AdminRoleAdministrator, AdminRoleCoordinator, AdminRoleProducer:
+	case AdminTypeAdministrator, AdminTypeCoordinator, AdminTypeProducer:
 		return nil
 	default:
 		return errInvalidAdminRole
@@ -85,7 +74,6 @@ func NewAdmin(params *NewAdminParams) *Admin {
 	return &Admin{
 		ID:            uuid.Base58Encode(uuid.New()),
 		CognitoID:     strings.ToLower(params.CognitoID), // Cognitoでは大文字小文字の区別がされず管理されているため
-		Role:          LegacyAdminRole(params.Type),
 		Type:          params.Type,
 		Lastname:      params.Lastname,
 		Firstname:     params.Firstname,
@@ -100,7 +88,7 @@ func (a *Admin) Name() string {
 }
 
 func (a *Admin) Fill() {
-	if a.Role == AdminRoleProducer {
+	if a.Type == AdminTypeProducer {
 		// 生産者は認証機能を持たないため、一律無効状態にする
 		a.Status = AdminStatusDeactivated
 		return
@@ -123,14 +111,14 @@ func (as Admins) Map() map[string]*Admin {
 	return res
 }
 
-func (as Admins) GroupByRole() map[LegacyAdminRole]Admins {
+func (as Admins) GroupByType() map[AdminType]Admins {
 	const maxRoles = 4
-	res := make(map[LegacyAdminRole]Admins, maxRoles)
+	res := make(map[AdminType]Admins, maxRoles)
 	for _, a := range as {
-		if _, ok := res[a.Role]; !ok {
-			res[a.Role] = make(Admins, 0, len(as))
+		if _, ok := res[a.Type]; !ok {
+			res[a.Type] = make(Admins, 0, len(as))
 		}
-		res[a.Role] = append(res[a.Role], a)
+		res[a.Type] = append(res[a.Type], a)
 	}
 	return res
 }

--- a/api/internal/user/entity/admin_auth.go
+++ b/api/internal/user/entity/admin_auth.go
@@ -6,17 +6,17 @@ import (
 
 // AdminAuth - 管理者認証情報
 type AdminAuth struct {
-	AdminID      string          // 管理者ID
-	Role         LegacyAdminRole // 権限
-	AccessToken  string          // アクセストークン
-	RefreshToken string          // 更新トークン
-	ExpiresIn    int32           // 有効期限
+	AdminID      string    // 管理者ID
+	Type         AdminType // 権限
+	AccessToken  string    // アクセストークン
+	RefreshToken string    // 更新トークン
+	ExpiresIn    int32     // 有効期限
 }
 
 func NewAdminAuth(admin *Admin, rs *cognito.AuthResult) *AdminAuth {
 	return &AdminAuth{
 		AdminID:      admin.ID,
-		Role:         admin.Role,
+		Type:         admin.Type,
 		AccessToken:  rs.AccessToken,
 		RefreshToken: rs.RefreshToken,
 		ExpiresIn:    rs.ExpiresIn,

--- a/api/internal/user/entity/admin_auth_test.go
+++ b/api/internal/user/entity/admin_auth_test.go
@@ -21,7 +21,7 @@ func TestAdminAuth(t *testing.T) {
 			admin: &Admin{
 				ID:            "admin-id",
 				CognitoID:     "cognito-id",
-				Role:          AdminRoleAdministrator,
+				Type:          AdminTypeAdministrator,
 				Lastname:      "&.",
 				Firstname:     "スタッフ",
 				LastnameKana:  "あんどどっと",
@@ -35,7 +35,7 @@ func TestAdminAuth(t *testing.T) {
 			},
 			expect: &AdminAuth{
 				AdminID:      "admin-id",
-				Role:         AdminRoleAdministrator,
+				Type:         AdminTypeAdministrator,
 				AccessToken:  "access-token",
 				RefreshToken: "refresh-token",
 				ExpiresIn:    3600,

--- a/api/internal/user/entity/admin_test.go
+++ b/api/internal/user/entity/admin_test.go
@@ -9,25 +9,25 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestAdminRole(t *testing.T) {
+func TestAdminType(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
-		role      int32
-		expect    LegacyAdminRole
+		adminType int32
+		expect    AdminType
 		expectErr error
 	}{
 		{
 			name:      "success",
-			role:      1,
-			expect:    AdminRoleAdministrator,
+			adminType: 1,
+			expect:    AdminTypeAdministrator,
 			expectErr: nil,
 		},
 		{
 			name:      "invalid role",
-			role:      0,
-			expect:    AdminRoleUnknown,
+			adminType: 0,
+			expect:    AdminTypeUnknown,
 			expectErr: errInvalidAdminRole,
 		},
 	}
@@ -36,40 +36,40 @@ func TestAdminRole(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual, err := NewAdminRole(tt.role)
+			actual, err := NewAdminType(tt.adminType)
 			assert.ErrorIs(t, tt.expectErr, err)
 			assert.Equal(t, tt.expect, actual)
 		})
 	}
 }
 
-func TestAdminRole_Validate(t *testing.T) {
+func TestAdminType_Validate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		role   LegacyAdminRole
-		expect error
+		name      string
+		adminType AdminType
+		expect    error
 	}{
 		{
-			name:   "administrator",
-			role:   AdminRoleAdministrator,
-			expect: nil,
+			name:      "administrator",
+			adminType: AdminTypeAdministrator,
+			expect:    nil,
 		},
 		{
-			name:   "coordinator",
-			role:   AdminRoleCoordinator,
-			expect: nil,
+			name:      "coordinator",
+			adminType: AdminTypeCoordinator,
+			expect:    nil,
 		},
 		{
-			name:   "producer",
-			role:   AdminRoleProducer,
-			expect: nil,
+			name:      "producer",
+			adminType: AdminTypeProducer,
+			expect:    nil,
 		},
 		{
-			name:   "unknown",
-			role:   AdminRoleUnknown,
-			expect: errInvalidAdminRole,
+			name:      "unknown",
+			adminType: AdminTypeUnknown,
+			expect:    errInvalidAdminRole,
 		},
 	}
 
@@ -77,7 +77,7 @@ func TestAdminRole_Validate(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := tt.role.Validate()
+			err := tt.adminType.Validate()
 			assert.ErrorIs(t, err, tt.expect)
 		})
 	}
@@ -104,7 +104,6 @@ func TestAdmin(t *testing.T) {
 			},
 			expect: &Admin{
 				CognitoID:     "cognito-id",
-				Role:          AdminRoleAdministrator,
 				Type:          AdminTypeAdministrator,
 				Lastname:      "&.",
 				Firstname:     "スタッフ",
@@ -139,7 +138,6 @@ func TestAdmin_Name(t *testing.T) {
 			name: "success",
 			admin: &Admin{
 				ID:            "admin-id",
-				Role:          AdminRoleAdministrator,
 				Lastname:      "&.",
 				Firstname:     "スタッフ",
 				LastnameKana:  "あんどぴりおど",
@@ -173,14 +171,14 @@ func TestAdmin_Fill(t *testing.T) {
 		{
 			name: "producer",
 			admin: &Admin{
-				Role: AdminRoleProducer,
+				Type: AdminTypeProducer,
 			},
 			expectStatus: AdminStatusDeactivated,
 		},
 		{
 			name: "invited",
 			admin: &Admin{
-				Role:          AdminRoleCoordinator,
+				Type:          AdminTypeCoordinator,
 				FirstSignInAt: time.Time{},
 			},
 			expectStatus: AdminStatusInvited,
@@ -188,7 +186,7 @@ func TestAdmin_Fill(t *testing.T) {
 		{
 			name: "activated",
 			admin: &Admin{
-				Role:          AdminRoleCoordinator,
+				Type:          AdminTypeCoordinator,
 				FirstSignInAt: now,
 			},
 			expectStatus: AdminStatusActivated,
@@ -196,7 +194,7 @@ func TestAdmin_Fill(t *testing.T) {
 		{
 			name: "deactivated",
 			admin: &Admin{
-				Role:          AdminRoleCoordinator,
+				Type:          AdminTypeCoordinator,
 				FirstSignInAt: now,
 				DeletedAt: gorm.DeletedAt{
 					Time:  now,
@@ -230,14 +228,14 @@ func TestAdmins_Map(t *testing.T) {
 				{
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
 			expect: map[string]*Admin{
 				"admin-id": {
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
 		},
@@ -252,13 +250,13 @@ func TestAdmins_Map(t *testing.T) {
 	}
 }
 
-func TestAdmins_GroupByRole(t *testing.T) {
+func TestAdmins_GroupByType(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name   string
 		admins Admins
-		expect map[LegacyAdminRole]Admins
+		expect map[AdminType]Admins
 	}{
 		{
 			name: "success",
@@ -266,15 +264,15 @@ func TestAdmins_GroupByRole(t *testing.T) {
 				{
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
-			expect: map[LegacyAdminRole]Admins{
-				AdminRoleAdministrator: {
+			expect: map[AdminType]Admins{
+				AdminTypeAdministrator: {
 					{
 						ID:        "admin-id",
 						CognitoID: "cognito-id",
-						Role:      AdminRoleAdministrator,
+						Type:      AdminTypeAdministrator,
 					},
 				},
 			},
@@ -285,7 +283,7 @@ func TestAdmins_GroupByRole(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, tt.admins.GroupByRole())
+			assert.Equal(t, tt.expect, tt.admins.GroupByType())
 		})
 	}
 }
@@ -304,7 +302,7 @@ func TestAdmins_IDs(t *testing.T) {
 				{
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
 			expect: []string{"admin-id"},
@@ -335,13 +333,13 @@ func TestAdmins_Devices(t *testing.T) {
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
 					Device:    "instance-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 				{
 					ID:        "admin-id",
 					CognitoID: "cognito-id",
 					Device:    "",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
 			expect: []string{"instance-id"},

--- a/api/internal/user/entity/administrator.go
+++ b/api/internal/user/entity/administrator.go
@@ -44,7 +44,7 @@ func (as Administrators) Fill(admins map[string]*Admin) {
 	for _, a := range as {
 		admin, ok := admins[a.AdminID]
 		if !ok {
-			admin = &Admin{ID: a.AdminID, Role: AdminRoleAdministrator}
+			admin = &Admin{ID: a.AdminID, Type: AdminTypeAdministrator}
 		}
 		a.Fill(admin)
 	}

--- a/api/internal/user/entity/administrator_test.go
+++ b/api/internal/user/entity/administrator_test.go
@@ -140,7 +140,7 @@ func TestAdministrators_Fill(t *testing.T) {
 				"admin-id01": {
 					ID:        "admin-id01",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleAdministrator,
+					Type:      AdminTypeAdministrator,
 				},
 			},
 			expect: Administrators{
@@ -149,14 +149,14 @@ func TestAdministrators_Fill(t *testing.T) {
 					Admin: Admin{
 						ID:        "admin-id01",
 						CognitoID: "cognito-id",
-						Role:      AdminRoleAdministrator,
+						Type:      AdminTypeAdministrator,
 					},
 				},
 				{
 					AdminID: "admin-id02",
 					Admin: Admin{
 						ID:   "admin-id02",
-						Role: AdminRoleAdministrator,
+						Type: AdminTypeAdministrator,
 					},
 				},
 			},

--- a/api/internal/user/entity/coordinator.go
+++ b/api/internal/user/entity/coordinator.go
@@ -161,7 +161,7 @@ func (cs Coordinators) Fill(admins map[string]*Admin) error {
 	for _, c := range cs {
 		admin, ok := admins[c.AdminID]
 		if !ok {
-			admin = &Admin{ID: c.AdminID, Role: AdminRoleCoordinator}
+			admin = &Admin{ID: c.AdminID, Type: AdminTypeCoordinator}
 		}
 		if err := c.Fill(admin); err != nil {
 			return err

--- a/api/internal/user/entity/coordinator_test.go
+++ b/api/internal/user/entity/coordinator_test.go
@@ -295,7 +295,7 @@ func TestCoordinators_Fill(t *testing.T) {
 				"admin-id01": {
 					ID:        "admin-id01",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleCoordinator,
+					Type:      AdminTypeCoordinator,
 				},
 			},
 			expect: Coordinators{
@@ -312,7 +312,7 @@ func TestCoordinators_Fill(t *testing.T) {
 					Admin: Admin{
 						ID:        "admin-id01",
 						CognitoID: "cognito-id",
-						Role:      AdminRoleCoordinator,
+						Type:      AdminTypeCoordinator,
 					},
 				},
 				{
@@ -327,7 +327,7 @@ func TestCoordinators_Fill(t *testing.T) {
 					BusinessDaysJSON: datatypes.JSON([]byte(`[1,3,5]`)),
 					Admin: Admin{
 						ID:   "admin-id02",
-						Role: AdminRoleCoordinator,
+						Type: AdminTypeCoordinator,
 					},
 				},
 			},

--- a/api/internal/user/entity/producer.go
+++ b/api/internal/user/entity/producer.go
@@ -118,7 +118,7 @@ func (ps Producers) Fill(admins map[string]*Admin) error {
 	for _, p := range ps {
 		admin, ok := admins[p.AdminID]
 		if !ok {
-			admin = &Admin{ID: p.AdminID, Role: AdminRoleProducer}
+			admin = &Admin{ID: p.AdminID, Type: AdminTypeProducer}
 		}
 		if err := p.Fill(admin); err != nil {
 			return err

--- a/api/internal/user/entity/producer_test.go
+++ b/api/internal/user/entity/producer_test.go
@@ -354,7 +354,7 @@ func TestProducers_Fill(t *testing.T) {
 				"admin-id01": {
 					ID:        "admin-id01",
 					CognitoID: "cognito-id",
-					Role:      AdminRoleProducer,
+					Type:      AdminTypeProducer,
 				},
 			},
 			expect: Producers{
@@ -365,7 +365,7 @@ func TestProducers_Fill(t *testing.T) {
 					Admin: Admin{
 						ID:        "admin-id01",
 						CognitoID: "cognito-id",
-						Role:      AdminRoleProducer,
+						Type:      AdminTypeProducer,
 					},
 				},
 				{
@@ -374,7 +374,7 @@ func TestProducers_Fill(t *testing.T) {
 					PrefectureCode: 13,
 					Admin: Admin{
 						ID:   "admin-id02",
-						Role: AdminRoleProducer,
+						Type: AdminTypeProducer,
 					},
 				},
 			},

--- a/api/internal/user/service/admin_auth_test.go
+++ b/api/internal/user/service/admin_auth_test.go
@@ -22,7 +22,7 @@ func TestSignInAdmin(t *testing.T) {
 	}
 	admin := &entity.Admin{
 		ID:   "admin-id",
-		Role: entity.AdminRoleAdministrator,
+		Type: entity.AdminTypeAdministrator,
 	}
 
 	tests := []struct {
@@ -46,7 +46,7 @@ func TestSignInAdmin(t *testing.T) {
 			},
 			expect: &entity.AdminAuth{
 				AdminID:      "admin-id",
-				Role:         entity.AdminRoleAdministrator,
+				Type:         entity.AdminTypeAdministrator,
 				AccessToken:  "access-token",
 				RefreshToken: "refresh-token",
 				ExpiresIn:    3600,
@@ -179,7 +179,7 @@ func TestGetAdminAuth(t *testing.T) {
 
 	admin := &entity.Admin{
 		ID:     "admin-id",
-		Role:   entity.AdminRoleAdministrator,
+		Type:   entity.AdminTypeAdministrator,
 		Status: entity.AdminStatusActivated,
 	}
 
@@ -201,7 +201,7 @@ func TestGetAdminAuth(t *testing.T) {
 			},
 			expect: &entity.AdminAuth{
 				AdminID:      "admin-id",
-				Role:         entity.AdminRoleAdministrator,
+				Type:         entity.AdminTypeAdministrator,
 				AccessToken:  "eyJraWQiOiJXOWxyODBzODRUVXQ3eWdyZ",
 				RefreshToken: "",
 				ExpiresIn:    0,
@@ -263,7 +263,7 @@ func TestRefreshAdminToken(t *testing.T) {
 	}
 	admin := &entity.Admin{
 		ID:   "admin-id",
-		Role: entity.AdminRoleAdministrator,
+		Type: entity.AdminTypeAdministrator,
 	}
 
 	tests := []struct {
@@ -286,7 +286,7 @@ func TestRefreshAdminToken(t *testing.T) {
 			},
 			expect: &entity.AdminAuth{
 				AdminID:      "admin-id",
-				Role:         entity.AdminRoleAdministrator,
+				Type:         entity.AdminTypeAdministrator,
 				AccessToken:  "access-token",
 				RefreshToken: "",
 				ExpiresIn:    3600,
@@ -514,7 +514,7 @@ func TestVerifyAdminEmail(t *testing.T) {
 
 	admin := &entity.Admin{
 		ID:   "admin-id",
-		Role: entity.AdminRoleAdministrator,
+		Type: entity.AdminTypeAdministrator,
 	}
 	params := &cognito.ConfirmChangeEmailParams{
 		AccessToken: "access-token",

--- a/api/internal/user/service/admin_test.go
+++ b/api/internal/user/service/admin_test.go
@@ -24,7 +24,7 @@ func TestMultiGetAdmins(t *testing.T) {
 	admins := entity.Admins{
 		{
 			ID:            "administrator-id",
-			Role:          entity.AdminRoleAdministrator,
+			Type:          entity.AdminTypeAdministrator,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",
 			LastnameKana:  "あんどぴりおど",
@@ -35,7 +35,7 @@ func TestMultiGetAdmins(t *testing.T) {
 		},
 		{
 			ID:            "coordinator-id",
-			Role:          entity.AdminRoleCoordinator,
+			Type:          entity.AdminTypeCoordinator,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",
 			LastnameKana:  "あんどぴりおど",
@@ -46,7 +46,7 @@ func TestMultiGetAdmins(t *testing.T) {
 		},
 		{
 			ID:            "producer-id",
-			Role:          entity.AdminRoleProducer,
+			Type:          entity.AdminTypeProducer,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",
 			LastnameKana:  "あんどぴりおど",
@@ -118,7 +118,7 @@ func TestMultiGetAdminDevices(t *testing.T) {
 		{
 			ID:        "admin-id",
 			CognitoID: "username",
-			Role:      entity.AdminRoleAdministrator,
+			Type:      entity.AdminTypeAdministrator,
 			Device:    "instance-id",
 		},
 	}
@@ -179,7 +179,7 @@ func TestGetAdmin(t *testing.T) {
 	now := jst.Date(2022, 5, 2, 18, 30, 0, 0)
 	admin := &entity.Admin{
 		ID:            "admin-id",
-		Role:          entity.AdminRoleAdministrator,
+		Type:          entity.AdminTypeAdministrator,
 		Lastname:      "&.",
 		Firstname:     "スタッフ",
 		LastnameKana:  "あんどぴりおど",
@@ -206,7 +206,7 @@ func TestGetAdmin(t *testing.T) {
 			},
 			expect: func() *entity.Admin {
 				admin := *admin
-				admin.Role = entity.AdminRoleAdministrator
+				admin.Type = entity.AdminTypeAdministrator
 				return &admin
 			}(),
 			expectErr: nil,

--- a/api/internal/user/service/administrator_test.go
+++ b/api/internal/user/service/administrator_test.go
@@ -26,7 +26,6 @@ func TestListAdministrators(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleAdministrator,
 				Type:          entity.AdminTypeAdministrator,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -121,7 +120,6 @@ func TestMultiGetAdministrators(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleAdministrator,
 				Type:          entity.AdminTypeAdministrator,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -194,7 +192,6 @@ func TestGetAdministrator(t *testing.T) {
 	administrator := &entity.Administrator{
 		Admin: entity.Admin{
 			ID:            "admin-id",
-			Role:          entity.AdminRoleAdministrator,
 			Type:          entity.AdminTypeAdministrator,
 			Status:        entity.AdminStatusActivated,
 			Lastname:      "&.",
@@ -271,7 +268,6 @@ func TestCreateAdministrator(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				expectAdministrator := &entity.Administrator{
 					Admin: entity.Admin{
-						Role:          entity.AdminRoleAdministrator,
 						Type:          entity.AdminTypeAdministrator,
 						Lastname:      "&.",
 						Firstname:     "スタッフ",
@@ -422,7 +418,6 @@ func TestUpdateAdministratorEmail(t *testing.T) {
 		Admin: entity.Admin{
 			ID:            "admin-id",
 			CognitoID:     "cognito-id",
-			Role:          entity.AdminRoleAdministrator,
 			Type:          entity.AdminTypeAdministrator,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",
@@ -520,7 +515,6 @@ func TestResetAdministratorPassword(t *testing.T) {
 		Admin: entity.Admin{
 			ID:            "admin-id",
 			CognitoID:     "cognito-id",
-			Role:          entity.AdminRoleAdministrator,
 			Type:          entity.AdminTypeAdministrator,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",

--- a/api/internal/user/service/coordinator_test.go
+++ b/api/internal/user/service/coordinator_test.go
@@ -29,7 +29,6 @@ func TestListCoordinators(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleCoordinator,
 				Type:          entity.AdminTypeCoordinator,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -136,7 +135,6 @@ func TestMultiGetCoordinators(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleCoordinator,
 				Type:          entity.AdminTypeCoordinator,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -245,7 +243,6 @@ func TestGetCoordinator(t *testing.T) {
 	coordinator := &entity.Coordinator{
 		Admin: entity.Admin{
 			ID:            "admin-id",
-			Role:          entity.AdminRoleCoordinator,
 			Type:          entity.AdminTypeCoordinator,
 			Status:        entity.AdminStatusActivated,
 			Lastname:      "&.",
@@ -368,7 +365,6 @@ func TestCreateCoordinator(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				expectCoordinator := &entity.Coordinator{
 					Admin: entity.Admin{
-						Role:          entity.AdminRoleCoordinator,
 						Type:          entity.AdminTypeCoordinator,
 						Lastname:      "&.",
 						Firstname:     "スタッフ",
@@ -797,7 +793,6 @@ func TestUpdateCoordinatorEmail(t *testing.T) {
 		Admin: entity.Admin{
 			ID:            "admin-id",
 			CognitoID:     "cognito-id",
-			Role:          entity.AdminRoleCoordinator,
 			Type:          entity.AdminTypeCoordinator,
 			Status:        entity.AdminStatusActivated,
 			Lastname:      "&.",
@@ -907,7 +902,6 @@ func TestResetCoordinatorPassword(t *testing.T) {
 		Admin: entity.Admin{
 			ID:            "admin-id",
 			CognitoID:     "cognito-id",
-			Role:          entity.AdminRoleCoordinator,
 			Type:          entity.AdminTypeCoordinator,
 			Lastname:      "&.",
 			Firstname:     "スタッフ",

--- a/api/internal/user/service/producer_test.go
+++ b/api/internal/user/service/producer_test.go
@@ -25,7 +25,6 @@ func TestListProducers(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleProducer,
 				Type:          entity.AdminTypeProducer,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -132,7 +131,6 @@ func TestMultiGetProducers(t *testing.T) {
 		{
 			Admin: entity.Admin{
 				ID:            "admin-id",
-				Role:          entity.AdminRoleProducer,
 				Type:          entity.AdminTypeProducer,
 				Status:        entity.AdminStatusActivated,
 				Lastname:      "&.",
@@ -241,7 +239,6 @@ func TestGetProducer(t *testing.T) {
 	producer := &entity.Producer{
 		Admin: entity.Admin{
 			ID:            "admin-id",
-			Role:          entity.AdminRoleProducer,
 			Type:          entity.AdminTypeProducer,
 			Status:        entity.AdminStatusActivated,
 			Lastname:      "&.",
@@ -347,7 +344,6 @@ func TestCreateProducer(t *testing.T) {
 	coordinator := &entity.Coordinator{
 		Admin: entity.Admin{
 			ID:            "admin-id",
-			Role:          entity.AdminRoleCoordinator,
 			Type:          entity.AdminTypeProducer,
 			Status:        entity.AdminStatusActivated,
 			Lastname:      "&.",
@@ -384,7 +380,6 @@ func TestCreateProducer(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				expectProducer := &entity.Producer{
 					Admin: entity.Admin{
-						Role:          entity.AdminRoleProducer,
 						Type:          entity.AdminTypeProducer,
 						Lastname:      "&.",
 						Firstname:     "スタッフ",

--- a/docs/swagger/admin/components/schemas/codes/admin.yaml
+++ b/docs/swagger/admin/components/schemas/codes/admin.yaml
@@ -1,7 +1,7 @@
-adminRole:
+adminType:
   type: integer
   format: int32
-  description: 管理者権限
+  description: 管理者種別
   nullable: false
   enum:
   - 0

--- a/docs/swagger/admin/components/schemas/entity/admin.yaml
+++ b/docs/swagger/admin/components/schemas/entity/admin.yaml
@@ -5,8 +5,8 @@ admin:
     id:
       type: string
       description: 管理者ID
-    role:
-      $ref: './../../../openapi.yaml#/components/schemas/adminRole'
+    type:
+      $ref: './../../../openapi.yaml#/components/schemas/adminType'
     lastname:
       type: string
       description: 姓
@@ -32,7 +32,7 @@ admin:
       description: 更新日時 (unixtime)
   required:
   - id
-  - role
+  - type
   - lastname
   - firstname
   - lastnameKana
@@ -42,7 +42,7 @@ admin:
   - updatedAt
   example:
     id: 'kSByoE6FetnPs5Byk3a9Zx'
-    role: 2
+    type: 2
     lastname: '&.'
     firstname: '管理者'
     lastnameKana: 'あんどどっと'

--- a/docs/swagger/admin/components/schemas/v1/auth.response.yaml
+++ b/docs/swagger/admin/components/schemas/v1/auth.response.yaml
@@ -4,8 +4,8 @@ authResponse:
     adminId:
       type: string
       description: 管理者ID
-    role:
-      $ref: './../../../openapi.yaml#/components/schemas/adminRole'
+    type:
+      $ref: './../../../openapi.yaml#/components/schemas/adminType'
     accessToken:
       type: string
       description: アクセストークン
@@ -21,14 +21,14 @@ authResponse:
       description: トークン種別
   required:
   - adminId
-  - role
+  - type
   - accessToken
   - refreshToken
   - expiresIn
   - tokenType
   example:
     adminId: 'kSByoE6FetnPs5Byk3a9Zx'
-    role: 1
+    type: 1
     accessToken: 'xxxxxxxxxx'
     refreshToken: 'xxxxxxxxxx'
     expiresIn: 3600
@@ -39,8 +39,8 @@ authUserResponse:
     id:
       type: string
       description: 管理者ID
-    role:
-      $ref: './../../../openapi.yaml#/components/schemas/adminRole'
+    type:
+      $ref: './../../../openapi.yaml#/components/schemas/adminType'
     username:
       type: string
       description: 表示名
@@ -52,13 +52,13 @@ authUserResponse:
       description: サムネイルURL
   required:
   - id
-  - role
+  - type
   - username
   - email
   - thumbnailUrl
   example:
     id: 'kSByoE6FetnPs5Byk3a9Zx'
-    role: 1
+    type: 1
     username: '&. 管理者'
     email: 'test-user@and-period.jp'
     thumbnailUrl: 'https://and-period.jp/thumbnail.png'

--- a/docs/swagger/admin/openapi.yaml
+++ b/docs/swagger/admin/openapi.yaml
@@ -336,8 +336,8 @@ components:
       name: session_id
   schemas:
     # Common
-    adminRole:
-      $ref: './components/schemas/codes/admin.yaml#/adminRole'
+    adminType:
+      $ref: './components/schemas/codes/admin.yaml#/adminType'
     adminStatus:
       $ref: './components/schemas/codes/admin.yaml#/adminStatus'
     broadcastStatus:

--- a/infra/mysql/schema/2025010202-users-drop-columns.sql
+++ b/infra/mysql/schema/2025010202-users-drop-columns.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users`.`admins` DROP COLUMN `role`;

--- a/infra/tidb/schema/users/2025010202-drop-column-to-admins.sql
+++ b/infra/tidb/schema/users/2025010202-drop-column-to-admins.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users`.`admins` DROP COLUMN `role`;

--- a/web/admin/src/components/organisms/CategoryList.vue
+++ b/web/admin/src/components/organisms/CategoryList.vue
@@ -3,7 +3,7 @@ import { mdiDelete, mdiPencil, mdiPlus } from '@mdi/js'
 import useVuelidate from '@vuelidate/core'
 import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
-import { AdminRole, type Category, type CreateCategoryRequest, type UpdateCategoryRequest } from '~/types/api'
+import { AdminType, type Category, type CreateCategoryRequest, type UpdateCategoryRequest } from '~/types/api'
 import { getErrorMessage } from '~/lib/validations'
 import { CreateCategoryValidationRules, UpdateCategoryValidationRules } from '~/types/validations'
 
@@ -12,9 +12,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   createDialog: {
     type: Boolean,
@@ -118,11 +118,11 @@ const createFormDataValidate = useVuelidate(CreateCategoryValidationRules, creat
 const updateFormDataValidate = useVuelidate(UpdateCategoryValidationRules, updateFormDataValue)
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onClickNew = (): void => {

--- a/web/admin/src/components/organisms/ProductTypeList.vue
+++ b/web/admin/src/components/organisms/ProductTypeList.vue
@@ -3,7 +3,7 @@ import { mdiAccount, mdiPencil, mdiDelete, mdiPlus } from '@mdi/js'
 import useVuelidate from '@vuelidate/core'
 import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
-import { AdminRole, type Category, type CreateProductTypeRequest, type ProductType, type UpdateProductTypeRequest } from '~/types/api'
+import { AdminType, type Category, type CreateProductTypeRequest, type ProductType, type UpdateProductTypeRequest } from '~/types/api'
 import type { ImageUploadStatus } from '~/types/props'
 import { getErrorMessage } from '~/lib/validations'
 import { getResizedImages } from '~/lib/helpers'
@@ -14,9 +14,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   createDialog: {
     type: Boolean,
@@ -163,11 +163,11 @@ const createFormDataValidate = useVuelidate(CreateProductTypeValidationRules, cr
 const updateFormDataValidate = useVuelidate(UpdateProductTypeValidationRules, updateFormDataValue)
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const getCategoryName = (categoryId: string): string => {

--- a/web/admin/src/components/templates/CategoryList.vue
+++ b/web/admin/src/components/templates/CategoryList.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { VTabs } from 'vuetify/lib/components/index.mjs'
 import type { AlertType } from '~/lib/hooks'
-import { type CreateCategoryRequest, type Category, type ProductType, type CreateProductTypeRequest, AdminRole, type UpdateCategoryRequest, type UpdateProductTypeRequest } from '~/types/api'
+import { type CreateCategoryRequest, type Category, type ProductType, type CreateProductTypeRequest, AdminType, type UpdateCategoryRequest, type UpdateProductTypeRequest } from '~/types/api'
 import type { ImageUploadStatus } from '~/types/props'
 
 const props = defineProps({
@@ -9,9 +9,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   isAlert: {
     type: Boolean,
@@ -339,7 +339,7 @@ const onSubmitDeleteProductType = (): void => {
           v-model:update-dialog="updateCategoryDialogValue"
           v-model:delete-dialog="deleteCategoryDialogValue"
           :loading="loading"
-          :role="role"
+          :admin-type="adminType"
           :category="category"
           :categories="categories"
           :table-items-per-page="categoryTableItemsPerPage"
@@ -363,7 +363,7 @@ const onSubmitDeleteProductType = (): void => {
           v-model:update-dialog="updateProductTypeDialogValue"
           v-model:delete-dialog="deleteProductTypeDialogValue"
           :loading="loading"
-          :role="role"
+          :admin-type="adminType"
           :product-type="productType"
           :product-types="productTypes"
           :categories="categories"

--- a/web/admin/src/components/templates/CustomerShow.vue
+++ b/web/admin/src/components/templates/CustomerShow.vue
@@ -5,16 +5,16 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
 import { convertI18nToJapanesePhoneNumber } from '~/lib/formatter'
 import type { AlertType } from '~/lib/hooks'
-import { type UserOrder, type User, Prefecture, PaymentStatus, UserStatus, AdminRole, type Address, AdminStatus } from '~/types/api'
+import { type UserOrder, type User, Prefecture, PaymentStatus, UserStatus, AdminType, type Address, AdminStatus } from '~/types/api'
 
 const props = defineProps({
   loading: {
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   isAlert: {
     type: Boolean,
@@ -157,7 +157,7 @@ const isEditable = (): boolean => {
   if (!props.customer || props.customer.status === AdminStatus.DEACTIVATED) {
     return false
   }
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const getName = (): string => {

--- a/web/admin/src/components/templates/ExperienceList.vue
+++ b/web/admin/src/components/templates/ExperienceList.vue
@@ -12,7 +12,7 @@ import {
   type ExperiencesResponse,
   type Producer,
   ExperienceStatus,
-  AdminRole,
+  AdminType,
 } from '~/types/api'
 
 const props = defineProps({
@@ -24,9 +24,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -162,12 +162,12 @@ const getExperienceType = (experienceTypeId: string): string => {
 }
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.COORDINATOR
+  return props.adminType === AdminType.COORDINATOR
 }
 
 const isDeletable = (): boolean => {
-  const targets: AdminRole[] = [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR]
-  return targets.includes(props.role)
+  const targets: AdminType[] = [AdminType.ADMINISTRATOR, AdminType.COORDINATOR]
+  return targets.includes(props.adminType)
 }
 
 const toggleDeleteDialog = (experience?: Experience): void => {

--- a/web/admin/src/components/templates/ExperienceTypeList.vue
+++ b/web/admin/src/components/templates/ExperienceTypeList.vue
@@ -4,7 +4,7 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 import useVuelidate from '@vuelidate/core'
 
 import type { AlertType } from '~/lib/hooks'
-import { AdminRole, type CreateExperienceTypeRequest, type ExperienceType, type UpdateExperienceTypeRequest } from '~/types/api'
+import { AdminType, type CreateExperienceTypeRequest, type ExperienceType, type UpdateExperienceTypeRequest } from '~/types/api'
 import { getErrorMessage } from '~/lib/validations'
 import { CreateExperienceTypeValidationRules, UpdateExperienceTypeValidationRules } from '~/types/validations'
 
@@ -13,9 +13,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   newDialog: {
     type: Boolean,
@@ -126,11 +126,11 @@ const newValidate = useVuelidate<CreateExperienceTypeRequest>(CreateExperienceTy
 const editValidate = useVuelidate<UpdateExperienceTypeRequest>(UpdateExperienceTypeValidationRules, editFormDataValue)
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onClickUpdatePage = (page: number): void => {

--- a/web/admin/src/components/templates/NotificationEdit.vue
+++ b/web/admin/src/components/templates/NotificationEdit.vue
@@ -4,7 +4,7 @@ import dayjs, { unix } from 'dayjs'
 import type { AlertType } from '~/lib/hooks'
 
 import { getErrorMessage } from '~/lib/validations'
-import { AdminRole, DiscountType, type Notification, NotificationStatus, NotificationTarget, NotificationType, type Promotion, type UpdateNotificationRequest, PromotionStatus } from '~/types/api'
+import { AdminType, DiscountType, type Notification, NotificationStatus, NotificationTarget, NotificationType, type Promotion, type UpdateNotificationRequest, PromotionStatus } from '~/types/api'
 import type { DateTimeInput } from '~/types/props'
 import { TimeDataValidationRules } from '~/types/validations'
 import { UpdateNotificationValidationRules } from '~/types/validations/notification'
@@ -14,9 +14,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   isAlert: {
     type: Boolean,
@@ -119,7 +119,7 @@ const formDataValidate = useVuelidate(UpdateNotificationValidationRules, formDat
 const timeDataValidate = useVuelidate(TimeDataValidationRules, timeDataValue)
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onChangePublishedAt = (): void => {

--- a/web/admin/src/components/templates/NotificationList.vue
+++ b/web/admin/src/components/templates/NotificationList.vue
@@ -5,16 +5,16 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
 import type { AlertType } from '~/lib/hooks'
 import type { Admin, Notification, NotificationTarget } from '~/types/api'
-import { AdminRole, NotificationStatus, NotificationType } from '~/types/api'
+import { AdminType, NotificationStatus, NotificationType } from '~/types/api'
 
 const props = defineProps({
   loading: {
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -110,11 +110,11 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const getAdminName = (adminId: string): string => {

--- a/web/admin/src/components/templates/ProducerList.vue
+++ b/web/admin/src/components/templates/ProducerList.vue
@@ -5,16 +5,16 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 import { convertI18nToJapanesePhoneNumber } from '~/lib/formatter'
 import { getResizedImages } from '~/lib/helpers'
 import type { AlertType } from '~/lib/hooks'
-import { AdminRole, type Coordinator, type Producer } from '~/types/api'
+import { AdminType, type Coordinator, type Producer } from '~/types/api'
 
 const props = defineProps({
   loading: {
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -100,7 +100,7 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.COORDINATOR
+  return props.adminType === AdminType.COORDINATOR
 }
 
 const getCoordinatorName = (coordinatorId: string) => {

--- a/web/admin/src/components/templates/ProductEdit.vue
+++ b/web/admin/src/components/templates/ProductEdit.vue
@@ -4,7 +4,7 @@ import { mdiClose, mdiPlus } from '@mdi/js'
 import useVuelidate from '@vuelidate/core'
 import dayjs, { unix } from 'dayjs'
 import type { AlertType } from '~/lib/hooks'
-import { type Category, DeliveryType, Prefecture, type Producer, type Product, ProductStatus, type ProductTag, type ProductType, StorageMethodType, type UpdateProductRequest, AdminRole } from '~/types/api'
+import { type Category, DeliveryType, Prefecture, type Producer, type Product, ProductStatus, type ProductTag, type ProductType, StorageMethodType, type UpdateProductRequest, AdminType } from '~/types/api'
 import { getErrorMessage } from '~/lib/validations'
 import { prefecturesList, cityList, type PrefecturesListItem, type CityListItem } from '~/constants'
 import type { DateTimeInput } from '~/types/props'
@@ -27,9 +27,9 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   formData: {
     type: Object as PropType<UpdateProductRequest>,
@@ -243,11 +243,11 @@ const isUpdatable = (): boolean => {
   if (props.product.status === ProductStatus.ARCHIVED) {
     return false
   }
-  const targets: AdminRole[] = [
-    AdminRole.ADMINISTRATOR,
-    AdminRole.COORDINATOR,
+  const targets: AdminType[] = [
+    AdminType.ADMINISTRATOR,
+    AdminType.COORDINATOR,
   ]
-  return targets.includes(props.role)
+  return targets.includes(props.adminType)
 }
 
 const onChangeStartAt = (): void => {

--- a/web/admin/src/components/templates/ProductList.vue
+++ b/web/admin/src/components/templates/ProductList.vue
@@ -12,7 +12,7 @@ import {
   type ProductTag,
   type ProductType,
   type Producer,
-  AdminRole,
+  AdminType,
 } from '~/types/api'
 
 const props = defineProps({
@@ -24,9 +24,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -151,12 +151,12 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.COORDINATOR
+  return props.adminType === AdminType.COORDINATOR
 }
 
 const isDeletable = (): boolean => {
-  const targets: AdminRole[] = [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR]
-  return targets.includes(props.role)
+  const targets: AdminType[] = [AdminType.ADMINISTRATOR, AdminType.COORDINATOR]
+  return targets.includes(props.adminType)
 }
 
 const getCategoryName = (categoryId: string): string => {

--- a/web/admin/src/components/templates/ProductTagList.vue
+++ b/web/admin/src/components/templates/ProductTagList.vue
@@ -4,7 +4,7 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 import useVuelidate from '@vuelidate/core'
 
 import type { AlertType } from '~/lib/hooks'
-import { AdminRole, type CreateProductTagRequest, type ProductTag, type UpdateProductTagRequest } from '~/types/api'
+import { AdminType, type CreateProductTagRequest, type ProductTag, type UpdateProductTagRequest } from '~/types/api'
 import { getErrorMessage } from '~/lib/validations'
 import { CreateProductTagValidationRules, UpdateProductTagValidationRules } from '~/types/validations'
 
@@ -13,9 +13,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   newDialog: {
     type: Boolean,
@@ -126,11 +126,11 @@ const newValidate = useVuelidate<CreateProductTagRequest>(CreateProductTagValida
 const editValidate = useVuelidate<UpdateProductTagRequest>(UpdateProductTagValidationRules, editFormDataValue)
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onClickUpdatePage = (page: number): void => {

--- a/web/admin/src/components/templates/PromotionEdit.vue
+++ b/web/admin/src/components/templates/PromotionEdit.vue
@@ -4,7 +4,7 @@ import dayjs, { unix } from 'dayjs'
 
 import type { AlertType } from '~/lib/hooks'
 import { getErrorMessage } from '~/lib/validations'
-import { AdminRole, DiscountType, PromotionStatus, type Promotion, type UpdatePromotionRequest } from '~/types/api'
+import { AdminType, DiscountType, PromotionStatus, type Promotion, type UpdatePromotionRequest } from '~/types/api'
 import type { DateTimeInput } from '~/types/props'
 import { TimeDataValidationRules, UpdatePromotionValidationRules } from '~/types/validations'
 
@@ -13,9 +13,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   isAlert: {
     type: Boolean,
@@ -109,7 +109,7 @@ const startTimeDataValidate = useVuelidate(TimeDataValidationRules, startTimeDat
 const endTimeDataValidate = useVuelidate(TimeDataValidationRules, endTimeDataValue)
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onChangeStartAt = (): void => {

--- a/web/admin/src/components/templates/PromotionList.vue
+++ b/web/admin/src/components/templates/PromotionList.vue
@@ -5,7 +5,7 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
 import type { AlertType } from '~/lib/hooks'
 import {
-  AdminRole,
+  AdminType,
   DiscountType,
   PromotionStatus,
   type Promotion,
@@ -16,9 +16,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -110,11 +110,11 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const getDiscount = (

--- a/web/admin/src/components/templates/ScheduleList.vue
+++ b/web/admin/src/components/templates/ScheduleList.vue
@@ -9,7 +9,7 @@ import {
   type Coordinator,
   ScheduleStatus,
   type Schedule,
-  AdminRole,
+  AdminType,
 } from '~/types/api'
 
 const props = defineProps({
@@ -17,9 +17,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -111,7 +111,7 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.COORDINATOR
+  return props.adminType === AdminType.COORDINATOR
 }
 
 const getCoordinatorName = (coordinatorId: string): string => {

--- a/web/admin/src/components/templates/ShippingList.vue
+++ b/web/admin/src/components/templates/ShippingList.vue
@@ -4,16 +4,16 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 
 import { dateTimeFormatter } from '~/lib/formatter'
 import type { AlertType } from '~/lib/hooks'
-import { AdminRole, type Coordinator, type Shipping } from '~/types/api'
+import { AdminType, type Coordinator, type Shipping } from '~/types/api'
 
 const props = defineProps({
   loading: {
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   deleteDialog: {
     type: Boolean,
@@ -93,7 +93,7 @@ const deleteDialogValue = computed({
 })
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.COORDINATOR
+  return props.adminType === AdminType.COORDINATOR
 }
 
 const getCoordinatorName = (coordinatorId: string) => {

--- a/web/admin/src/components/templates/SpotTypeList.vue
+++ b/web/admin/src/components/templates/SpotTypeList.vue
@@ -4,7 +4,7 @@ import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 import useVuelidate from '@vuelidate/core'
 
 import type { AlertType } from '~/lib/hooks'
-import { AdminRole, type CreateSpotTypeRequest, type SpotType, type UpdateSpotTypeRequest } from '~/types/api'
+import { AdminType, type CreateSpotTypeRequest, type SpotType, type UpdateSpotTypeRequest } from '~/types/api'
 import { getErrorMessage } from '~/lib/validations'
 import { CreateSpotTypeValidationRules, UpdateSpotTypeValidationRules } from '~/types/validations'
 
@@ -13,9 +13,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  role: {
-    type: Number as PropType<AdminRole>,
-    default: AdminRole.UNKNOWN,
+  adminType: {
+    type: Number as PropType<AdminType>,
+    default: AdminType.UNKNOWN,
   },
   newDialog: {
     type: Boolean,
@@ -122,11 +122,11 @@ const newValidate = useVuelidate<CreateSpotTypeRequest>(CreateSpotTypeValidation
 const editValidate = useVuelidate<UpdateSpotTypeRequest>(UpdateSpotTypeValidationRules, editFormDataValue)
 
 const isRegisterable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const isEditable = (): boolean => {
-  return props.role === AdminRole.ADMINISTRATOR
+  return props.adminType === AdminType.ADMINISTRATOR
 }
 
 const onClickUpdatePage = (page: number): void => {

--- a/web/admin/src/layouts/default.vue
+++ b/web/admin/src/layouts/default.vue
@@ -17,13 +17,13 @@ import {
 import { storeToRefs } from 'pinia'
 import { getResizedImages } from '~/lib/helpers'
 import { useAuthStore, useCommonStore, useMessageStore } from '~/store'
-import { AdminRole } from '~/types/api'
+import { AdminType } from '~/types/api'
 
 interface NavigationDrawerItem {
   to: string
   icon: string
   title: string
-  roles?: AdminRole[]
+  adminTypes?: AdminType[]
 }
 
 const drawer = ref<boolean>(true)
@@ -32,7 +32,7 @@ const authStore = useAuthStore()
 const commonStore = useCommonStore()
 const messageStore = useMessageStore()
 
-const { user, role } = storeToRefs(authStore)
+const { user, adminType } = storeToRefs(authStore)
 
 const snackbars = computed(() => {
   return commonStore.snackbars.filter(item => item.isOpen)
@@ -50,61 +50,61 @@ const generalDrawers: NavigationDrawerItem[] = [
     to: '/producers',
     icon: mdiAccount,
     title: '生産者管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/products',
     icon: mdiCart,
     title: '商品管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/experiences',
     icon: mdiFootPrint,
     title: '体験管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/schedules',
     icon: mdiAntenna,
     title: 'ライブ配信',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/videos',
     icon: mdiVideo,
     title: '動画管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/orders',
     icon: mdiOrderBoolAscendingVariant,
     title: '注文管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/customers',
     icon: mdiAccountDetails,
     title: '顧客管理',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   // {
   //   to: '/contacts',
   //   icon: mdiForum,
   //   title: 'お問い合わせ',
-  //   roles: [AdminRole.ADMINISTRATOR]
+  //   adminTypes: [AdminType.ADMINISTRATOR]
   // },
   {
     to: '/notifications',
     icon: mdiBellRing,
     title: 'お知らせ情報',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/promotions',
     icon: mdiCash100,
     title: 'セール情報',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
 ]
 const settingDrawers: NavigationDrawerItem[] = [
@@ -112,19 +112,19 @@ const settingDrawers: NavigationDrawerItem[] = [
     to: '/accounts',
     icon: mdiAccount,
     title: 'マイページ',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/system',
     icon: mdiCog,
     title: 'システム設定',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     to: '/version',
     icon: mdiCog,
     title: 'バージョン情報',
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
 ]
 
@@ -137,13 +137,13 @@ const getImages = (): string => {
 
 const getGeneralDrawers = (): NavigationDrawerItem[] => {
   return generalDrawers.filter((drawer: NavigationDrawerItem): boolean => {
-    return drawer.roles?.includes(role.value) || false
+    return drawer.adminTypes?.includes(adminType.value) || false
   })
 }
 
 const getSettingDrawers = (): NavigationDrawerItem[] => {
   return settingDrawers.filter((drawer: NavigationDrawerItem): boolean => {
-    return drawer.roles?.includes(role.value) || false
+    return drawer.adminTypes?.includes(adminTypes.value) || false
   })
 }
 

--- a/web/admin/src/layouts/default.vue
+++ b/web/admin/src/layouts/default.vue
@@ -143,7 +143,7 @@ const getGeneralDrawers = (): NavigationDrawerItem[] => {
 
 const getSettingDrawers = (): NavigationDrawerItem[] => {
   return settingDrawers.filter((drawer: NavigationDrawerItem): boolean => {
-    return drawer.adminTypes?.includes(adminTypes.value) || false
+    return drawer.adminTypes?.includes(adminType.value) || false
   })
 }
 

--- a/web/admin/src/pages/accounts/index.vue
+++ b/web/admin/src/pages/accounts/index.vue
@@ -1,28 +1,28 @@
 <script lang="ts" setup>
 import { useAuthStore } from '~/store'
-import { AdminRole } from '~/types/api'
+import { AdminType } from '~/types/api'
 import type { SettingMenu } from '~/types/props'
 
 const router = useRouter()
 const authStore = useAuthStore()
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 
 const menus: SettingMenu[] = [
   {
     text: 'プロフィール変更',
     action: () => router.push('/accounts/coordinator'),
-    roles: [AdminRole.COORDINATOR],
+    adminTypes: [AdminType.COORDINATOR],
   },
   {
     text: 'メールアドレス変更',
     action: () => router.push('/accounts/email'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR, AdminRole.PRODUCER],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR, AdminType.PRODUCER],
   },
   {
     text: 'パスワード変更',
     action: () => router.push('/accounts/password'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR, AdminRole.PRODUCER],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR, AdminType.PRODUCER],
   },
   {
     text: 'サインアウト',
@@ -31,13 +31,13 @@ const menus: SettingMenu[] = [
       authStore.logout()
       router.push('/signin')
     },
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR, AdminRole.PRODUCER],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR, AdminType.PRODUCER],
   },
 ]
 
 const getMenus = (): SettingMenu[] => {
   return menus.filter((drawer: SettingMenu): boolean => {
-    return drawer.roles?.includes(role.value) || false
+    return drawer.adminTypes?.includes(adminType.value) || false
   })
 }
 

--- a/web/admin/src/pages/categories/index.vue
+++ b/web/admin/src/pages/categories/index.vue
@@ -13,7 +13,7 @@ const categoryPagination = usePagination()
 const productTypePagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { categories, total: categoryTotal } = storeToRefs(categoryStore)
 const { productTypes, totalItems: productTypeTotal } = storeToRefs(productTypeStore)
 
@@ -396,7 +396,7 @@ catch (err) {
     v-model:create-product-type-form-data="createProductTypeFormData"
     v-model:update-product-type-form-data="updateProductTypeFormData"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/customers/[id]/index.vue
+++ b/web/admin/src/pages/customers/[id]/index.vue
@@ -14,7 +14,7 @@ const { isShow, alertText, alertType, show } = useAlert('error')
 
 const customerId = route.params.id as string
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { address } = storeToRefs(addressStore)
 const {
   customer,
@@ -95,7 +95,7 @@ catch (err) {
   <templates-customer-show
     v-model:delete-dialog="deleteDialog"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/experience-types/index.vue
+++ b/web/admin/src/pages/experience-types/index.vue
@@ -8,7 +8,7 @@ const experienceTypeStore = useExperienceTypeStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { experienceTypes, total } = storeToRefs(experienceTypeStore)
 
 const loading = ref<boolean>(false)
@@ -149,7 +149,7 @@ catch (err) {
     v-model:delete-dialog="deleteDialog"
     v-model:sort-by="sortBy"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/experiences/index.vue
+++ b/web/admin/src/pages/experiences/index.vue
@@ -17,7 +17,7 @@ const producerStore = useProducerStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { experiencesResponse, totalItems } = storeToRefs(experienceStore)
 const { experienceTypes } = storeToRefs(experienceTypeStore)
 const { producers } = storeToRefs(producerStore)
@@ -124,7 +124,7 @@ catch (err) {
     v-model:delete-dialog="deleteDialog"
     v-model:selected-item-id="selectedItemId"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/notifications/[id]/index.vue
+++ b/web/admin/src/pages/notifications/[id]/index.vue
@@ -16,7 +16,7 @@ const { alertType, isShow, alertText, show } = useAlert('error')
 
 const notificationId = route.params.id as string
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { admin } = storeToRefs(adminStore)
 const { notification } = storeToRefs(notificationStore)
 const { promotion } = storeToRefs(promotionStore)
@@ -83,7 +83,7 @@ catch (err) {
   <templates-notification-edit
     v-model:form-data="formData"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/notifications/index.vue
+++ b/web/admin/src/pages/notifications/index.vue
@@ -12,7 +12,7 @@ const notificationStore = useNotificationStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { admins } = storeToRefs(adminStore)
 const { notifications, totalItems } = storeToRefs(notificationStore)
 
@@ -93,7 +93,7 @@ catch (err) {
   <templates-notification-list
     v-model:delete-dialog="deleteDialog"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/producers/index.vue
+++ b/web/admin/src/pages/producers/index.vue
@@ -12,7 +12,7 @@ const producerStore = useProducerStore()
 const pagination = usePagination()
 const { isShow, alertText, alertType, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { coordinators } = storeToRefs(coordinatorStore)
 const { producers, totalItems } = storeToRefs(producerStore)
 
@@ -90,7 +90,7 @@ catch (err) {
   <templates-producer-list
     v-model:delete-dialog="deleteDialog"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/product-tags/index.vue
+++ b/web/admin/src/pages/product-tags/index.vue
@@ -12,7 +12,7 @@ const productTagStore = useProductTagStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { productTags, total } = storeToRefs(productTagStore)
 
 const loading = ref<boolean>(false)
@@ -153,7 +153,7 @@ catch (err) {
     v-model:delete-dialog="deleteDialog"
     v-model:sort-by="sortBy"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/products/[id]/index.vue
+++ b/web/admin/src/pages/products/[id]/index.vue
@@ -30,7 +30,7 @@ const productTagStore = useProductTagStore()
 const productTypeStore = useProductTypeStore()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { categories } = storeToRefs(categoryStore)
 const { producers } = storeToRefs(producerStore)
 const { productTags } = storeToRefs(productTagStore)
@@ -228,7 +228,7 @@ catch (err) {
     :categories="categories"
     :product-types="productTypes"
     :product-tags="productTags"
-    :role="role"
+    :admin-type="adminType"
     @update:files="handleImageUpload"
     @update:search-category="handleSearchCategory"
     @update:search-product-type="handleSearchProductType"

--- a/web/admin/src/pages/products/index.vue
+++ b/web/admin/src/pages/products/index.vue
@@ -21,7 +21,7 @@ const productTypeStore = useProductTypeStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { categories } = storeToRefs(categoryStore)
 const { producers } = storeToRefs(producerStore)
 const { products, totalItems } = storeToRefs(productStore)
@@ -108,7 +108,7 @@ catch (err) {
     v-model:delete-dialog="deleteDialog"
     v-model:selected-item-id="selectedItemId"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/promotions/[id]/index.vue
+++ b/web/admin/src/pages/promotions/[id]/index.vue
@@ -15,7 +15,7 @@ const { alertType, isShow, alertText, show } = useAlert('error')
 
 const promotionId = route.params.id as string
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { promotion } = storeToRefs(promotionStore)
 
 const loading = ref<boolean>(false)
@@ -84,7 +84,7 @@ catch (err) {
   <templates-promotion-edit
     v-model:form-data="formData"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/promotions/index.vue
+++ b/web/admin/src/pages/promotions/index.vue
@@ -12,7 +12,7 @@ const promotionStore = usePromotionStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { promotions, total } = storeToRefs(promotionStore)
 
 const loading = ref<boolean>(false)
@@ -101,7 +101,7 @@ catch (err) {
     v-model:delete-dialog="deleteDialog"
     v-model:sort-by="sortBy"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/schedules/index.vue
+++ b/web/admin/src/pages/schedules/index.vue
@@ -12,7 +12,7 @@ const scheduleStore = useScheduleStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { coordinators } = storeToRefs(coordinatorStore)
 const { schedules, total } = storeToRefs(scheduleStore)
 
@@ -140,7 +140,7 @@ catch (err) {
   <templates-schedule-list
     v-model:delete-dialog="deleteDialog"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/spot-types/index.vue
+++ b/web/admin/src/pages/spot-types/index.vue
@@ -12,7 +12,7 @@ const spotTypeStore = useSpotTypeStore()
 const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 const { spotTypes, total } = storeToRefs(spotTypeStore)
 
 const loading = ref<boolean>(false)
@@ -137,7 +137,7 @@ catch (err) {
     v-model:edit-dialog="editDialog"
     v-model:delete-dialog="deleteDialog"
     :loading="isLoading()"
-    :role="role"
+    :admin-type="adminType"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"

--- a/web/admin/src/pages/system.vue
+++ b/web/admin/src/pages/system.vue
@@ -1,65 +1,65 @@
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '~/store'
-import { AdminRole } from '~/types/api'
+import { AdminType } from '~/types/api'
 import type { SettingMenu } from '~/types/props'
 
 const router = useRouter()
 const authStore = useAuthStore()
 
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 
 const menus: SettingMenu[] = [
   {
     text: '管理者管理',
     action: () => router.push('/administrators'),
-    roles: [AdminRole.ADMINISTRATOR],
+    adminTypes: [AdminType.ADMINISTRATOR],
   },
   {
     text: 'コーディネーター管理',
     action: () => router.push('/coordinators'),
-    roles: [AdminRole.ADMINISTRATOR],
+    adminTypes: [AdminType.ADMINISTRATOR],
   },
   {
     text: 'カテゴリー・品目管理',
     action: () => router.push('/categories'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     text: '商品タグ管理',
     action: () => router.push('/product-tags'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     text: '体験種別管理',
     action: () => router.push('/experience-types'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     text: '配送設定管理',
     action: () => router.push('/shippings'),
-    roles: [AdminRole.COORDINATOR],
+    adminTypes: [AdminType.COORDINATOR],
   },
   {
     text: 'デフォルト配送設定管理',
     action: () => router.push('/shippings/default'),
-    roles: [AdminRole.ADMINISTRATOR],
+    adminTypes: [AdminType.ADMINISTRATOR],
   },
   {
     text: 'スポット種別管理',
     action: () => router.push('/spot-types'),
-    roles: [AdminRole.ADMINISTRATOR, AdminRole.COORDINATOR],
+    adminTypes: [AdminType.ADMINISTRATOR, AdminType.COORDINATOR],
   },
   {
     text: '決済システム管理',
     action: () => router.push('/payment-systems'),
-    roles: [AdminRole.ADMINISTRATOR],
+    adminTypes: [AdminType.ADMINISTRATOR],
   },
 ]
 
 const getMenus = (): SettingMenu[] => {
   return menus.filter((menu: SettingMenu): boolean => {
-    return menu.roles.includes(role.value)
+    return menu.adminTypes.includes(adminType.value)
   })
 }
 

--- a/web/admin/src/pages/videos/index.vue
+++ b/web/admin/src/pages/videos/index.vue
@@ -4,7 +4,7 @@ import { unix } from 'dayjs'
 import { usePagination } from '~/lib/hooks'
 import { useAuthStore, useVideoStore } from '~/store'
 import { videoStatusToString, videoStatusToColor } from '~/lib/formatter'
-import { AdminRole } from '~/types/api'
+import { AdminType } from '~/types/api'
 
 const videoStore = useVideoStore()
 const { videoResponse } = storeToRefs(videoStore)
@@ -13,7 +13,7 @@ const pagination = usePagination()
 const router = useRouter()
 
 const authStore = useAuthStore()
-const { role } = storeToRefs(authStore)
+const { adminType } = storeToRefs(authStore)
 
 const headers: VDataTable['headers'] = [
   {
@@ -72,7 +72,7 @@ const { status } = useAsyncData(async () => {
     <v-card-title>動画管理</v-card-title>
 
     <v-card-text
-      v-if="role === AdminRole.COORDINATOR"
+      v-if="adminType === AdminType.COORDINATOR"
       class="text-right"
     >
       <v-btn

--- a/web/admin/src/store/auth.ts
+++ b/web/admin/src/store/auth.ts
@@ -6,7 +6,7 @@ import Cookies from 'universal-cookie'
 import { messaging } from '~/plugins/firebase'
 import { apiClient } from '~/plugins/api-client'
 import {
-  AdminRole,
+  AdminType,
   type AuthResponse,
   type AuthUserResponse,
   type Coordinator,
@@ -40,8 +40,8 @@ export const useAuthStore = defineStore('auth', {
     accessToken(state): string | undefined {
       return state.auth?.accessToken
     },
-    role(state): AdminRole {
-      return state.auth?.role || AdminRole.UNKNOWN
+    adminType(state): AdminType {
+      return state.auth?.type || AdminType.UNKNOWN
     },
   },
 

--- a/web/admin/src/types/api/api.ts
+++ b/web/admin/src/types/api/api.ts
@@ -131,10 +131,10 @@ export interface Admin {
     'id': string;
     /**
      * 
-     * @type {AdminRole}
+     * @type {AdminType}
      * @memberof Admin
      */
-    'role': AdminRole;
+    'type': AdminType;
     /**
      * 姓
      * @type {string}
@@ -181,34 +181,6 @@ export interface Admin {
 
 
 /**
- * 管理者権限
- * @export
- * @enum {string}
- */
-
-export const AdminRole = {
-    /**
-    * 不明
-    */
-    UNKNOWN: 0,
-    /**
-    * 管理者
-    */
-    ADMINISTRATOR: 1,
-    /**
-    * コーディネータ
-    */
-    COORDINATOR: 2,
-    /**
-    * 生産者
-    */
-    PRODUCER: 3
-} as const;
-
-export type AdminRole = typeof AdminRole[keyof typeof AdminRole];
-
-
-/**
  * 管理者の状態
  * @export
  * @enum {string}
@@ -234,6 +206,34 @@ export const AdminStatus = {
 } as const;
 
 export type AdminStatus = typeof AdminStatus[keyof typeof AdminStatus];
+
+
+/**
+ * 管理者種別
+ * @export
+ * @enum {string}
+ */
+
+export const AdminType = {
+    /**
+    * 不明
+    */
+    UNKNOWN: 0,
+    /**
+    * 管理者
+    */
+    ADMINISTRATOR: 1,
+    /**
+    * コーディネータ
+    */
+    COORDINATOR: 2,
+    /**
+    * 生産者
+    */
+    PRODUCER: 3
+} as const;
+
+export type AdminType = typeof AdminType[keyof typeof AdminType];
 
 
 /**
@@ -415,10 +415,10 @@ export interface AuthResponse {
     'adminId': string;
     /**
      * 
-     * @type {AdminRole}
+     * @type {AdminType}
      * @memberof AuthResponse
      */
-    'role': AdminRole;
+    'type': AdminType;
     /**
      * アクセストークン
      * @type {string}
@@ -460,10 +460,10 @@ export interface AuthUserResponse {
     'id': string;
     /**
      * 
-     * @type {AdminRole}
+     * @type {AdminType}
      * @memberof AuthUserResponse
      */
-    'role': AdminRole;
+    'type': AdminType;
     /**
      * 表示名
      * @type {string}

--- a/web/admin/src/types/props/setting.ts
+++ b/web/admin/src/types/props/setting.ts
@@ -1,8 +1,8 @@
-import type { AdminRole } from '../api'
+import type { AdminType } from '../api'
 
 export interface SettingMenu {
   text: string
   color?: string
   action: () => void
-  roles: AdminRole[]
+  adminTypes: AdminType[]
 }


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

- **新機能**
	- 管理者の役割を表現するシステムを「役割（Role）」から「タイプ（Type）」に変更しました。

- **改善点**
	- 管理者の権限管理システムを、より明確で柔軟な分類に更新しました。
	- 管理者の権限チェックロジックを統一し、一貫性を向上させました。

- **変更点**
	- 全てのコンポーネントとサービスで、`AdminRole`から`AdminType`への移行を実施しました。
	- 管理者の権限を表す変数名を`role`から`adminType`に変更しました。
	- データベースの`admins`テーブルから`role`カラムを削除しました。

- **影響範囲**
	- フロントエンド：Vue.jsコンポーネント全体
	- バックエンド：APIハンドラー、サービス層
	- データモデル：管理者エンティティの構造

注意：この変更は、システム全体の管理者権限の表現方法を改善するものです。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->