### PR TITLE
Fix: fixed button color to proceed purchase

### DIFF
--- a/web/user/src/components/molecules/TheLiveTimelineProduct.vue
+++ b/web/user/src/components/molecules/TheLiveTimelineProduct.vue
@@ -151,7 +151,7 @@ const handleClickItem = () => {
             </select>
           </div>
           <button
-            class="flex h-full bg-main px-4 py-1 text-white disabled:cursor-not-allowed disabled:bg-main/60"
+            class="flex h-full bg-orange px-4 py-1 text-white disabled:cursor-not-allowed disabled:bg-main/60"
             :disabled="!canAddCart"
             @click.stop="handleClickAddCart"
           >

--- a/web/user/src/components/molecules/TheProductListItem.vue
+++ b/web/user/src/components/molecules/TheProductListItem.vue
@@ -164,7 +164,7 @@ const handleClickAddCartButton = () => {
       </div>
       <button
         :disabled="!canAddCart"
-        class="flex h-full grow items-center justify-center bg-main p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
+        class="flex h-full grow items-center justify-center bg-orange p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
         @click="handleClickAddCartButton"
       >
         <the-cart-icon

--- a/web/user/src/components/molecules/TheVideoExperienceItem.vue
+++ b/web/user/src/components/molecules/TheVideoExperienceItem.vue
@@ -107,7 +107,7 @@ const handleClickProceedButton = () => {
     <div class="flex h-6 items-center gap-2 text-[10px]">
       <button
         :disabled="!canAddCart"
-        class="flex h-full grow items-center justify-center bg-main p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
+        class="flex h-full grow items-center justify-center bg-orange p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
         @click="handleClickProceedButton"
       >
         {{ lt("proceedPurchase") }}

--- a/web/user/src/components/molecules/TheVideoProductListItem.vue
+++ b/web/user/src/components/molecules/TheVideoProductListItem.vue
@@ -150,7 +150,7 @@ const handleClickAddCartButton = () => {
       </div>
       <button
         :disabled="!canAddCart"
-        class="flex h-full grow items-center justify-center bg-main p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
+        class="flex h-full grow items-center justify-center bg-orange p-1 text-[10px] text-white disabled:cursor-not-allowed disabled:bg-main/60 lg:px-4 xl:text-[14px]"
         @click="handleClickAddCartButton"
       >
         <the-cart-icon

--- a/web/user/src/components/organisms/header/TheCartItem.vue
+++ b/web/user/src/components/organisms/header/TheCartItem.vue
@@ -117,7 +117,7 @@ const handleClickRemoveButton = (id: string) => {
       </div>
 
       <button
-        class="w-full bg-main py-1 text-white"
+        class="w-full bg-orange py-1 text-white"
         @click="handleClick"
       >
         {{ ht("viewMyCartText") }}

--- a/web/user/src/components/organisms/header/ThePcCartMenu.vue
+++ b/web/user/src/components/organisms/header/ThePcCartMenu.vue
@@ -91,7 +91,7 @@ defineExpose<Expose>({
           </p>
         </div>
         <button
-          class="w-full bg-main py-1 text-white"
+          class="w-full bg-orange py-1 text-white"
           @click="handleClickBuyButton"
         >
           {{ viewMycartText }}

--- a/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
+++ b/web/user/src/components/organisms/purchase/TheMarcheCartItem.vue
@@ -81,7 +81,7 @@ const handelClickRemoveItemButton = (id: string) => {
       <div>{{ ct("shippingFeeNotice") }}</div>
 
       <button
-        class="mt-8 bg-main p-[14px] text-[16px] text-white"
+        class="mt-8 bg-orange p-[14px] text-[16px] text-white"
         @click="handleBuyButton"
       >
         {{ ct("checkoutButtonText") }}
@@ -281,7 +281,7 @@ const handelClickRemoveItemButton = (id: string) => {
             </div>
 
             <button
-              class="bg-main p-[14px] text-[16px] text-white"
+              class="bg-orange p-[14px] text-[16px] text-white"
               @click="handleCartBuyButton"
             >
               {{ ct("checkoutButtonText") }}

--- a/web/user/src/pages/experiences/[...id].vue
+++ b/web/user/src/pages/experiences/[...id].vue
@@ -499,7 +499,7 @@ useSeoMeta({
             </div>
 
             <button
-              class="mt-2 w-full bg-main py-4 text-center text-white disabled:cursor-not-allowed disabled:bg-main/60 md:mt-8"
+              class="mt-2 w-full bg-orange py-4 text-center text-white disabled:cursor-not-allowed disabled:bg-main/60 md:mt-8"
               :disabled="!canAddCart"
               @click="handleClickApplyButton"
             >

--- a/web/user/src/pages/experiences/purchase/guest/index.vue
+++ b/web/user/src/pages/experiences/purchase/guest/index.vue
@@ -405,7 +405,7 @@ useSeoMeta(
 
         <div class="text-center">
           <button
-            class="bg-main text-white py-2 w-60 disabled:cursor-wait"
+            class="bg-orange text-white py-2 w-60 disabled:cursor-wait"
             type="submit"
             form="checkout-form"
             :disabled="isSubmitting"

--- a/web/user/src/pages/experiences/purchase/index.vue
+++ b/web/user/src/pages/experiences/purchase/index.vue
@@ -492,7 +492,7 @@ useSeoMeta(
 
         <div class="text-center">
           <button
-            class="bg-main text-white py-2 w-60 disabled:cursor-wait"
+            class="bg-orange text-white py-2 w-60 disabled:cursor-wait"
             type="submit"
             form="checkout-form"
             :disabled="isSubmitting"

--- a/web/user/src/pages/v1/purchase/address.vue
+++ b/web/user/src/pages/v1/purchase/address.vue
@@ -458,7 +458,7 @@ useSeoMeta({
                     >
                   </div>
                   <button
-                    class="whitespace-nowrap bg-main p-2 text-[14px] text-white md:text-[16px]"
+                    class="whitespace-nowrap bg-orange p-2 text-[14px] text-white md:text-[16px]"
                     @click="handleClickUsePromotionCodeButton"
                   >
                     {{ at("applyButtonText") }}
@@ -521,7 +521,7 @@ useSeoMeta({
           <template v-if="defaultAddress && targetAddress === 'default'">
             <!-- 通常のボタンの場合 -->
             <button
-              class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
+              class="w-full bg-orange p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
               @click="handleClickNextStepButton(defaultAddress.id)"
             >
               {{ at("paymentMethodButtonText") }}
@@ -530,7 +530,7 @@ useSeoMeta({
           <template v-else>
             <!-- フォーム要素の場合 -->
             <button
-              class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
+              class="w-full bg-orange p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
               type="submit"
               form="new-address-form"
             >

--- a/web/user/src/pages/v1/purchase/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/confirmation.vue
@@ -556,7 +556,7 @@ useSeoMeta({
             {{ ct("backToPreviousPageButtonText") }}
           </button>
           <button
-            class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
+            class="w-full bg-orange p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
             :type="checkoutFormData.paymentMethod === 2 ? 'submit' : 'button'"
             :form="
               checkoutFormData.paymentMethod === 2 ? 'credit-card-form' : ''

--- a/web/user/src/pages/v1/purchase/guest/address.vue
+++ b/web/user/src/pages/v1/purchase/guest/address.vue
@@ -571,7 +571,7 @@ useSeoMeta({
 
         <div>
           <button
-            class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
+            class="w-full bg-orange p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
             @click="handleClickNextStepButton()"
           >
             {{ gt("paymentMethodButtonText") }}

--- a/web/user/src/pages/v1/purchase/guest/confirmation.vue
+++ b/web/user/src/pages/v1/purchase/guest/confirmation.vue
@@ -590,7 +590,7 @@ useSeoMeta({
             {{ ct("backToPreviousPageButtonText") }}
           </button>
           <button
-            class="w-full bg-main p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
+            class="w-full bg-orange p-[14px] text-[16px] text-white md:order-1 md:w-[240px]"
             :type="checkoutFormData.paymentMethod === 2 ? 'submit' : 'button'"
             :form="
               checkoutFormData.paymentMethod === 2 ? 'credit-card-form' : ''


### PR DESCRIPTION
## やったこと
購入の動線のボタンをbg-main -> bg-orangeに変更した

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット
<img width="1442" alt="スクリーンショット 2025-02-02 20 43 07" src="https://github.com/user-attachments/assets/81561ea9-7d94-4920-8d86-02fdd5ba025a" />

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 複数のユーザーインターフェースにおいて、ボタンのデザインが従来の配色から新たなオレンジ色に刷新されました。これにより、各画面での視認性や統一感が向上し、より魅力的な操作体験が実現されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->