### PR TITLE
Release for v4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v4.4.2](https://github.com/and-period/furumaru/compare/v4.4.1...v4.4.2) - 2025-02-22
+- レビュー投稿機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2735
+- feat: トップページのコンセプトテキスト部分のアニメーションを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2737
+
 ## [v4.4.1](https://github.com/and-period/furumaru/compare/v4.4.0...v4.4.1) - 2025-02-21
 - Fix: fixed top page by @hamachans in https://github.com/and-period/furumaru/pull/2733
 


### PR DESCRIPTION
This pull request is for the next release as v4.4.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* レビュー投稿機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2735
* feat: トップページのコンセプトテキスト部分のアニメーションを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2737


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.1...v4.4.2