### PR TITLE
fix(store): KOMOJUのステータスに応じて処理を変えるように

### DIFF
--- a/api/internal/store/komoju/komoju.go
+++ b/api/internal/store/komoju/komoju.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Payment interface {
+	Show(ctx context.Context, paymentID string) (*PaymentResponse, error)                     // 決済情報の照会
 	Capture(ctx context.Context, paymentID string) (*PaymentResponse, error)                  // 売上確定処理
 	Cancel(ctx context.Context, paymentID string) (*PaymentResponse, error)                   // キャンセル
 	Refund(ctx context.Context, params *RefundParams) (*PaymentResponse, error)               // 返金処理

--- a/api/internal/store/komoju/payment/payment.go
+++ b/api/internal/store/komoju/payment/payment.go
@@ -29,6 +29,21 @@ func NewClient(cli *http.Client, params *Params, opts ...komoju.Option) komoju.P
 	}
 }
 
+func (c *client) Show(ctx context.Context, paymentID string) (*komoju.PaymentResponse, error) {
+	const path = "/api/v1/payments/%s"
+	req := &komoju.APIParams{
+		Host:   c.host,
+		Method: http.MethodGet,
+		Path:   path,
+		Params: []interface{}{paymentID},
+	}
+	res := &komoju.PaymentResponse{}
+	if err := c.client.Do(ctx, req, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 type captureRequest struct {
 	Amount int64 `json:"amount,omitempty"`
 	Tax    int64 `json:"tax,omitempty"`

--- a/api/internal/store/service/checkout_event.go
+++ b/api/internal/store/service/checkout_event.go
@@ -27,6 +27,11 @@ func (s *service) NotifyPaymentAuthorized(ctx context.Context, in *store.NotifyP
 	if err != nil {
 		return internalError(err)
 	}
+	// KOMOJU側の仕様として、即時決済出ないものは支払い待ちステータスでAuthorizedの通知が来るためスキップさせる
+	if order.OrderPayment.IsDeferredPayment() {
+		s.logger.Info("Order is authorized but deferred payment", zap.String("orderId", in.OrderID))
+		return nil
+	}
 	params := &database.UpdateOrderAuthorizedParams{
 		PaymentID: in.PaymentID,
 		IssuedAt:  in.IssuedAt,

--- a/api/internal/store/service/checkout_event_test.go
+++ b/api/internal/store/service/checkout_event_test.go
@@ -108,8 +108,6 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 			name: "success when not immediate payment",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeKonbini), nil)
-				mocks.db.Order.EXPECT().UpdateAuthorized(ctx, "order-id", params).Return(nil)
-				mocks.komojuPayment.EXPECT().Capture(ctx, "payment-id").Return(&komoju.PaymentResponse{}, nil)
 			},
 			input: &store.NotifyPaymentAuthorizedInput{
 				NotifyPaymentPayload: store.NotifyPaymentPayload{

--- a/api/internal/store/service/checkout_event_test.go
+++ b/api/internal/store/service/checkout_event_test.go
@@ -80,6 +80,12 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 		PaymentID: "payment-id",
 		IssuedAt:  now,
 	}
+	payment := &komoju.PaymentResponse{
+		PaymentInfo: &komoju.PaymentInfo{
+			ID:     "payment-id",
+			Status: komoju.PaymentStatusAuthorized,
+		},
+	}
 	tests := []struct {
 		name   string
 		setup  func(ctx context.Context, mocks *mocks)
@@ -91,6 +97,7 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeCreditCard), nil)
 				mocks.db.Order.EXPECT().UpdateAuthorized(ctx, "order-id", params).Return(nil)
+				mocks.komojuPayment.EXPECT().Show(ctx, "payment-id").Return(payment, nil)
 				mocks.komojuPayment.EXPECT().Capture(ctx, "payment-id").Return(&komoju.PaymentResponse{}, nil)
 				mocks.cache.EXPECT().Get(gomock.Any(), &entity.Cart{SessionID: "session-id"}).Return(assert.AnError)
 			},
@@ -108,6 +115,29 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 			name: "success when not immediate payment",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeKonbini), nil)
+			},
+			input: &store.NotifyPaymentAuthorizedInput{
+				NotifyPaymentPayload: store.NotifyPaymentPayload{
+					OrderID:   "order-id",
+					PaymentID: "payment-id",
+					IssuedAt:  now,
+					Status:    entity.PaymentStatusAuthorized,
+				},
+			},
+			expect: nil,
+		},
+		{
+			name: "success when already captured",
+			setup: func(ctx context.Context, mocks *mocks) {
+				payment := &komoju.PaymentResponse{
+					PaymentInfo: &komoju.PaymentInfo{
+						ID:     "payment-id",
+						Status: komoju.PaymentStatusCaptured,
+					},
+				}
+				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeCreditCard), nil)
+				mocks.db.Order.EXPECT().UpdateAuthorized(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
+				mocks.komojuPayment.EXPECT().Show(ctx, "payment-id").Return(payment, nil)
 			},
 			input: &store.NotifyPaymentAuthorizedInput{
 				NotifyPaymentPayload: store.NotifyPaymentPayload{
@@ -170,11 +200,11 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 			expect: exception.ErrInternal,
 		},
 		{
-			name: "failed to capture for retryable error",
+			name: "failed to show payment",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeCreditCard), nil)
 				mocks.db.Order.EXPECT().UpdateAuthorized(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
-				mocks.komojuPayment.EXPECT().Capture(ctx, "payment-id").Return(nil, &komoju.Error{Code: komoju.ErrCodeBadGateway})
+				mocks.komojuPayment.EXPECT().Show(ctx, "payment-id").Return(nil, assert.AnError)
 			},
 			input: &store.NotifyPaymentAuthorizedInput{
 				NotifyPaymentPayload: store.NotifyPaymentPayload{
@@ -187,10 +217,11 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 			expect: exception.ErrInternal,
 		},
 		{
-			name: "failed to capture for non-retryable error",
+			name: "failed to capture",
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order(entity.PaymentMethodTypeCreditCard), nil)
 				mocks.db.Order.EXPECT().UpdateAuthorized(ctx, "order-id", params).Return(database.ErrFailedPrecondition)
+				mocks.komojuPayment.EXPECT().Show(ctx, "payment-id").Return(payment, nil)
 				mocks.komojuPayment.EXPECT().Capture(ctx, "payment-id").Return(nil, assert.AnError)
 			},
 			input: &store.NotifyPaymentAuthorizedInput{
@@ -201,7 +232,7 @@ func TestNotifyPaymentAuthorized(t *testing.T) {
 					Status:    entity.PaymentStatusAuthorized,
 				},
 			},
