### PR TITLE
Release for v4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.0.6](https://github.com/and-period/furumaru/compare/v4.0.5...v4.0.6) - 2025-01-17
+- fix(gateway): 注文詳細が取得できない不具合の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2663
+
 ## [v4.0.5](https://github.com/and-period/furumaru/compare/v4.0.4...v4.0.5) - 2025-01-15
 - refactor(messenger): メソッド名の変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2660
 - build(deps): bump the dependencies group in /api with 39 updates by @dependabot in https://github.com/and-period/furumaru/pull/2658


### PR DESCRIPTION
This pull request is for the next release as v4.0.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.0.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.0.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(gateway): 注文詳細が取得できない不具合の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2663


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.0.5...v4.0.6