### PR TITLE
Release for v4.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v4.0.7](https://github.com/and-period/furumaru/compare/v4.0.6...v4.0.7) - 2025-01-17
+
 ## [v4.0.6](https://github.com/and-period/furumaru/compare/v4.0.5...v4.0.6) - 2025-01-17
 - fix(gateway): 注文詳細が取得できない不具合の修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2663
 


### PR DESCRIPTION
This pull request is for the next release as v4.0.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.0.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.0.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.0.6...v4.0.7