### PR TITLE
Release for v4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.2.3](https://github.com/and-period/furumaru/compare/v4.2.2...v4.2.3) - 2025-02-11
+- fix(store): 店舗IDを詰めるように by @taba2424 in https://github.com/and-period/furumaru/pull/2716
+
 ## [v4.2.2](https://github.com/and-period/furumaru/compare/v4.2.1...v4.2.2) - 2025-02-11
 - fix(admin): 店舗関連の取得ロジックを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2713
 - FIX: fixed top page by @hamachans in https://github.com/and-period/furumaru/pull/2715


### PR DESCRIPTION
This pull request is for the next release as v4.2.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.2.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(store): 店舗IDを詰めるように by @taba2424 in https://github.com/and-period/furumaru/pull/2716


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.2.2...v4.2.3