### PR TITLE
Release for v4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v4.4.3](https://github.com/and-period/furumaru/compare/v4.4.2...v4.4.3) - 2025-03-05
+- fix(admin): リフレッシュトークンの有効期限を明示的に指定 by @taba2424 in https://github.com/and-period/furumaru/pull/2738
+- feat(messenger): レビュー依頼通知の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2740
+- Fix: fixed shipping message by @hamachans in https://github.com/and-period/furumaru/pull/2743
+- feat(store): ダミーの商品レビューを追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2746
+- build(deps): bump the dependencies group across 1 directory with 77 updates by @dependabot in https://github.com/and-period/furumaru/pull/2744
+- build(deps): bump the dependencies group across 1 directory with 58 updates by @dependabot in https://github.com/and-period/furumaru/pull/2745
+- fix(messenger): メールに添付するサムネイルのURLをフィルタリング by @taba2424 in https://github.com/and-period/furumaru/pull/2747
+
 ## [v4.4.2](https://github.com/and-period/furumaru/compare/v4.4.1...v4.4.2) - 2025-02-22
 - レビュー投稿機能の実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2735
 - feat: トップページのコンセプトテキスト部分のアニメーションを追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2737


### PR DESCRIPTION
This pull request is for the next release as v4.4.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(admin): リフレッシュトークンの有効期限を明示的に指定 by @taba2424 in https://github.com/and-period/furumaru/pull/2738
* feat(messenger): レビュー依頼通知の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2740
* Fix: fixed shipping message by @hamachans in https://github.com/and-period/furumaru/pull/2743
* feat(store): ダミーの商品レビューを追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2746
* build(deps): bump the dependencies group across 1 directory with 77 updates by @dependabot in https://github.com/and-period/furumaru/pull/2744
* build(deps): bump the dependencies group across 1 directory with 58 updates by @dependabot in https://github.com/and-period/furumaru/pull/2745
* fix(messenger): メールに添付するサムネイルのURLをフィルタリング by @taba2424 in https://github.com/and-period/furumaru/pull/2747


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.2...v4.4.3