### PR TITLE
feat(media): オンデマンド配信のバリデーションを削除

### DIFF
--- a/api/internal/media/entity/video.go
+++ b/api/internal/media/entity/video.go
@@ -63,9 +63,9 @@ type NewVideoParams struct {
 	PublishedAt       time.Time
 }
 
-func NewVideo(params *NewVideoParams) (*Video, error) {
+func NewVideo(params *NewVideoParams) *Video {
 	videoID := uuid.Base58Encode(uuid.New())
-	video := &Video{
+	return &Video{
 		ID:                videoID,
 		CoordinatorID:     params.CoordinatorID,
 		ProductIDs:        params.ProductIDs,
@@ -82,20 +82,6 @@ func NewVideo(params *NewVideoParams) (*Video, error) {
 		VideoProducts:     NewVideoProducts(videoID, params.ProductIDs),
 		VideoExperiences:  NewVideoExperiences(videoID, params.ExperienceIDs),
 	}
-	if err := video.Validate(); err != nil {
-		return nil, err
-	}
-	return video, nil
-}
-
-func (v *Video) Validate() error {
-	if v.DisplayProduct && len(v.ProductIDs) == 0 {
-		return ErrVideoRequiredProductIDs
-	}
-	if v.DisplayExperience && len(v.ExperienceIDs) == 0 {
-		return ErrVideoRequiredExperienceIDs
-	}
-	return nil
 }
 
 func (v *Video) Fill(products VideoProducts, experiences VideoExperiences, now time.Time) {

--- a/api/internal/media/entity/video_test.go
+++ b/api/internal/media/entity/video_test.go
@@ -16,7 +16,6 @@ func TestVideo(t *testing.T) {
 		name   string
 		params *NewVideoParams
 		expect *Video
-		hasErr bool
 	}{
 		{
 			name: "success",
@@ -51,38 +50,13 @@ func TestVideo(t *testing.T) {
 				VideoExperiences:  []*VideoExperience{{ExperienceID: "experience-id", Priority: 1}},
 				PublishedAt:       now.AddDate(0, 0, -1),
 			},
-			hasErr: false,
-		},
-		{
-			name: "validation error",
-			params: &NewVideoParams{
-				CoordinatorID:     "coordinator-id",
-				ProductIDs:        []string{},
-				ExperienceIDs:     []string{"experience-id"},
-				Title:             "じゃがいもの育て方",
-				Description:       "じゃがいもの育て方の動画です。",
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    true,
-				DisplayExperience: true,
-				PublishedAt:       now.AddDate(0, 0, -1),
-			},
-			expect: nil,
-			hasErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual, err := NewVideo(tt.params)
-			if tt.hasErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
+			actual := NewVideo(tt.params)
 			actual.ID = "" // ignore
 			for _, vp := range actual.VideoProducts {
 				vp.VideoID = "" // ignore
@@ -91,89 +65,6 @@ func TestVideo(t *testing.T) {
 				ve.VideoID = "" // ignore
 			}
 			assert.Equal(t, tt.expect, actual)
-		})
-	}
-}
-
-func TestVideo_Validate(t *testing.T) {
-	t.Parallel()
-
-	now := time.Now()
-
-	tests := []struct {
-		name   string
-		video  *Video
-		expect error
-	}{
-		{
-			name: "success",
-			video: &Video{
-				CoordinatorID:     "coordinator-id",
-				ProductIDs:        []string{"product-id"},
-				ExperienceIDs:     []string{"experience-id"},
-				Title:             "じゃがいもの育て方",
-				Description:       "じゃがいもの育て方の動画です。",
-				Status:            VideoStatusUnknown,
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    false,
-				DisplayExperience: true,
-				VideoProducts:     []*VideoProduct{{ProductID: "product-id", Priority: 1}},
-				VideoExperiences:  []*VideoExperience{{ExperienceID: "experience-id", Priority: 1}},
-				PublishedAt:       now.AddDate(0, 0, -1),
-			},
-			expect: nil,
-		},
-		{
-			name: "required product ids",
-			video: &Video{
-				CoordinatorID:     "coordinator-id",
-				ProductIDs:        []string{},
-				ExperienceIDs:     []string{"experience-id"},
-				Title:             "じゃがいもの育て方",
-				Description:       "じゃがいもの育て方の動画です。",
-				Status:            VideoStatusUnknown,
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    true,
-				DisplayExperience: true,
-				VideoProducts:     []*VideoProduct{{ProductID: "product-id", Priority: 1}},
-				VideoExperiences:  []*VideoExperience{{ExperienceID: "experience-id", Priority: 1}},
-				PublishedAt:       now.AddDate(0, 0, -1),
-			},
-			expect: ErrVideoRequiredProductIDs,
-		},
-		{
-			name: "success",
-			video: &Video{
-				CoordinatorID:     "coordinator-id",
-				ProductIDs:        []string{"product-id"},
-				ExperienceIDs:     []string{},
-				Title:             "じゃがいもの育て方",
-				Description:       "じゃがいもの育て方の動画です。",
-				Status:            VideoStatusUnknown,
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    true,
-				DisplayExperience: true,
-				VideoProducts:     []*VideoProduct{{ProductID: "product-id", Priority: 1}},
-				VideoExperiences:  []*VideoExperience{{ExperienceID: "experience-id", Priority: 1}},
-				PublishedAt:       now.AddDate(0, 0, -1),
-			},
-			expect: ErrVideoRequiredExperienceIDs,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.video.Validate()
-			assert.ErrorIs(t, err, tt.expect)
 		})
 	}
 }

--- a/api/internal/media/service/video.go
+++ b/api/internal/media/service/video.go
@@ -137,10 +137,7 @@ func (s *service) CreateVideo(ctx context.Context, in *media.CreateVideoInput) (
 		DisplayExperience: in.DisplayExperience,
 		PublishedAt:       in.PublishedAt,
 	}
-	video, err := entity.NewVideo(params)
-	if err != nil {
-		return nil, fmt.Errorf("service: video validation failed: %w: %s", exception.ErrInvalidArgument, err.Error())
-	}
+	video := entity.NewVideo(params)
 	if err := s.db.Video.Create(ctx, video); err != nil {
 		return nil, internalError(err)
 	}
@@ -192,12 +189,6 @@ func (s *service) UpdateVideo(ctx context.Context, in *media.UpdateVideoInput) e
 		return internalError(err)
 	}
 
-	if in.DisplayProduct && len(in.ProductIDs) == 0 {
-		return fmt.Errorf("service: product is required: %w", exception.ErrInvalidArgument)
-	}
-	if in.DisplayExperience && len(in.ExperienceIDs) == 0 {
-		return fmt.Errorf("service: experience is required: %w", exception.ErrInvalidArgument)
-	}
 	params := &database.UpdateVideoParams{
 		Title:             in.Title,
 		Description:       in.Description,

--- a/api/internal/media/service/video_test.go
+++ b/api/internal/media/service/video_test.go
@@ -634,27 +634,6 @@ func TestCreateVideo(t *testing.T) {
 			expectErr: exception.ErrInternal,
 		},
 		{
-			name: "invalid video validation",
-			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
-			},
-			input: &media.CreateVideoInput{
-				Title:             "オンデマンド配信",
-				Description:       "オンデマンド配信の説明",
-				CoordinatorID:     "coordinator-id",
-				ProductIDs:        []string{},
-				ExperienceIDs:     []string{},
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    true,
-				DisplayExperience: true,
-				PublishedAt:       now,
-			},
-			expectErr: exception.ErrInvalidArgument,
-		},
-		{
 			name: "failed to create video",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
@@ -841,44 +820,6 @@ func TestUpdateVideo(t *testing.T) {
 				PublishedAt:       now,
 			},
 			expectErr: exception.ErrInternal,
-		},
-		{
-			name:  "required product id",
-			setup: func(ctx context.Context, mocks *mocks) {},
-			input: &media.UpdateVideoInput{
-				VideoID:           "video-id",
-				Title:             "オンデマンド配信",
-				Description:       "オンデマンド配信の説明",
-				ProductIDs:        []string{},
-				ExperienceIDs:     []string{},
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    true,
-				DisplayExperience: true,
-				PublishedAt:       now,
-			},
-			expectErr: exception.ErrInvalidArgument,
-		},
-		{
-			name:  "required experience id",
-			setup: func(ctx context.Context, mocks *mocks) {},
-			input: &media.UpdateVideoInput{
-				VideoID:           "video-id",
-				Title:             "オンデマンド配信",
-				Description:       "オンデマンド配信の説明",
-				ProductIDs:        []string{},
-				ExperienceIDs:     []string{},
-				ThumbnailURL:      "https://example.com/thumbnail.jpg",
-				VideoURL:          "https://example.com/video.mp4",
-				Public:            true,
-				Limited:           false,
-				DisplayProduct:    false,
-				DisplayExperience: true,
-				PublishedAt:       now,
-			},
-			expectErr: exception.ErrInvalidArgument,
 		},
 		{
 			name: "failed to update video",


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重大な変更**
	- ビデオ作成プロセスからバリデーション機能を削除
	- エラーチェックロジックを簡素化
	- 製品IDおよびエクスペリエンスIDの必須チェックを廃止

- **影響**
	- データ整合性の事前チェックが無効化
	- ビデオ作成および更新プロセスが柔軟になる一方、潜在的なデータ品質リスクが増加

- **注意点**
	- システムは不完全なデータでのビデオ作成を許可
	- 開発者は手動でのデータ検証により注意を払う必要がある

<!-- end of auto-generated comment: release notes by coderabbit.ai -->