-			expect: nil,
+			expect: exception.ErrInternal,
 		},
 	}
 	for _, tt := range tests {
@@ -290,7 +321,7 @@ func TestNotifyPaymentCaptured(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
 				mocks.db.Order.EXPECT().UpdateCaptured(ctx, "order-id", params).Return(nil)
-				mocks.messenger.EXPECT().NotifyOrderCaptured(ctx, in).Return(nil)
+				mocks.messenger.EXPECT().NotifyOrderCaptured(gomock.Any(), in).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentCapturedInput{
 				NotifyPaymentPayload: store.NotifyPaymentPayload{
@@ -357,23 +388,6 @@ func TestNotifyPaymentCaptured(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
 				mocks.db.Order.EXPECT().UpdateCaptured(ctx, "order-id", params).Return(assert.AnError)
-			},
-			input: &store.NotifyPaymentCapturedInput{
-				NotifyPaymentPayload: store.NotifyPaymentPayload{
-					OrderID:   "order-id",
-					PaymentID: "payment-id",
-					Status:    entity.PaymentStatusCaptured,
-					IssuedAt:  now,
-				},
-			},
-			expect: exception.ErrInternal,
-		},
-		{
-			name: "failed to notify order captured",
-			setup: func(ctx context.Context, mocks *mocks) {
-				mocks.db.Order.EXPECT().Get(ctx, "order-id").Return(order, nil)
-				mocks.db.Order.EXPECT().UpdateCaptured(ctx, "order-id", params).Return(nil)
-				mocks.messenger.EXPECT().NotifyOrderCaptured(ctx, in).Return(assert.AnError)
 			},
 			input: &store.NotifyPaymentCapturedInput{
 				NotifyPaymentPayload: store.NotifyPaymentPayload{


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Komoju決済APIで特定の支払い情報を取得する新しい`Show`メソッドを追加しました。

- **バグ修正**
	- 支払い処理のエラーハンドリングと状態チェックを改善しました。

- **改善**
	- 支払い通知とインベントリ更新のプロセスを非同期化しました。
	- 支払いステータスの確認ロジックを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->