### PR TITLE
Release for v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.4.1](https://github.com/and-period/furumaru/compare/v4.4.0...v4.4.1) - 2025-02-21
+- Fix: fixed top page by @hamachans in https://github.com/and-period/furumaru/pull/2733
+
 ## [v4.4.0](https://github.com/and-period/furumaru/compare/v4.3.1...v4.4.0) - 2025-02-21
 - feat(store): 店舗ごとのプロモーションを発行できるように by @taba2424 in https://github.com/and-period/furumaru/pull/2729
 - feat(admin): 店舗ごとのプロモーション発行機能を実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2731


### PR DESCRIPTION
This pull request is for the next release as v4.4.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix: fixed top page by @hamachans in https://github.com/and-period/furumaru/pull/2733


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.0...v4.4.1