### PR TITLE
feat: ふりがなのバリデーションを追加し、エラーメッセージを表示するように変更

### DIFF
--- a/web/user/src/components/organisms/TheSignUpForm.vue
+++ b/web/user/src/components/organisms/TheSignUpForm.vue
@@ -5,6 +5,8 @@ import type { I18n } from '~/types/locales'
 interface Props {
   modelValue: CreateAuthUserRequest
   buttonText: string
+  lastnameKanaErrorMessage: string
+  firstnameKanaErrorMessage: string
   telLabel: string
   telPlaceholder: string
   telErrorMessage: string
@@ -86,6 +88,7 @@ const handleSubmit = () => {
           label="姓（かな）"
           :with-label="false"
           :placeholder="t('lastNameKanaPlaceholder')"
+          :error-message="lastnameKanaErrorMessage"
           type="text"
           required
         />
@@ -95,6 +98,7 @@ const handleSubmit = () => {
           label="名（かな）"
           :with-label="false"
           :placeholder="t('firstNameKanaPlaceholder')"
+          :error-message="firstnameKanaErrorMessage"
           type="text"
           required
         />

--- a/web/user/src/components/templates/TheSignUpPage.vue
+++ b/web/user/src/components/templates/TheSignUpPage.vue
@@ -7,6 +7,8 @@ interface Props {
   errorMessage: string
   buttonText: string
   modelValue: CreateAuthUserRequest
+  lastnameKanaErrorMessage: string
+  firstnameKanaErrorMessage: string
   telLabel: string
   telPlaceholder: string
   telErrorMessage: string
@@ -41,7 +43,7 @@ const handleSubmit = () => {
 </script>
 
 <template>
-  <div class="mx-auto block sm:min-w-[560px]">
+  <div class="mx-auto block sm:max-w-[560px]">
     <the-marche-logo class="mb-10" />
     <the-card>
       <the-card-title>
@@ -59,6 +61,8 @@ const handleSubmit = () => {
           <the-sign-up-form
             v-model="formData"
             :button-text="buttonText"
+            :lastname-kana-error-message="lastnameKanaErrorMessage"
+            :firstname-kana-error-message="firstnameKanaErrorMessage"
             :tel-label="telLabel"
             :tel-placeholder="telPlaceholder"
             :tel-error-message="telErrorMessage"

--- a/web/user/src/pages/signup.vue
+++ b/web/user/src/pages/signup.vue
@@ -69,18 +69,56 @@ const formData = reactive<CreateAuthUserRequest>({
 })
 
 const hasError = ref<boolean>(false)
+const lastnameKanaErrorMessage = ref<string>('')
+const firstnameKanaMessage = ref<string>('')
 const telErrorMessage = ref<string>('')
+const passwordErrorMessage = ref<string>('')
 const passwordConfirmErrorMessage = ref<string>('')
 
 const apiErrorMessage = ref<string>('')
 
+const isKana = (input: string): boolean => {
+  // ひらがなの正規表現
+  const kanaRegex = /^[\u3040-\u309F]+$/
+  return kanaRegex.test(input)
+}
+
+const isValidJapanesePhoneNumber = (phoneNumber: string): boolean => {
+  const regex = /^0\d{9,10}$/
+  return regex.test(phoneNumber)
+}
+
+const isValidPassword = (password: string): boolean => {
+  // パスワードの正規表現 - 8～32文字で英数字をそれぞれ1文字以上含む
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,32}$/
+  return passwordRegex.test(password)
+}
+
 const validate = () => {
   hasError.value = false
+  lastnameKanaErrorMessage.value = ''
+  firstnameKanaMessage.value = ''
   telErrorMessage.value = ''
+  passwordErrorMessage.value = ''
   passwordConfirmErrorMessage.value = ''
 
-  if (!formData.phoneNumber.startsWith('0')) {
-    telErrorMessage.value = '電話番号は0から始まる値を入力してください'
+  if (!isKana(formData.lastnameKana)) {
+    lastnameKanaErrorMessage.value = 'ふりがな（姓）は全角ひらがなで入力してください'
+    hasError.value = true
+  }
+
+  if (!isKana(formData.firstnameKana)) {
+    firstnameKanaMessage.value = 'ふりがな（名）は全角ひらがなで入力してください'
+    hasError.value = true
+  }
+
+  if (!isValidJapanesePhoneNumber(formData.phoneNumber)) {
+    telErrorMessage.value = '電話番号は0から始まる値でハイフンは含めずに入力してください'
+    hasError.value = true
+  }
+
+  if (!isValidPassword(formData.password)) {
+    passwordErrorMessage.value = 'パスワードは8～32文字で英数字をそれぞれ1つ以上含む必要があります'
     hasError.value = true
   }
 
@@ -131,6 +169,8 @@ useSeoMeta({
     :page-name="t('pageName')"
     :error-message="apiErrorMessage"
     :button-text="t('signUp')"
+    :firstname-kana-error-message="firstnameKanaMessage"
+    :lastname-kana-error-message="lastnameKanaErrorMessage"
     :tel-label="t('tel')"
     :tel-placeholder="t('tel')"
     :tel-error-message="telErrorMessage"
@@ -139,7 +179,7 @@ useSeoMeta({
     email-error-message=""
     :password-label="t('password')"
     :password-placeholder="t('password')"
-    password-error-message=""
+    :password-error-message="passwordErrorMessage"
     :password-confirm-label="t('passwordConfirm')"
     :password-confirm-placeholder="t('passwordConfirm')"
     :password-confirm-error-message="passwordConfirmErrorMessage"


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「姓（かな）」および「名（かな）」入力欄に専用のエラーメッセージ表示機能を追加しました。

- **バグ修正**
  - 電話番号の入力チェックを強化し、日本の形式に合わない場合にエラーが表示されるようになりました。
  - パスワードに8〜32文字・英字と数字を含む条件を追加し、不正な場合はエラーが表示されます。

- **スタイル**
  - サインアップページのレイアウト幅を調整しました（最小幅から最大幅へ変更）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->