### PR TITLE
Release for v4.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.4.10](https://github.com/and-period/furumaru/compare/v4.4.9...v4.4.10) - 2025-03-17
+- 体験登録で動画を紐づけられるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2764
+
 ## [v4.4.9](https://github.com/and-period/furumaru/compare/v4.4.8...v4.4.9) - 2025-03-16
 - build(deps): bump @unhead/dom from 1.11.18 to 1.11.20 in /web/admin by @dependabot in https://github.com/and-period/furumaru/pull/2760
 - build(deps): bump @babel/standalone from 7.26.9 to 7.26.10 in /web/admin by @dependabot in https://github.com/and-period/furumaru/pull/2761


### PR DESCRIPTION
This pull request is for the next release as v4.4.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 体験登録で動画を紐づけられるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2764


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.9...v4.4.10