### PR TITLE
Release for v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.0.1](https://github.com/and-period/furumaru/compare/v4.0.0...v4.0.1) - 2025-01-14
+- fix(gateway): Broadcastのパース処理でnil pointerになっている箇所の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2650
+
 ## [v4.0.0](https://github.com/and-period/furumaru/compare/v3.4.2...v4.0.0) - 2025-01-13
 - feat(user): 管理面ロール用のエンティティ定義を更新 by @taba2424 in https://github.com/and-period/furumaru/pull/2624
 - refactor(api): MySQLの詳細実装を削除 by @taba2424 in https://github.com/and-period/furumaru/pull/2626


### PR DESCRIPTION
This pull request is for the next release as v4.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(gateway): Broadcastのパース処理でnil pointerになっている箇所の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2650


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.0.0...v4.0.1