### PR TITLE
feat(store): Shippingsテーブルにレコード追加

### DIFF
--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -580,7 +580,7 @@ type Shipping interface {
 	ListByCoordinatorIDs(ctx context.Context, coordinatorIDs []string, fields ...string) (entity.Shippings, error)
 	MultiGetByRevision(ctx context.Context, revisionIDs []int64, fields ...string) (entity.Shippings, error)
 	GetDefault(ctx context.Context, fields ...string) (*entity.Shipping, error)
-	GetByCoordinatorID(ctx context.Context, coordinatorID string, fields ...string) (*entity.Shipping, error)
+	GetByCoordinatorID(ctx context.Context, coordinatorID string, fields ...string) (*entity.Shipping, error) // Depcecated
 	Create(ctx context.Context, shipping *entity.Shipping) error
 	Update(ctx context.Context, shippingID string, params *UpdateShippingParams) error
 }
@@ -594,6 +594,7 @@ type UpdateShippingParams struct {
 	Box100Frozen      int64
 	HasFreeShipping   bool
 	FreeShippingRates int64
+	InUse             bool
 }
 
 type Shop interface {

--- a/api/internal/store/entity/shipping.go
+++ b/api/internal/store/entity/shipping.go
@@ -31,6 +31,7 @@ type Shipping struct {
 	ID               string    `gorm:"primaryKey;<-:create"` // 配送設定ID
 	ShopID           string    `gorm:"default:null"`         // 店舗ID
 	CoordinatorID    string    `gorm:""`                     // コーディネータID
+	InUse            bool      `gorm:""`                     // 使用中
 	CreatedAt        time.Time `gorm:"<-:create"`            // 登録日時
 	UpdatedAt        time.Time `gorm:""`                     // 更新日時
 }
@@ -48,6 +49,7 @@ type NewShippingParams struct {
 	Box100Frozen      int64
 	HasFreeShipping   bool
 	FreeShippingRates int64
+	InUse             bool
 }
 
 func (t ShippingType) String() string {
@@ -78,6 +80,7 @@ func NewShipping(params *NewShippingParams) *Shipping {
 		ID:               params.CoordinatorID, // PKはコーディネータと同一にする
 		ShopID:           params.ShopID,
 		CoordinatorID:    params.CoordinatorID,
+		InUse:            params.InUse,
 		ShippingRevision: *revision,
 	}
 }

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -983,6 +983,7 @@ type UpsertShippingInput struct {
 	Box100Frozen      int64                 `validate:"min=0,lt=10000000000"`
 	HasFreeShipping   bool                  `validate:""`
 	FreeShippingRates int64                 `validate:"min=0,lt=10000000000"`
+	InUse             bool                  `validate:""`
 }
 
 type UpsertShippingRate struct {

--- a/api/internal/store/service/shipping.go
+++ b/api/internal/store/service/shipping.go
@@ -112,6 +112,7 @@ func (s *service) UpsertShipping(ctx context.Context, in *store.UpsertShippingIn
 			Box100Frozen:      in.Box100Frozen,
 			HasFreeShipping:   in.HasFreeShipping,
 			FreeShippingRates: in.FreeShippingRates,
+			InUse:             true,
 		}
 		shipping = entity.NewShipping(params)
 		err = s.db.Shipping.Create(ctx, shipping)
@@ -126,6 +127,7 @@ func (s *service) UpsertShipping(ctx context.Context, in *store.UpsertShippingIn
 			Box100Frozen:      in.Box100Frozen,
 			HasFreeShipping:   in.HasFreeShipping,
 			FreeShippingRates: in.FreeShippingRates,
+			InUse:             in.InUse,
 		}
 		err = s.db.Shipping.Update(ctx, shipping.ID, params)
 	}

--- a/api/internal/store/service/shipping_test.go
+++ b/api/internal/store/service/shipping_test.go
@@ -503,6 +503,7 @@ func TestUpsertShipping(t *testing.T) {
 		Box100Frozen:      800,
 		HasFreeShipping:   true,
 		FreeShippingRates: 3000,
+		InUse:             true,
 	}
 	shipping := func(revisionID int64) *entity.Shipping {
 		rates := entity.ShippingRates{
@@ -513,6 +514,7 @@ func TestUpsertShipping(t *testing.T) {
 			ID:            "coordinator-id",
 			ShopID:        "shop-id",
 			CoordinatorID: "coordinator-id",
+			InUse:         true,
 			ShippingRevision: entity.ShippingRevision{
 				ShippingID:        "coordinator-id",
 				Box60Rates:        rates,
@@ -550,6 +552,7 @@ func TestUpsertShipping(t *testing.T) {
 				Box100Frozen:      800,
 				HasFreeShipping:   true,
 				FreeShippingRates: 3000,
+				InUse:             true,
 			},
 			expectErr: nil,
 		},
@@ -570,6 +573,7 @@ func TestUpsertShipping(t *testing.T) {
 				Box100Frozen:      800,
 				HasFreeShipping:   true,
 				FreeShippingRates: 3000,
+				InUse:             true,
 			},
 			expectErr: nil,
 		},
@@ -595,6 +599,7 @@ func TestUpsertShipping(t *testing.T) {
 				Box100Frozen:      800,
 				HasFreeShipping:   true,
 				FreeShippingRates: 3000,
+				InUse:             true,
 			},
 			expectErr: exception.ErrInternal,
 		},
@@ -615,6 +620,7 @@ func TestUpsertShipping(t *testing.T) {
 				Box100Frozen:      800,
 				HasFreeShipping:   true,
 				FreeShippingRates: 3000,
+				InUse:             true,
 			},
 			expectErr: exception.ErrInternal,
 		},
@@ -635,6 +641,7 @@ func TestUpsertShipping(t *testing.T) {
 				Box100Frozen:      800,
 				HasFreeShipping:   true,
 				FreeShippingRates: 3000,
+				InUse:             true,
 			},
 			expectErr: exception.ErrInternal,
 		},

--- a/infra/tidb/schema/stores/2025050301-add-column-to-shippings.sql
+++ b/infra/tidb/schema/stores/2025050301-add-column-to-shippings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `stores`.`shippings` ADD COLUMN `in_use` TINYINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 配送設定に「利用中」ステータス（InUse）を管理する機能を追加しました。これにより、配送設定が現在利用中かどうかを明示的に指定・確認できるようになりました。

- **データベース**
  - 配送設定テーブルに「in_use」カラムが追加されました。

- **テスト**
  - 「利用中」ステータスに対応したテストケースが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->