### PR TITLE
商品詳細ページのエラーハンドリングを強化

### DIFF
--- a/web/user/src/components/molecules/ThePhoneNumberInput.vue
+++ b/web/user/src/components/molecules/ThePhoneNumberInput.vue
@@ -59,6 +59,16 @@ const viewMessage = computed(() => {
     return props.message
   }
 })
+
+onMounted(() => {
+  // 初期値を設定
+  const tel = props.modelValue.split('-')
+  if (tel.length === 3) {
+    tel1.value = tel[0]
+    tel2.value = tel[1]
+    tel3.value = tel[2]
+  }
+})
 </script>
 
 <template>

--- a/web/user/src/components/molecules/TheProductListItem.vue
+++ b/web/user/src/components/molecules/TheProductListItem.vue
@@ -8,6 +8,7 @@ import type { I18n } from '~/types/locales'
 import { productStatusToString } from '~/lib/product'
 
 interface Props {
+  href?: string
   id: string
   status: ProductStatus
   name: string
@@ -21,7 +22,6 @@ interface Props {
 }
 
 interface Emits {
-  (e: 'click:item', id: string): void
   (e: 'click:addCart', name: string, id: string, quantity: number): void
 }
 
@@ -65,10 +65,6 @@ const canAddCart = computed<boolean>(() => {
   return false
 })
 
-const handleClickItem = () => {
-  emits('click:item', props.id)
-}
-
 const handleClickCoorinator = () => {
   router.push(`/coordinator/${props.coordinator?.id}`)
 }
@@ -93,10 +89,10 @@ const handleClickAddCartButton = () => {
           }}
         </p>
       </div>
-      <div
+      <nuxt-link
         v-if="thumbnail"
-        class="cursor-pointer w-full"
-        @click="handleClickItem"
+        :to="`/items/${id}`"
+        class="block w-full"
       >
         <template v-if="thumbnailIsVideo">
           <video
