### PR TITLE
fix: ユーザーが位置情報の取得を許可している場合に現在地の座標がユーザーの現在地になるように修正

### DIFF
--- a/web/user/src/pages/experiences/index.vue
+++ b/web/user/src/pages/experiences/index.vue
@@ -120,6 +120,11 @@ onMounted(() => {
 })
 
 onMounted(() => {
+  // ユーザーが位置情報の取得を許可した場合に中心座標を現在地に変更
+  if (geoLocationError.value === null) {
+    centerPositionType.value = 'geo'
+  }
+
   const svg = window.btoa(`
   <svg fill="#604C3F" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
     <circle cx="120" cy="120" opacity=".8" r="70" />


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーが位置情報の使用を許可した場合、地図の中心が自動的に現在位置に更新されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->