### PR TITLE
fix: 郵便番号のエラーメッセージがリセットされない不具合の修正

### DIFF
--- a/web/user/src/pages/experiences/purchase/guest/index.vue
+++ b/web/user/src/pages/experiences/purchase/guest/index.vue
@@ -199,6 +199,7 @@ const {
  * 住所検索ボタンクリック時の処理
  */
 const handleClickSearchAddressButton = async () => {
+  postalCodeErrorMessage.value = ''
   try {
     const res = await searchAddressByPostalCode(formData.value.billingAddress.postalCode)
     formData.value.billingAddress.prefectureCode = res.prefectureCode

--- a/web/user/src/pages/v1/purchase/address.vue
+++ b/web/user/src/pages/v1/purchase/address.vue
@@ -95,6 +95,7 @@ const priceFormatter = (price: number) => {
 }
 
 const handleClickSearchAddressButton = async () => {
+  postalCodeErrorMessage.value = ''
   try {
     const res = await searchAddressByPostalCode(formData.value.postalCode)
     formData.value.prefectureCode = res.prefectureCode

--- a/web/user/src/pages/v1/purchase/guest/address.vue
+++ b/web/user/src/pages/v1/purchase/guest/address.vue
@@ -112,6 +112,7 @@ const priceFormatter = (price: number) => {
 }
 
 const handleClickSearchAddressButton = async () => {
+  postalCodeErrorMessage.value = ''
   try {
     const res = await searchAddressByPostalCode(formData.value.postalCode)
     formData.value.prefectureCode = res.prefectureCode


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- 郵便番号検索機能のエラーメッセージをリセットする処理を追加
	- 古いエラーメッセージが新しい検索時に残らないよう修正

- **ユーザーエクスペリエンス**
	- 住所検索時のエラーハンドリングを改善
	- より清潔で分かりやすいエラー表示を実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->