### PR TITLE
fix: 体験情報が取得できていない場合に再取得する処理を追加

### DIFF
--- a/web/user/src/pages/experiences/purchase/guest/index.vue
+++ b/web/user/src/pages/experiences/purchase/guest/index.vue
@@ -84,6 +84,7 @@ const {
   data: targetExperience,
   status: targetExperienceFetchStatus,
   error: targetExperienceFetchError,
+  refresh,
 } = useAsyncData('target-experience', async () => {
   if (experienceId.value) {
     return await fetchCheckoutTarget({
@@ -251,11 +252,15 @@ const handleSubmit = async () => {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   // フォームデータのセットアップ
   formData.value.callbackUrl = `${window.location.origin}/v1/purchase/guest/complete`
   if (availablePaymentSystem.value.length > 0) {
     formData.value.paymentMethod = availablePaymentSystem.value[0].methodType
+  }
+
+  if (!targetExperience.value) {
+    await refresh()
   }
 
   // リクエストID

--- a/web/user/src/pages/experiences/purchase/index.vue
+++ b/web/user/src/pages/experiences/purchase/index.vue
@@ -130,6 +130,7 @@ const {
   data: targetExperience,
   status: targetExperienceFetchStatus,
   error: targetExperienceFetchError,
+  refresh,
 } = useAsyncData('target-experience', async () => {
   if (experienceId.value) {
     return await fetchCheckoutTarget({
@@ -283,11 +284,15 @@ const handleSubmit = async () => {
   isSubmitting.value = false
 }
 
-onMounted(() => {
+onMounted(async () => {
   // フォームデータのセットアップ
   formData.value.callbackUrl = `${window.location.origin}/v1/purchase/complete`
   if (availablePaymentSystem.value.length > 0) {
     formData.value.paymentMethod = availablePaymentSystem.value[0].methodType
+  }
+
+  if (!targetExperience.value) {
+    await refresh()
   }
 
   // リクエストID


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ゲストチェックアウトページの非同期データ取得プロセスを改善
	- エクスペリエンス購入ページのデータ更新メカニズムを強化

- **バグ修正**
	- ターゲットエクスペリエンスデータの読み込みが不完全な場合の処理を最適化
	- フォームデータの初期化プロセスを修正

- **パフォーマンス**
	- データ取得の柔軟性と信頼性を向上
	- コンポーネントのマウント時のデータ更新ロジックを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->