### PR TITLE
fix(store): 店舗IDを詰めるように

### DIFF
--- a/api/internal/gateway/admin/v1/handler/schedule.go
+++ b/api/internal/gateway/admin/v1/handler/schedule.go
@@ -36,7 +36,7 @@ func (h *handler) filterAccessSchedule(ctx *gin.Context) {
 			if err != nil {
 				return false, err
 			}
-			return schedule.CoordinatorID == getAdminID(ctx), nil
+			return currentAdmin(ctx, schedule.CoordinatorID), nil
 		},
 	}
 	if err := filterAccess(ctx, params); err != nil {
@@ -141,8 +141,14 @@ func (h *handler) CreateSchedule(ctx *gin.Context) {
 		h.httpError(ctx, err)
 		return
 	}
+	shop, err := h.getShopByCoordinatorID(ctx, req.CoordinatorID)
+	if err != nil {
+		h.httpError(ctx, err)
+		return
+	}
 
 	in := &store.CreateScheduleInput{
+		ShopID:          shop.ID,
 		CoordinatorID:   req.CoordinatorID,
 		Title:           req.Title,
 		Description:     req.Description,

--- a/api/internal/gateway/admin/v1/handler/shipping.go
+++ b/api/internal/gateway/admin/v1/handler/shipping.go
@@ -116,7 +116,13 @@ func (h *handler) UpsertShipping(ctx *gin.Context) {
 		h.forbidden(ctx, errors.New("handler: not authorized this coordinator"))
 		return
 	}
+	shop, err := h.getShopByCoordinatorID(ctx, coordinatorID)
+	if err != nil {
+		h.httpError(ctx, err)
+		return
+	}
 	in := &store.UpsertShippingInput{
+		ShopID:            shop.ID,
 		CoordinatorID:     coordinatorID,
 		Box60Rates:        h.newShippingRatesForUpsert(req.Box60Rates),
 		Box60Frozen:       req.Box60Frozen,

--- a/api/internal/store/entity/experience.go
+++ b/api/internal/store/entity/experience.go
@@ -73,6 +73,7 @@ type ExperienceMedia struct {
 type MultiExperienceMedia []*ExperienceMedia
 
 type NewExperienceParams struct {
+	ShopID                string
 	CoordinatorID         string
 	ProducerID            string
 	TypeID                string
@@ -120,6 +121,7 @@ func NewExperience(params *NewExperienceParams) (*Experience, error) {
 	revision := NewExperienceRevision(rparams)
 	experience := &Experience{
 		ID:                 experienceID,
+		ShopID:             params.ShopID,
 		CoordinatorID:      params.CoordinatorID,
 		ProducerID:         params.ProducerID,
 		TypeID:             params.TypeID,

--- a/api/internal/store/entity/experience_test.go
+++ b/api/internal/store/entity/experience_test.go
@@ -22,6 +22,7 @@ func TestExperience(t *testing.T) {
 		{
 			name: "success",
 			params: &NewExperienceParams{
+				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				ProducerID:    "producer-id",
 				TypeID:        "experience-type-id",
@@ -59,6 +60,7 @@ func TestExperience(t *testing.T) {
 				PriceSenior:           200,
 			},
 			expect: &Experience{
+				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				ProducerID:    "producer-id",
 				TypeID:        "experience-type-id",

--- a/api/internal/store/entity/order.go
+++ b/api/internal/store/entity/order.go
@@ -68,6 +68,7 @@ type Orders []*Order
 type NewProductOrderParams struct {
 	OrderID           string
 	SessionID         string
+	ShopID            string
 	CoordinatorID     string
 	Customer          *entity.User
 	BillingAddress    *entity.Address
@@ -82,6 +83,7 @@ type NewProductOrderParams struct {
 type NewExperienceOrderParams struct {
 	OrderID               string
 	SessionID             string
+	ShopID                string
 	CoordinatorID         string
 	Customer              *entity.User
 	BillingAddress        *entity.Address
@@ -133,6 +135,7 @@ func NewProductOrder(params *NewProductOrderParams) (*Order, error) {
 		ID:                params.OrderID,
 		SessionID:         params.SessionID,
 		UserID:            params.Customer.ID,
+		ShopID:            params.ShopID,
 		CoordinatorID:     params.CoordinatorID,
 		PromotionID:       promotionID,
 		Type:              OrderTypeProduct,
@@ -184,6 +187,7 @@ func NewExperienceOrder(params *NewExperienceOrderParams) (*Order, error) {
 		ID:              params.OrderID,
 		SessionID:       params.SessionID,
 		UserID:          params.Customer.ID,
+		ShopID:          params.ShopID,
 		CoordinatorID:   params.CoordinatorID,
 		PromotionID:     promotionID,
 		Type:            OrderTypeExperience,

--- a/api/internal/store/entity/order_test.go
+++ b/api/internal/store/entity/order_test.go
@@ -42,6 +42,7 @@ func TestOrderProduct(t *testing.T) {
 			params: &NewProductOrderParams{
 				OrderID:       "order-id",
 				SessionID:     "session-id",
+				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				Customer: &entity.User{
 					Member: entity.Member{
@@ -197,6 +198,7 @@ func TestOrderProduct(t *testing.T) {
 				ID:              "order-id",
 				SessionID:       "session-id",
 				UserID:          "user-id",
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				PromotionID:     "",
 				Type:            OrderTypeProduct,
@@ -242,6 +244,7 @@ func TestNewExperienceOrder(t *testing.T) {
 			params: &NewExperienceOrderParams{
 				OrderID:       "order-id",
 				SessionID:     "session-id",
+				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				Customer: &entity.User{
 					Member: entity.Member{
@@ -346,6 +349,7 @@ func TestNewExperienceOrder(t *testing.T) {
 				ID:              "order-id",
 				SessionID:       "session-id",
 				UserID:          "user-id",
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				PromotionID:     "promotion-id",
 				Type:            OrderTypeExperience,

--- a/api/internal/store/entity/product.go
+++ b/api/internal/store/entity/product.go
@@ -104,6 +104,7 @@ type ProductMedia struct {
 type MultiProductMedia []*ProductMedia
 
 type NewProductParams struct {
+	ShopID               string
 	CoordinatorID        string
 	ProducerID           string
 	TypeID               string
@@ -147,6 +148,7 @@ func NewProduct(params *NewProductParams) (*Product, error) {
 	revision := NewProductRevision(rparams)
 	return &Product{
 		ID:                   productID,
+		ShopID:               params.ShopID,
 		CoordinatorID:        params.CoordinatorID,
 		ProducerID:           params.ProducerID,
 		TypeID:               params.TypeID,

--- a/api/internal/store/entity/product_test.go
+++ b/api/internal/store/entity/product_test.go
@@ -20,6 +20,7 @@ func TestProduct(t *testing.T) {
 		{
 			name: "success",
 			params: &NewProductParams{
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				ProducerID:      "producer-id",
 				TypeID:          "type-id",
@@ -53,6 +54,7 @@ func TestProduct(t *testing.T) {
 			},
 			expect: &Product{
 				ID:              "", // ignore
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				ProducerID:      "producer-id",
 				TypeID:          "type-id",

--- a/api/internal/store/entity/schedule.go
+++ b/api/internal/store/entity/schedule.go
@@ -44,6 +44,7 @@ type Schedule struct {
 type Schedules []*Schedule
 
 type NewScheduleParams struct {
+	ShopID          string
 	CoordinatorID   string
 	Title           string
 	Description     string
@@ -58,6 +59,7 @@ type NewScheduleParams struct {
 func NewSchedule(params *NewScheduleParams) *Schedule {
 	return &Schedule{
 		ID:              uuid.Base58Encode(uuid.New()),
+		ShopID:          params.ShopID,
 		CoordinatorID:   params.CoordinatorID,
 		Title:           params.Title,
 		Description:     params.Description,

--- a/api/internal/store/entity/schedule_test.go
+++ b/api/internal/store/entity/schedule_test.go
@@ -18,6 +18,7 @@ func TestSchedule(t *testing.T) {
 		{
 			name: "success",
 			params: &NewScheduleParams{
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				Title:           "スケジュールタイトル",
 				Description:     "スケジュールの詳細です。",
@@ -30,6 +31,7 @@ func TestSchedule(t *testing.T) {
 			},
 			expect: &Schedule{
 				ID:              "",
+				ShopID:          "shop-id",
 				CoordinatorID:   "coordinator-id",
 				Title:           "スケジュールタイトル",
 				Description:     "スケジュールの詳細です。",

--- a/api/internal/store/entity/shipping.go
+++ b/api/internal/store/entity/shipping.go
@@ -38,6 +38,7 @@ type Shipping struct {
 type Shippings []*Shipping
 
 type NewShippingParams struct {
+	ShopID            string
 	CoordinatorID     string
 	Box60Rates        ShippingRates
 	Box60Frozen       int64
@@ -75,6 +76,7 @@ func NewShipping(params *NewShippingParams) *Shipping {
 	revision := NewShippingRevision(rparams)
 	return &Shipping{
 		ID:               params.CoordinatorID, // PKはコーディネータと同一にする
+		ShopID:           params.ShopID,
 		CoordinatorID:    params.CoordinatorID,
 		ShippingRevision: *revision,
 	}

--- a/api/internal/store/entity/shipping_test.go
+++ b/api/internal/store/entity/shipping_test.go
@@ -69,6 +69,7 @@ func TestShipping(t *testing.T) {
 		{
 			name: "success",
 			params: &NewShippingParams{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -81,6 +82,7 @@ func TestShipping(t *testing.T) {
 			},
 			expect: &Shipping{
 				ID:            "coordinator-id",
+				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				ShippingRevision: ShippingRevision{
 					ShippingID:        "coordinator-id",

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -233,6 +233,7 @@ type GetExperienceInput struct {
 }
 
 type CreateExperienceInput struct {
+	ShopID                string                   `validate:"required"`
 	CoordinatorID         string                   `validate:"required"`
 	ProducerID            string                   `validate:"required"`
 	TypeID                string                   `validate:"required"`
@@ -592,6 +593,7 @@ type GetProductInput struct {
 }
 
 type CreateProductInput struct {
+	ShopID               string                   `validate:"required"`
 	CoordinatorID        string                   `validate:"required"`
 	ProducerID           string                   `validate:"required"`
 	TypeID               string                   `validate:"required"`
@@ -905,6 +907,7 @@ type GetScheduleInput struct {
 }
 
 type CreateScheduleInput struct {
+	ShopID          string    `validate:"required"`
 	CoordinatorID   string    `validate:"required"`
 	Title           string    `validate:"required,max=64"`
 	Description     string    `validate:"required,max=2000"`
@@ -960,6 +963,7 @@ type GetShippingByCoordinatorIDInput struct {
 }
 
 type UpsertShippingInput struct {
+	ShopID            string                `validate:"required"`
 	CoordinatorID     string                `validate:"required"`
 	Box60Rates        []*UpsertShippingRate `validate:"required,dive,required"`
 	Box60Frozen       int64                 `validate:"min=0,lt=10000000000"`

--- a/api/internal/store/service/checkout.go
+++ b/api/internal/store/service/checkout.go
@@ -397,6 +397,7 @@ func (s *service) checkoutProduct(ctx context.Context, params *checkoutParams) (
 	oparams := &entity.NewProductOrderParams{
 		OrderID:           params.payload.RequestID,
 		SessionID:         params.payload.SessionID,
+		ShopID:            products[0].ShopID, // すべて同じ店舗IDであることを前提とする
 		CoordinatorID:     params.payload.CoordinatorID,
 		Customer:          params.customer,
 		BillingAddress:    params.billingAddress,
@@ -504,6 +505,7 @@ func (s *service) checkoutExperience(ctx context.Context, params *checkoutParams
 	oparams := &entity.NewExperienceOrderParams{
 		OrderID:               params.payload.RequestID,
 		SessionID:             params.payload.SessionID,
+		ShopID:                experience.ShopID,
 		CoordinatorID:         experience.CoordinatorID,
 		Customer:              params.customer,
 		BillingAddress:        params.billingAddress,

--- a/api/internal/store/service/checkout_test.go
+++ b/api/internal/store/service/checkout_test.go
@@ -1329,6 +1329,7 @@ func TestCheckoutProduct(t *testing.T) {
 			FreeShippingRates: 3000,
 		},
 		ID:            "coordinator-id",
+		ShopID:        "shop-id",
 		CoordinatorID: "coordinator-id",
 		CreatedAt:     now,
 		UpdatedAt:     now,
@@ -1350,6 +1351,7 @@ func TestCheckoutProduct(t *testing.T) {
 		return entity.Products{
 			{
 				ID:        "product-id",
+				ShopID:    "shop-id",
 				Name:      "じゃがいも",
 				Inventory: inventory,
 				Public:    true,
@@ -1453,6 +1455,7 @@ func TestCheckoutProduct(t *testing.T) {
 			ID:              "order-id",
 			SessionID:       "session-id",
 			UserID:          "user-id",
+			ShopID:          "shop-id",
 			CoordinatorID:   "coordinator-id",
 			PromotionID:     "promotion-id",
 			Type:            entity.OrderTypeProduct,
@@ -2240,6 +2243,7 @@ func TestCheckoutExperience(t *testing.T) {
 	}
 	experience := &entity.Experience{
 		ID:            "experience-id",
+		ShopID:        "shop-id",
 		CoordinatorID: "coordinator-id",
 		ProducerID:    "producer-id",
 		TypeID:        "experience-type-id",
@@ -2340,6 +2344,7 @@ func TestCheckoutExperience(t *testing.T) {
 			ID:            "order-id",
 			SessionID:     "session-id",
 			UserID:        "user-id",
+			ShopID:        "shop-id",
 			CoordinatorID: "coordinator-id",
 			PromotionID:   "promotion-id",
 			Type:          entity.OrderTypeExperience,

--- a/api/internal/store/service/shipping.go
+++ b/api/internal/store/service/shipping.go
@@ -102,6 +102,7 @@ func (s *service) UpsertShipping(ctx context.Context, in *store.UpsertShippingIn
 	if errors.Is(err, database.ErrNotFound) {
 		// create
 		params := &entity.NewShippingParams{
+			ShopID:            in.ShopID,
 			CoordinatorID:     in.CoordinatorID,
 			Box60Rates:        box60Rates,
 			Box60Frozen:       in.Box60Frozen,

--- a/api/internal/store/service/shipping_test.go
+++ b/api/internal/store/service/shipping_test.go
@@ -511,6 +511,7 @@ func TestUpsertShipping(t *testing.T) {
 		}
 		return &entity.Shipping{
 			ID:            "coordinator-id",
+			ShopID:        "shop-id",
 			CoordinatorID: "coordinator-id",
 			ShippingRevision: entity.ShippingRevision{
 				ShippingID:        "coordinator-id",
@@ -539,6 +540,7 @@ func TestUpsertShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Create(ctx, shipping(0)).Return(nil)
 			},
 			input: &store.UpsertShippingInput{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -558,6 +560,7 @@ func TestUpsertShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Update(ctx, "coordinator-id", params).Return(nil)
 			},
 			input: &store.UpsertShippingInput{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -582,6 +585,7 @@ func TestUpsertShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().GetByCoordinatorID(ctx, "coordinator-id").Return(nil, assert.AnError)
 			},
 			input: &store.UpsertShippingInput{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -601,6 +605,7 @@ func TestUpsertShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Create(ctx, shipping(0)).Return(assert.AnError)
 			},
 			input: &store.UpsertShippingInput{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -620,6 +625,7 @@ func TestUpsertShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Update(ctx, "coordinator-id", params).Return(assert.AnError)
 			},
 			input: &store.UpsertShippingInput{
+				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 体験、商品、スケジュール、配送、注文などの各操作で、特定の店舗情報（ショップID）の紐付けを必須化しました。これにより、各機能が対象の店舗に正確に連携され、運用の一貫性が向上しています。

- **リファクタ**
  - 管理者のアクセス確認ロジックを簡素化し、認証チェックとエラーハンドリングの信頼性を高めました。

- **テスト**
  - ショップ情報の統合に伴い、各種検証テストを更新し、新要件への対応を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->