@@ -124,7 +120,7 @@ const handleClickAddCartButton = () => {
             </picture>
           </div>
         </template>
-      </div>
+      </nuxt-link>
     </div>
 
     <p

--- a/web/user/src/components/molecules/TheProductListItem.vue
+++ b/web/user/src/components/molecules/TheProductListItem.vue
@@ -2,7 +2,7 @@
 import {
   ProductStatus,
   type Coordinator,
-  type ProductMediaInner,
+  type ExperienceMediaInner,
 } from '~/types/api'
 import type { I18n } from '~/types/locales'
 import { productStatusToString } from '~/lib/product'
@@ -16,7 +16,7 @@ interface Props {
   hasStock: boolean
   originCity: string
   coordinator: Coordinator | undefined
-  thumbnail: ProductMediaInner | undefined
+  thumbnail: ExperienceMediaInner | undefined
   thumbnailIsVideo: boolean
 }
 

--- a/web/user/src/components/templates/TheItem.vue
+++ b/web/user/src/components/templates/TheItem.vue
@@ -24,10 +24,6 @@ const lt = (str: keyof I18n['items']['list']) => {
   return i18n.t(`items.list.${str}`)
 }
 
-const handleClick = (id: string) => {
-  router.push(`/items/${id}`)
-}
-
 const snackbarItems = ref<Snackbar[]>([])
 
 const handleClickAddCartButton = async (
@@ -79,8 +75,9 @@ watch(currentPage, () => {
   fetchProducts(pagePerItems.value, pagination.value.offset)
 })
 
-const { status } = useAsyncData('products', () => {
-  return fetchProducts(pagePerItems.value, pagination.value.offset)
+const { status } = useAsyncData('products', async () => {
+  await fetchProducts(pagePerItems.value, pagination.value.offset)
+  return true
 })
 
 const hideV1App = false
@@ -175,7 +172,6 @@ const hideV1App = false
             :coordinator="product.coordinator"
             :origin-city="product.originCity"
             :thumbnail-is-video="product.thumbnailIsVideo"
-            @click:item="handleClick"
             @click:add-cart="handleClickAddCartButton"
           />
         </template>

--- a/web/user/src/pages/items/[...id].vue
+++ b/web/user/src/pages/items/[...id].vue
@@ -69,11 +69,17 @@ const priceString = computed<string>(() => {
 })
 
 const canAddCart = computed<boolean>(() => {
-  if (product.value) {
-    return (
-      product.value.status === ProductStatus.FOR_SALE
-      && product.value.inventory > 0
-    )
+  // データ取得に失敗していたらfalseを返す
+  if (status.value === 'success') {
+    if (product.value) {
+      return (
+        product.value.status === ProductStatus.FOR_SALE
+        && product.value.inventory > 0
+      )
+    }
+    else {
+      return false
+    }
   }
   else {
     return false
@@ -130,7 +136,7 @@ const handleClickMediaItem = (index: number) => {
   selectedMediaIndex.value = index
 }
 
-useAsyncData(`product-${id.value}`, async () => {
+const { status, error } = useAsyncData(`product-${id.value}`, async () => {
   await fetchProduct(id.value)
   return true
 })
@@ -156,7 +162,8 @@ useSeoMeta({
     />
   </template>
 
-  <template v-if="productFetchState.isLoading">
+  <!-- ロード状態 -->
+  <template v-if="status === 'pending'">
     <div
       class="animate-pulse bg-white px-[112px] pb-6 pt-[40px] text-main md:grid md:grid-cols-2"
     >
@@ -170,7 +177,15 @@ useSeoMeta({
     </div>
   </template>
 
-  <template v-if="!productFetchState.isLoading && product.thumbnail">
+  <!-- エラーの場合の表示 -->
+  <template v-if="status === 'error'">
+    <the-alert>
+      {{ error?.message }}
+    </the-alert>
+  </template>
+
+  <!-- 商品情報の表示 -->
+  <template v-if="status == 'success' && !productFetchState.isLoading && product.thumbnail">
     <div class="bg-white w-full">
       <div
         class="gap-10 px-4 pb-6 pt-[40px] text-main md:grid md:grid-cols-2 lg:px-[112px] w-full max-w-[1440px] mx-auto"

--- a/web/user/src/types/locales/i18n.ts
+++ b/web/user/src/types/locales/i18n.ts
@@ -354,6 +354,8 @@ export interface I18n {
       storageTypeRefrigerated: string
       storageTypeFrozen: string
       producerInformationTitle: string
+      reviewLabel: string
+      noReviewText: string
     }
     experiences: {
       producerLabel: string

--- a/web/user/src/types/store/shopping.ts
+++ b/web/user/src/types/store/shopping.ts
@@ -5,7 +5,7 @@ import type {
   Coordinator,
   PaymentSystem,
   Product,
-  ProductMediaInner,
+  ExperienceMediaInner,
 } from '../api'
 
 export interface ImageItem {
@@ -21,7 +21,7 @@ export interface MediaItem {
 
 // UI上で表示する商品の型定義
 export interface ProductItem extends Product {
-  thumbnail: ProductMediaInner | undefined
+  thumbnail: ExperienceMediaInner | undefined
 }
 
 // UI上で表示するカートの中身の型定義


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 商品詳細ページにレビュー関連のラベルとテキストのローカライズ項目を追加しました。
  - 商品詳細ページでデータ取得中・エラー・成功状態に応じた表示切り替えとエラー表示を追加しました。

- **改善**
  - 商品リストアイテムのクリック時、手動のイベント発火から直接ページ遷移するリンク方式に変更しました。
  - 商品リストや詳細ページで商品画像の型を統一しました。
  - 電話番号入力欄で初期値を自動分割して各フィールドに反映するようになりました。

- **バグ修正**
  - 商品詳細ページで商品データが取得できていない場合にカート追加ボタンが無効化されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->