### PR TITLE
Release for v4.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v4.4.11](https://github.com/and-period/furumaru/compare/v4.4.10...v4.4.11) - 2025-03-20
+- レビューの星表示の修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2766
+- 商品登録・編集画面のUI/UX調整 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2770
+
 ## [v4.4.10](https://github.com/and-period/furumaru/compare/v4.4.9...v4.4.10) - 2025-03-17
 - 体験登録で動画を紐づけられるように修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2764
 


### PR DESCRIPTION
This pull request is for the next release as v4.4.11 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.11 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.10" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* レビューの星表示の修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2766
* 商品登録・編集画面のUI/UX調整 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2770


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.10...v4.4.11