### PR TITLE
Release for v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v4.1.1](https://github.com/and-period/furumaru/compare/v4.1.0...v4.1.1) - 2025-02-06
+- fix(user): 山田が頑張った by @taba2424 in https://github.com/and-period/furumaru/pull/2697
+- feat: Google Mapの描画を安定化 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2700
+- wip: Google認証 by @taba2424 in https://github.com/and-period/furumaru/pull/2695
+- レビュー表示機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2701
+- feat(admin): Google連携機能の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2702
+- build(deps): bump the dependencies group in /api with 46 updates by @dependabot in https://github.com/and-period/furumaru/pull/2699
+- build(deps): bump the dependencies group in /web/admin with 92 updates by @dependabot in https://github.com/and-period/furumaru/pull/2698
+- Feat/user/implement connect sns account by @taba2424 in https://github.com/and-period/furumaru/pull/2706
+- Fix: fixed button color to proceed purchase by @hamachans in https://github.com/and-period/furumaru/pull/2703
+- feat(admin): 認証プロバイダー一覧画面の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2707
+- build(deps): bump the dependencies group in /api with 39 updates by @dependabot in https://github.com/and-period/furumaru/pull/2704
+- build(deps): bump the dependencies group in /web/admin with 56 updates by @dependabot in https://github.com/and-period/furumaru/pull/2705
+- feat(user): LINEアカウント認証の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2708
+
 ## [v4.1.0](https://github.com/and-period/furumaru/compare/v4.0.7...v4.1.0) - 2025-01-26
 - feat(store): 商品購入のフローを刷新 by @taba2424 in https://github.com/and-period/furumaru/pull/2662
 - fix(gateway): 商品レビューがないときのハンドリング追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2667


### PR DESCRIPTION
This pull request is for the next release as v4.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(user): 山田が頑張った by @taba2424 in https://github.com/and-period/furumaru/pull/2697
* feat: Google Mapの描画を安定化 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2700
* wip: Google認証 by @taba2424 in https://github.com/and-period/furumaru/pull/2695
* レビュー表示機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2701
* feat(admin): Google連携機能の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2702
* build(deps): bump the dependencies group in /api with 46 updates by @dependabot in https://github.com/and-period/furumaru/pull/2699
* build(deps): bump the dependencies group in /web/admin with 92 updates by @dependabot in https://github.com/and-period/furumaru/pull/2698
* Feat/user/implement connect sns account by @taba2424 in https://github.com/and-period/furumaru/pull/2706
* Fix: fixed button color to proceed purchase by @hamachans in https://github.com/and-period/furumaru/pull/2703
* feat(admin): 認証プロバイダー一覧画面の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2707
* build(deps): bump the dependencies group in /api with 39 updates by @dependabot in https://github.com/and-period/furumaru/pull/2704
* build(deps): bump the dependencies group in /web/admin with 56 updates by @dependabot in https://github.com/and-period/furumaru/pull/2705
* feat(user): LINEアカウント認証の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2708


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.1.0...v4.1.1