### PR TITLE
Release for v4.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v4.4.7](https://github.com/and-period/furumaru/compare/v4.4.6...v4.4.7) - 2025-03-10
+- feat(media): 署名URL発行時のヘッダー情報も連携するように by @taba2424 in https://github.com/and-period/furumaru/pull/2753
+- Fix: fixed terms of use by @hamachans in https://github.com/and-period/furumaru/pull/2755
+
 ## [v4.4.6](https://github.com/and-period/furumaru/compare/v4.4.5...v4.4.6) - 2025-03-08
 - Add: added terms of use by @hamachans in https://github.com/and-period/furumaru/pull/2751
 


### PR DESCRIPTION
This pull request is for the next release as v4.4.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(media): 署名URL発行時のヘッダー情報も連携するように by @taba2424 in https://github.com/and-period/furumaru/pull/2753
* Fix: fixed terms of use by @hamachans in https://github.com/and-period/furumaru/pull/2755


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.6...v4.4.7