### PR TITLE
Release for v4.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.4.15](https://github.com/and-period/furumaru/compare/v4.4.14...v4.4.15) - 2025-05-04
+- feat: ふりがなのバリデーションを追加し、エラーメッセージを表示するように変更 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2791
+
 ## [v4.4.14](https://github.com/and-period/furumaru/compare/v4.4.13...v4.4.14) - 2025-05-03
 - feat(store): Shippingsテーブルにレコード追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2788
 - fix: 管理者画面のラベルの表記を更新 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2790


### PR DESCRIPTION
This pull request is for the next release as v4.4.15 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v4.4.15 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v4.4.14" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: ふりがなのバリデーションを追加し、エラーメッセージを表示するように変更 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2791


**Full Changelog**: https://github.com/and-period/furumaru/compare/v4.4.14...v4.4.15