### PR TITLE
Release for v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v4.3.0](https://github.com/and-period/furumaru/compare/v4.2.3...v4.3.0) - 2025-02-13
+- build(deps): bump the dependencies group in /web/admin with 34 updates by @dependabot in https://github.com/and-period/furumaru/pull/2719
+- build(deps): bump the dependencies group in /api with 37 updates by @dependabot in https://github.com/and-period/furumaru/pull/2718
+- feat(user): 購入者側のOAuth認証実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2721
+- fix(gateway): 体験一覧取得時、削除済みのものは取得しないように by @taba2424 in https://github.com/and-period/furumaru/pull/2723
+- Fix: fixed form to change business time by @hamachans in https://github.com/and-period/furumaru/pull/2722
+- fix: ユーザーが位置情報の取得を許可している場合に現在地の座標がユーザーの現在地になるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2724
+- feat(user): 購入者側のOAuth認証実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2725
+
 ## [v4.2.3](https://github.com/and-period/furumaru/compare/v4.2.2...v4.2.3) - 2025-02-11
 - fix(store): 店舗IDを詰めるように by @taba2424 in https://github.com/and-period/furumaru/pull/2716
 


### PR DESCRIPTION
This pull request is for the next release as v4.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump the dependencies group in /web/admin with 34 updates by @dependabot in https://github.com/and-period/furumaru/pull/2719
* build(deps): bump the dependencies group in /api with 37 updates by @dependabot in https://github.com/and-period/furumaru/pull/2718
* feat(user): 購入者側のOAuth認証実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2721
* fix(gateway): 体験一覧取得時、削除済みのものは取得しないように by @taba2424 in https://github.com/and-period/furumaru/pull/2723
* Fix: fixed form to change business time by @hamachans in https://github.com/and-period/furumaru/pull/2722
* fix: ユーザーが位置情報の取得を許可している場合に現在地の座標がユーザーの現在地になるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2724
* feat(user): 購入者側のOAuth認証実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2725


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.2.3...v4.3.0