### PR TITLE
fix(database): 削除件数が0件になる不具合を修正

### DIFF
--- a/api/internal/media/database/tidb/video.go
+++ b/api/internal/media/database/tidb/video.go
@@ -236,9 +236,10 @@ func (v *video) fill(ctx context.Context, tx *gorm.DB, videos ...*entity.Video) 
 
 func (v *video) replaceProducts(ctx context.Context, tx *gorm.DB, videoID string, products entity.VideoProducts) error {
 	// 不要なレコードを削除
-	stmt := tx.WithContext(ctx).
-		Where("video_id = ?", videoID).
-		Where("product_id NOT IN (?)", products.ProductIDs())
+	stmt := tx.WithContext(ctx).Where("video_id = ?", videoID)
+	if len(products.ProductIDs()) > 0 {
+		stmt = stmt.Where("product_id NOT IN (?)", products.ProductIDs())
+	}
 	if err := stmt.Delete(&entity.VideoProduct{}).Error; err != nil {
 		return err
 	}
@@ -267,9 +268,10 @@ func (v *video) replaceProducts(ctx context.Context, tx *gorm.DB, videoID string
 
 func (v *video) replaceExperiences(ctx context.Context, tx *gorm.DB, videoID string, experiences entity.VideoExperiences) error {
 	// 不要なレコードを削除
-	stmt := tx.WithContext(ctx).
-		Where("video_id = ?", videoID).
-		Where("experience_id NOT IN (?)", experiences.ExperienceIDs())
+	stmt := tx.WithContext(ctx).Where("video_id = ?", videoID)
+	if len(experiences.ExperienceIDs()) > 0 {
+		stmt = stmt.Where("experience_id NOT IN (?)", experiences.ExperienceIDs())
+	}
 	if err := stmt.Delete(&entity.VideoExperience{}).Error; err != nil {
 		return err
 	}

--- a/api/internal/store/database/tidb/live.go
+++ b/api/internal/store/database/tidb/live.go
@@ -156,9 +156,10 @@ func (l *live) fill(ctx context.Context, tx *gorm.DB, lives ...*entity.Live) err
 
 func (l *live) replaceProducts(ctx context.Context, tx *gorm.DB, liveID string, products entity.LiveProducts) error {
 	// 不要なレコードを削除
-	stmt := tx.WithContext(ctx).
-		Where("live_id = ?", liveID).
-		Where("product_id NOT IN (?)", products.ProductIDs())
+	stmt := tx.WithContext(ctx).Where("live_id = ?", liveID)
+	if len(products.ProductIDs()) > 0 {
+		stmt = stmt.Where("product_id NOT IN (?)", products.ProductIDs())
+	}
 	if err := stmt.Delete(&entity.LiveProduct{}).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- データベース操作の削除ロジックを最適化し、不要なSQLクエリ条件を防止
	- 製品IDと体験IDの削除条件を、IDリストの存在に基づいて条件付きで適用するよう改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->