### PR TITLE
Fix: 体験で動画があれば動画を表示するように修正

### DIFF
--- a/web/user/src/components/molecules/experiences/TheExperienceMarker.vue
+++ b/web/user/src/components/molecules/experiences/TheExperienceMarker.vue
@@ -8,6 +8,7 @@ interface Props {
   title: string
   description: string
   thumbnailUrl: string
+  promotionVideoUrl: string
 }
 
 const props = defineProps<Props>()
@@ -70,18 +71,35 @@ watch(isShowInfoWindow, (newValue) => {
     >
       <div
         v-show="isShowInfoWindow"
-        class="text-main grid grid-cols-5 gap-2 max-w-sm"
+        class="text-main grid grid-cols-1 md:grid-cols-5 gap-2 max-w-sm"
       >
-        <div class=" col-span-1">
-          <img
-            :src="thumbnailUrl"
-            class="w-full object-cover"
-            :alt="`${title}のサムネイル`"
-          >
+        <div class="col-span-1 md:col-span-1">
+          <div v-if="promotionVideoUrl">
+            <video
+              :src="promotionVideoUrl"
+              class="w-full max-h-[150px] mt-2"
+              :title="`${title}の動画`"
+              muted
+              playsinline
+              autoplay
+              loop
+            />
+          </div>
+          <div v-else>
+            <img
+              v-if="thumbnailUrl"
+              :src="thumbnailUrl"
+              class="w-full max-h-[150px] mt-2"
+              :title="`${title}の画像`"
+            >
+          </div>
         </div>
-        <div class=" tracking-wider col-span-4 flex flex-col gap-2">
+
+        <div
+          class="tracking-wider md:col-span-4 flex flex-col gap-2 ml-0 md:ml-4"
+        >
           <div
-            class="font-semibold cursor-pointer hover:underline "
+            class="font-semibold cursor-pointer hover:underline"
             @click="handleClickName"
           >
             {{ title }}

--- a/web/user/src/pages/experiences/index.vue
+++ b/web/user/src/pages/experiences/index.vue
@@ -212,6 +212,7 @@ useSeoMeta({
               :title="experience.title"
               :description="experience.description"
               :thumbnail-url="experience.thumbnailUrl"
+              :promotion-video-url="experience.promotionVideoUrl"
               @click:name="handleClickSpot"
             />
           </template>


### PR DESCRIPTION
## やったこと
- 体験で動画があれば動画を表示するように修正
- スマホのUIが悪かったので修正
- 
<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 体験マーカーにプロモーション動画の表示機能を追加。動画URLが設定されている場合、サムネイル画像の代わりに自動再生・ループ・ミュートの動画が表示されます。

- **スタイル**
  - メディア表示部分のレイアウトがレスポンシブ対応になり、画面サイズに応じて見やすく調整されました。
  - テキスト部分の余白が調整され、デザインが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->