### PR TITLE
feat(admin): 注文ステータスの変更ロジックの改修

### DIFF
--- a/web/admin/src/components/templates/OrderShow.vue
+++ b/web/admin/src/components/templates/OrderShow.vue
@@ -246,32 +246,34 @@ const isAuthorized = (): boolean => {
   return props.order.status === OrderStatus.WAITING
 }
 
-// 配送完了通知 - 商品購入時のみ
-const isShipped = (): boolean => {
-  if (!props.order || props.order.type !== OrderType.PRODUCT) {
-    return false
-  }
-  return props.order.status === OrderStatus.SHIPPED
-}
-
 // 発送連絡時のメッセージ下書き保存 - 商品購入時のみ
 const isPreservable = (): boolean => {
   if (!props.order || props.order.type !== OrderType.PRODUCT) {
     return false
   }
   const targets: OrderStatus[] = [
+    OrderStatus.WAITING,
     OrderStatus.PREPARING,
     OrderStatus.SHIPPED,
   ]
   return targets.includes(props.order.status)
 }
 
-// 完了通知 - 体験予約時のみ
+// 完了通知
 const isCompletable = (): boolean => {
-  if (!props.order || props.order.type !== OrderType.EXPERIENCE) {
+  if (!props.order) {
     return false
   }
-  return props.order.status === OrderStatus.SHIPPED
+  const targets: OrderStatus[] = []
+  switch (props.order.type) {
+    case OrderType.PRODUCT:
+      targets.push(OrderStatus.PREPARING, OrderStatus.SHIPPED)
+      break
+    case OrderType.EXPERIENCE:
+      targets.push(OrderStatus.SHIPPED)
+      break
+  }
+  return targets.includes(props.order.status)
 }
 
 const isCancelable = (): boolean => {
@@ -742,14 +744,6 @@ const onSubmitRefund = (): void => {
           </v-row>
           <v-row>
             <v-col cols="3">
-              マルシェ名
-            </v-col>
-            <v-col cols="9">
-              {{ coordinator.marcheName }}
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col cols="3">
               コーディネーター名
             </v-col>
             <v-col cols="9">
@@ -1167,20 +1161,6 @@ const onSubmitRefund = (): void => {
         注文を確定
       </v-btn>
       <v-btn
-        v-show="isShipped()"
-        :loading="loading"
-        variant="outlined"
-        color="primary"
-        class="mr-2"
-        @click="onSubmitComplete()"
-      >
-        <v-icon
-          start
-          :icon="mdiPlus"
-        />
-        発送完了を通知
-      </v-btn>
-      <v-btn
         v-show="isCompletable()"
         :loading="loading"
         variant="outlined"
@@ -1192,7 +1172,7 @@ const onSubmitRefund = (): void => {
           start
           :icon="mdiPlus"
         />
-        レビュー依頼を送信
+        {{ props.order.type === OrderType.PRODUCT ? '発送完了を通知' : 'レビュー依頼を送信' }}
       </v-btn>
       <v-btn
         v-show="isCancelable()"


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 商品注文と体験注文の両方に対応した発送完了・レビュー依頼ボタンを統合し、注文タイプに応じてボタンラベルが自動で切り替わるようになりました。

- **改善**
  - 商品注文で「WAITING」ステータスも保存可能になりました。
  - 「マルシェ名」の表示セクションを注文情報から削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->