### PR TITLE
Release for v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.2.1](https://github.com/and-period/furumaru/compare/v4.2.0...v4.2.1) - 2025-02-11
+- feat(store): 店舗エンティティの定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2709
+- feat(store): 店舗のWrite処理を実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2711
+- fix(store): 店舗情報の追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2712
+
 ## [v4.1.1](https://github.com/and-period/furumaru/compare/v4.1.0...v4.1.1) - 2025-02-06
 - fix(user): 山田が頑張った by @taba2424 in https://github.com/and-period/furumaru/pull/2697
 - feat: Google Mapの描画を安定化 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2700


### PR DESCRIPTION
This pull request is for the next release as v4.2.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.2.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(store): 店舗エンティティの定義 by @taba2424 in https://github.com/and-period/furumaru/pull/2709
* feat(store): 店舗のWrite処理を実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2711
* fix(store): 店舗情報の追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2712


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.2.0...v4.2.1