### PR TITLE
Release for v4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.0.3](https://github.com/and-period/furumaru/compare/v4.0.2...v4.0.3) - 2025-01-14
+- fix(gateway): 配信URLを詰める処理の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2654
+
 ## [v4.0.2](https://github.com/and-period/furumaru/compare/v4.0.1...v4.0.2) - 2025-01-14
 - fix(store): 注文履歴一覧をcreated_atの降順で並び替え by @taba2424 in https://github.com/and-period/furumaru/pull/2652
 


### PR DESCRIPTION
This pull request is for the next release as v4.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(gateway): 配信URLを詰める処理の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2654


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.0.2...v4.0.3