### PR TITLE
feat(gateway): 配送設定取得APIの実装

### DIFF
--- a/api/internal/gateway/admin/v1/handler/api.go
+++ b/api/internal/gateway/admin/v1/handler/api.go
@@ -273,6 +273,10 @@ func (h *handler) forbidden(ctx *gin.Context, err error) {
 	h.httpError(ctx, status.Error(codes.PermissionDenied, err.Error()))
 }
 
+func (h *handler) notFound(ctx *gin.Context, err error) {
+	h.httpError(ctx, status.Error(codes.NotFound, err.Error()))
+}
+
 func (h *handler) reportError(ctx *gin.Context, err error, res *util.ErrorResponse) {
 	if h.sentry == nil || res.Status < 500 {
 		return

--- a/api/internal/gateway/admin/v1/handler/shipping.go
+++ b/api/internal/gateway/admin/v1/handler/shipping.go
@@ -122,7 +122,7 @@ func (h *handler) GetShipping(ctx *gin.Context) {
 	})
 	eg.Go(func() (err error) {
 		coordinator, err = h.getCoordinator(ctx, util.GetParam(ctx, "coordinatorId"))
-		return nil
+		return
 	})
 	if err := eg.Wait(); err != nil {
 		h.httpError(ctx, err)

--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -582,6 +582,7 @@ type Shipping interface {
 	ListByCoordinatorIDs(ctx context.Context, coordinatorIDs []string, fields ...string) (entity.Shippings, error)
 	Count(ctx context.Context, params *ListShippingsParams) (int64, error)
 	MultiGetByRevision(ctx context.Context, revisionIDs []int64, fields ...string) (entity.Shippings, error)
+	Get(ctx context.Context, shippingID string, fields ...string) (*entity.Shipping, error)
 	GetDefault(ctx context.Context, fields ...string) (*entity.Shipping, error)
 	GetByCoordinatorID(ctx context.Context, coordinatorID string, fields ...string) (*entity.Shipping, error) // Depcecated
 	Create(ctx context.Context, shipping *entity.Shipping) error

--- a/api/internal/store/database/tidb/shipping.go
+++ b/api/internal/store/database/tidb/shipping.go
@@ -144,6 +144,21 @@ func (s *shipping) MultiGetByRevision(ctx context.Context, revisionIDs []int64, 
 	return res, nil
 }
 
+func (s *shipping) Get(ctx context.Context, shippingID string, fields ...string) (*entity.Shipping, error) {
+	var shipping *entity.Shipping
+
+	stmt := s.db.Statement(ctx, s.db.DB, shippingTable, fields...).
+		Where("id = ?", shippingID)
+
+	if err := stmt.First(&shipping).Error; err != nil {
+		return nil, dbError(err)
+	}
+	if err := s.fill(ctx, s.db.DB, shipping); err != nil {
+		return nil, dbError(err)
+	}
+	return shipping, nil
+}
+
 func (s *shipping) GetDefault(ctx context.Context, fields ...string) (*entity.Shipping, error) {
 	var shipping *entity.Shipping
 

--- a/api/internal/store/database/tidb/shipping_test.go
+++ b/api/internal/store/database/tidb/shipping_test.go
@@ -381,7 +381,7 @@ func TestShipping_Get(t *testing.T) {
 			name:  "not found",
 			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
 			args: args{
-				shippingID: "shipping-id",
+				shippingID: "",
 			},
 			want: want{
 				shipping: nil,

--- a/api/internal/store/database/tidb/shipping_test.go
+++ b/api/internal/store/database/tidb/shipping_test.go
@@ -326,6 +326,86 @@ func TestShipping_MultiGetByRevision(t *testing.T) {
 	}
 }
 
+func TestShipping_Get(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := dbClient
+	now := func() time.Time {
+		return current
+	}
+
+	err := deleteAll(ctx)
+	require.NoError(t, err)
+
+	shop := testShop("shop-id", "coordinator-id", []string{}, []string{}, now())
+	err = db.DB.Table(shopTable).Create(&shop).Error
+	require.NoError(t, err)
+
+	s := testShipping("shipping-id", "shop-id", "coordinator-id", 1, now())
+	err = db.DB.Create(&s).Error
+	require.NoError(t, err)
+
+	internal, err := newInternalShippingRevision(&s.ShippingRevision)
+	require.NoError(t, err)
+	err = db.DB.Table(shippingRevisionTable).Create(&internal).Error
+	require.NoError(t, err)
+
+	type args struct {
+		shippingID string
+	}
+	type want struct {
+		shipping *entity.Shipping
+		err      error
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, db *mysql.Client)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				shippingID: "shipping-id",
+			},
+			want: want{
+				shipping: s,
+				err:      nil,
+			},
+		},
+		{
+			name:  "not found",
+			setup: func(ctx context.Context, t *testing.T, db *mysql.Client) {},
+			args: args{
+				shippingID: "shipping-id",
+			},
+			want: want{
+				shipping: nil,
+				err:      database.ErrNotFound,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, db)
+
+			db := &shipping{db: db, now: now}
+			actual, err := db.Get(ctx, tt.args.shippingID)
+			assert.Equal(t, tt.want.err, err)
+			assert.Equal(t, tt.want.shipping, actual)
+		})
+	}
+}
+
 func TestShipping_GetDefault(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -972,6 +972,10 @@ type MultiGetShippingsByRevisionInput struct {
 	ShippingRevisionIDs []int64 `validate:"dive,required"`
 }
 
+type GetShippingInput struct {
+	ShippingID string `validate:"required"`
+}
+
 type GetDefaultShippingInput struct{}
 
 type GetShippingByCoordinatorIDInput struct {

--- a/api/internal/store/service.go
+++ b/api/internal/store/service.go
@@ -148,6 +148,7 @@ type Service interface {
 	ListShippingsByShopID(ctx context.Context, in *ListShippingsByShopIDInput) (entity.Shippings, int64, error)          // 一覧取得(店舗ID指定)
 	ListShippingsByCoordinatorIDs(ctx context.Context, in *ListShippingsByCoordinatorIDsInput) (entity.Shippings, error) // 一覧取得(コーディネータID指定)
 	MultiGetShippingsByRevision(ctx context.Context, in *MultiGetShippingsByRevisionInput) (entity.Shippings, error)     // 一覧取得(変更履歴指定)
+	GetShipping(ctx context.Context, in *GetShippingInput) (*entity.Shipping, error)                                     // １件取得
 	GetDefaultShipping(ctx context.Context, in *GetDefaultShippingInput) (*entity.Shipping, error)                       // １件取得(デフォルト設定)
 	GetShippingByCoordinatorID(ctx context.Context, in *GetShippingByCoordinatorIDInput) (*entity.Shipping, error)       // １件取得(コーディネータID設定)
 	CreateShipping(ctx context.Context, in *CreateShippingInput) (*entity.Shipping, error)                               // 登録

--- a/api/internal/store/service/shipping.go
+++ b/api/internal/store/service/shipping.go
@@ -64,6 +64,14 @@ func (s *service) MultiGetShippingsByRevision(
 	return shippings, internalError(err)
 }
 
+func (s *service) GetShipping(ctx context.Context, in *store.GetShippingInput) (*entity.Shipping, error) {
+	if err := s.validator.Struct(in); err != nil {
+		return nil, internalError(err)
+	}
+	shipping, err := s.db.Shipping.Get(ctx, in.ShippingID)
+	return shipping, internalError(err)
+}
+
 func (s *service) GetDefaultShipping(ctx context.Context, in *store.GetDefaultShippingInput) (*entity.Shipping, error) {
 	if err := s.validator.Struct(in); err != nil {
 		return nil, internalError(err)

--- a/api/internal/store/service/shipping_test.go
+++ b/api/internal/store/service/shipping_test.go
@@ -322,6 +322,87 @@ func TestMutiGetShippingsByRevision(t *testing.T) {
 	}
 }
 
+func TestGetShipping(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Date(2022, 7, 16, 18, 30, 0, 0)
+	shikoku := []int32{
+		codes.PrefectureValues["tokushima"],
+		codes.PrefectureValues["kagawa"],
+		codes.PrefectureValues["ehime"],
+		codes.PrefectureValues["kochi"],
+	}
+	set := set.New(shikoku...)
+	others := make([]int32, 0, 47-len(shikoku))
+	for val := range codes.PrefectureNames {
+		if set.Contains(val) {
+			continue
+		}
+		others = append(others, val)
+	}
+	rates := entity.ShippingRates{
+		{Number: 1, Name: "四国", Price: 250, PrefectureCodes: shikoku},
+		{Number: 2, Name: "その他", Price: 500, PrefectureCodes: others},
+	}
+	shipping := &entity.Shipping{
+		ID:            "shipping-id",
+		CoordinatorID: "",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		ShippingRevision: entity.ShippingRevision{
+			ID:                1,
+			ShippingID:        "shipping-id",
+			Box60Rates:        rates,
+			Box60Frozen:       800,
+			Box80Rates:        rates,
+			Box80Frozen:       800,
+			Box100Rates:       rates,
+			Box100Frozen:      800,
+			HasFreeShipping:   true,
+			FreeShippingRates: 3000,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(ctx context.Context, mocks *mocks)
+		input     *store.GetShippingInput
+		expect    *entity.Shipping
+		expectErr error
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Shipping.EXPECT().Get(ctx, "shipping-id").Return(shipping, nil)
+			},
+			input: &store.GetShippingInput{
+				ShippingID: "shipping-id",
+			},
+			expect:    shipping,
+			expectErr: nil,
+		},
+		{
+			name: "failed to get shipping",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.Shipping.EXPECT().Get(ctx, "shipping-id").Return(nil, assert.AnError)
+			},
+			input: &store.GetShippingInput{
+				ShippingID: "shipping-id",
+			},
+			expect:    nil,
+			expectErr: exception.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, testService(tt.setup, func(ctx context.Context, t *testing.T, service *service) {
+			actual, err := service.GetShipping(ctx, tt.input)
+			assert.ErrorIs(t, err, tt.expectErr)
+			assert.Equal(t, tt.expect, actual)
+		}))
+	}
+}
+
 func TestGetDefaultShipping(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 配送情報をIDで取得するAPIの機能を追加しました。
	- 配送情報取得時にコーディネーター情報も同時に取得し、両者の店舗IDが一致しない場合は404エラーを返すようになりました。

- **バグ修正**
	- 配送情報取得時のエラーハンドリングが改善され、該当データが存在しない場合に適切なエラー応答が返されるようになりました。

- **テスト**
	- 配送情報取得機能に関するユニットテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->