### PR TITLE
Release for v3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v3.4.2](https://github.com/and-period/furumaru/compare/v3.4.1...v3.4.2) - 2025-01-02
+- refactor(user): 管理者種別のフィールド名を置き換え by @taba2424 in https://github.com/and-period/furumaru/pull/2622
+
 ## [v3.4.1](https://github.com/and-period/furumaru/compare/v3.4.0...v3.4.1) - 2025-01-02
 - マップから体験を選択する部分の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2585
 - refactor(api): DB層のコンストラクタ定義を変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2613


### PR DESCRIPTION
This pull request is for the next release as v3.4.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v3.4.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v3.4.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* refactor(user): 管理者種別のフィールド名を置き換え by @taba2424 in https://github.com/and-period/furumaru/pull/2622


**Full Changelog**: https://github.com/and-period/furumaru/compare/v3.4.1...v3.4.2