### PR TITLE
feat(store): 配送設定名の追加

### DIFF
--- a/api/hack/database-seeds/master/shipping.go
+++ b/api/hack/database-seeds/master/shipping.go
@@ -5,6 +5,7 @@ import "github.com/and-period/furumaru/api/internal/store/entity"
 var DefaultShipping = &entity.Shipping{
 	ID:            "default",
 	CoordinatorID: "",
+	Name:          "デフォルト配送設定",
 }
 
 var DefaultShippingRevision = &entity.ShippingRevision{

--- a/api/internal/gateway/admin/v1/handler/shipping.go
+++ b/api/internal/gateway/admin/v1/handler/shipping.go
@@ -191,6 +191,7 @@ func (h *handler) CreateShipping(ctx *gin.Context) {
 		return
 	}
 	in := &store.CreateShippingInput{
+		Name:              req.Name,
 		ShopID:            coordinator.ShopID,
 		CoordinatorID:     coordinator.ID,
 		Box60Rates:        h.newShippingRatesForCreate(req.Box60Rates),
@@ -235,6 +236,7 @@ func (h *handler) UpdateShipping(ctx *gin.Context) {
 		return
 	}
 	in := &store.UpdateShippingInput{
+		Name:              req.Name,
 		ShippingID:        shipping.ID,
 		Box60Rates:        h.newShippingRatesForUpdate(req.Box60Rates),
 		Box60Frozen:       req.Box60Frozen,

--- a/api/internal/gateway/admin/v1/request/shipping.go
+++ b/api/internal/gateway/admin/v1/request/shipping.go
@@ -1,6 +1,7 @@
 package request
 
 type CreateShippingRequest struct {
+	Name              string                `json:"name,omitempty"`              // 配送設定名
 	Box60Rates        []*CreateShippingRate `json:"box60Rates,omitempty"`        // 箱サイズ60の通常便配送料一覧
 	Box60Frozen       int64                 `json:"box60Frozen,omitempty"`       // 箱サイズ60の冷凍便追加配送料(税込)
 	Box80Rates        []*CreateShippingRate `json:"box80Rates,omitempty"`        // 箱サイズ80の通常便配送料一覧
@@ -18,6 +19,7 @@ type CreateShippingRate struct {
 }
 
 type UpdateShippingRequest struct {
+	Name              string                `json:"name,omitempty"`              // 配送設定名
 	Box60Rates        []*UpdateShippingRate `json:"box60Rates,omitempty"`        // 箱サイズ60の通常便配送料一覧
 	Box60Frozen       int64                 `json:"box60Frozen,omitempty"`       // 箱サイズ60の冷凍便追加配送料(税込)
 	Box80Rates        []*UpdateShippingRate `json:"box80Rates,omitempty"`        // 箱サイズ80の通常便配送料一覧

--- a/api/internal/gateway/admin/v1/response/shipping.go
+++ b/api/internal/gateway/admin/v1/response/shipping.go
@@ -3,6 +3,7 @@ package response
 // Shipping - 配送設定情報
 type Shipping struct {
 	ID                string          `json:"id"`                // 配送設定ID
+	Name              string          `json:"name,omitempty"`    // 配送設定名
 	IsDefault         bool            `json:"isDefault"`         // デフォルト設定フラグ
 	Box60Rates        []*ShippingRate `json:"box60Rates"`        // 箱サイズ60の通常（常温・冷蔵便）配送料一覧
 	Box60Frozen       int64           `json:"box60Frozen"`       // 箱サイズ60の追加（冷凍便）追加配送料(税込)

--- a/api/internal/gateway/admin/v1/service/shipping.go
+++ b/api/internal/gateway/admin/v1/service/shipping.go
@@ -23,6 +23,7 @@ func NewShipping(shipping *entity.Shipping) *Shipping {
 	return &Shipping{
 		Shipping: response.Shipping{
 			ID:                shipping.ID,
+			Name:              shipping.Name,
 			IsDefault:         shipping.IsDefault(),
 			Box60Rates:        NewShippingRates(shipping.Box60Rates).Response(),
 			Box60Frozen:       shipping.Box60Frozen,

--- a/api/internal/gateway/admin/v1/service/shipping_test.go
+++ b/api/internal/gateway/admin/v1/service/shipping_test.go
@@ -22,6 +22,7 @@ func TestShipping(t *testing.T) {
 				ID:            "shipping-id",
 				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
+				Name:          "配送設定",
 				CreatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
 				UpdatedAt:     jst.Date(2022, 1, 1, 0, 0, 0, 0),
 				ShippingRevision: entity.ShippingRevision{
@@ -46,6 +47,7 @@ func TestShipping(t *testing.T) {
 			expect: &Shipping{
 				Shipping: response.Shipping{
 					ID:        "shipping-id",
+					Name:      "配送設定",
 					IsDefault: false,
 					Box60Rates: []*response.ShippingRate{
 						{Number: 1, Name: "東京都", Price: 0, PrefectureCodes: []int32{13}},

--- a/api/internal/store/database/database.go
+++ b/api/internal/store/database/database.go
@@ -600,6 +600,7 @@ type ListShippingsParams struct {
 }
 
 type UpdateShippingParams struct {
+	Name              string
 	Box60Rates        entity.ShippingRates
 	Box60Frozen       int64
 	Box80Rates        entity.ShippingRates

--- a/api/internal/store/database/tidb/shipping_test.go
+++ b/api/internal/store/database/tidb/shipping_test.go
@@ -671,6 +671,7 @@ func TestShipping_Update(t *testing.T) {
 			args: args{
 				shippingID: "shipping-id",
 				params: &database.UpdateShippingParams{
+					Name:              "配送設定",
 					Box60Rates:        s.Box60Rates,
 					Box60Frozen:       800,
 					Box80Rates:        s.Box80Rates,
@@ -934,6 +935,7 @@ func testShipping(shippingID, shopID, coordinatorID string, revisionID int64, no
 		ID:               shippingID,
 		ShopID:           shopID,
 		CoordinatorID:    coordinatorID,
+		Name:             "配送設定",
 		InUse:            true,
 		ShippingRevision: *revision,
 		CreatedAt:        now,

--- a/api/internal/store/entity/shipping.go
+++ b/api/internal/store/entity/shipping.go
@@ -32,6 +32,7 @@ type Shipping struct {
 	ID               string         `gorm:"primaryKey;<-:create"` // 配送設定ID
 	ShopID           string         `gorm:"default:null"`         // 店舗ID
 	CoordinatorID    string         `gorm:""`                     // コーディネータID
+	Name             string         `gorm:""`                     // 配送設定名
 	InUse            bool           `gorm:""`                     // 使用中
 	CreatedAt        time.Time      `gorm:"<-:create"`            // 登録日時
 	UpdatedAt        time.Time      `gorm:""`                     // 更新日時
@@ -42,6 +43,7 @@ type Shippings []*Shipping
 
 type NewShippingParams struct {
 	ShopID            string
+	Name              string
 	CoordinatorID     string
 	Box60Rates        ShippingRates
 	Box60Frozen       int64
@@ -82,6 +84,7 @@ func NewShipping(params *NewShippingParams) *Shipping {
 		ID:               params.CoordinatorID, // PKはコーディネータと同一にする
 		ShopID:           params.ShopID,
 		CoordinatorID:    params.CoordinatorID,
+		Name:             params.Name,
 		InUse:            params.InUse,
 		ShippingRevision: *revision,
 	}

--- a/api/internal/store/entity/shipping_test.go
+++ b/api/internal/store/entity/shipping_test.go
@@ -70,6 +70,7 @@ func TestShipping(t *testing.T) {
 			params: &NewShippingParams{
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
+				Name:              "配送設定",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
 				Box80Rates:        rates,
@@ -83,6 +84,7 @@ func TestShipping(t *testing.T) {
 				ID:            "coordinator-id",
 				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
+				Name:          "配送設定",
 				ShippingRevision: ShippingRevision{
 					ShippingID:        "coordinator-id",
 					Box60Rates:        rates,

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -985,6 +985,7 @@ type GetShippingByCoordinatorIDInput struct {
 type CreateShippingInput struct {
 	ShopID            string                `validate:"required"`
 	CoordinatorID     string                `validate:"required"`
+	Name              string                `validate:"required,max=64"`
 	Box60Rates        []*CreateShippingRate `validate:"required,dive,required"`
 	Box60Frozen       int64                 `validate:"min=0,lt=10000000000"`
 	Box80Rates        []*CreateShippingRate `validate:"required,dive,required"`
@@ -1004,6 +1005,7 @@ type CreateShippingRate struct {
 
 type UpdateShippingInput struct {
 	ShippingID        string                `validate:"required"`
+	Name              string                `validate:"required,max=64"`
 	Box60Rates        []*UpdateShippingRate `validate:"required,dive,required"`
 	Box60Frozen       int64                 `validate:"min=0,lt=10000000000"`
 	Box80Rates        []*UpdateShippingRate `validate:"required,dive,required"`

--- a/api/internal/store/service/shipping.go
+++ b/api/internal/store/service/shipping.go
@@ -121,6 +121,7 @@ func (s *service) CreateShipping(ctx context.Context, in *store.CreateShippingIn
 	params := &entity.NewShippingParams{
 		ShopID:            in.ShopID,
 		CoordinatorID:     in.CoordinatorID,
+		Name:              in.Name,
 		Box60Rates:        box60Rates,
 		Box60Frozen:       in.Box60Frozen,
 		Box80Rates:        box80Rates,
@@ -155,6 +156,7 @@ func (s *service) UpdateShipping(ctx context.Context, in *store.UpdateShippingIn
 		return fmt.Errorf("api: invalid box 100 rates format: %s: %w", err.Error(), exception.ErrInvalidArgument)
 	}
 	params := &database.UpdateShippingParams{
+		Name:              in.Name,
 		Box60Rates:        box60Rates,
 		Box60Frozen:       in.Box60Frozen,
 		Box80Rates:        box80Rates,

--- a/api/internal/store/service/shipping_test.go
+++ b/api/internal/store/service/shipping_test.go
@@ -607,6 +607,7 @@ func TestCreateShipping(t *testing.T) {
 							ID:            shipping.ID, // ignore
 							ShopID:        "shop-id",
 							CoordinatorID: "coordinator-id",
+							Name:          "配送設定",
 							ShippingRevision: entity.ShippingRevision{
 								ShippingID: shipping.ID,
 								Box60Rates: entity.ShippingRates{
@@ -634,6 +635,7 @@ func TestCreateShipping(t *testing.T) {
 					})
 			},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
@@ -661,6 +663,7 @@ func TestCreateShipping(t *testing.T) {
 					})
 			},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
@@ -685,6 +688,7 @@ func TestCreateShipping(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 			},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        []*store.CreateShippingRate{},
@@ -702,6 +706,7 @@ func TestCreateShipping(t *testing.T) {
 			name:  "invalid box 80 rates",
 			setup: func(ctx context.Context, mocks *mocks) {},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
@@ -719,6 +724,7 @@ func TestCreateShipping(t *testing.T) {
 			name:  "invalid box 100 rates",
 			setup: func(ctx context.Context, mocks *mocks) {},
 			input: &store.CreateShippingInput{
+				Name:          "配送設定",
 				ShopID:        "shop-id",
 				CoordinatorID: "coordinator-id",
 				Box60Rates:    rates,
@@ -735,6 +741,7 @@ func TestCreateShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().GetByCoordinatorID(ctx, "coordinator-id").Return(nil, assert.AnError)
 			},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
@@ -755,6 +762,7 @@ func TestCreateShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Create(ctx, gomock.Any()).Return(assert.AnError)
 			},
 			input: &store.CreateShippingInput{
+				Name:              "配送設定",
 				ShopID:            "shop-id",
 				CoordinatorID:     "coordinator-id",
 				Box60Rates:        rates,
@@ -800,6 +808,7 @@ func TestUpdateShipping(t *testing.T) {
 		{Name: "その他", Price: 500, PrefectureCodes: others},
 	}
 	params := &database.UpdateShippingParams{
+		Name: "配送設定",
 		Box60Rates: entity.ShippingRates{
 			{Number: 1, Name: "四国", Price: 250, PrefectureCodes: shikoku},
 			{Number: 2, Name: "その他", Price: 500, PrefectureCodes: others},
@@ -831,6 +840,7 @@ func TestUpdateShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Update(ctx, "shipping-id", params).Return(nil)
 			},
 			input: &store.UpdateShippingInput{
+				Name:              "配送設定",
 				ShippingID:        "shipping-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,
@@ -854,6 +864,7 @@ func TestUpdateShipping(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 			},
 			input: &store.UpdateShippingInput{
+				Name:              "配送設定",
 				ShippingID:        "shipping-id",
 				Box60Rates:        []*store.UpdateShippingRate{},
 				Box60Frozen:       800,
@@ -871,6 +882,7 @@ func TestUpdateShipping(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 			},
 			input: &store.UpdateShippingInput{
+				Name:         "配送設定",
 				ShippingID:   "shipping-id",
 				Box60Rates:   rates,
 				Box60Frozen:  800,
@@ -886,6 +898,7 @@ func TestUpdateShipping(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 			},
 			input: &store.UpdateShippingInput{
+				Name:         "配送設定",
 				ShippingID:   "shipping-id",
 				Box60Rates:   rates,
 				Box60Frozen:  800,
@@ -902,6 +915,7 @@ func TestUpdateShipping(t *testing.T) {
 				mocks.db.Shipping.EXPECT().Update(ctx, "shipping-id", params).Return(assert.AnError)
 			},
 			input: &store.UpdateShippingInput{
+				Name:              "配送設定",
 				ShippingID:        "shipping-id",
 				Box60Rates:        rates,
 				Box60Frozen:       800,

--- a/infra/tidb/schema/stores/2025050501-add-column-to-shippings.sql
+++ b/infra/tidb/schema/stores/2025050501-add-column-to-shippings.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `stores`.`shippings` ADD COLUMN `deleted_at` DATETIME NULL DEFAULT NULL;
+ALTER TABLE `stores`.`shippings` ADD COLUMN `name` VARCHAR(64) NOT NULL DEFAULT '';

--- a/infra/tidb/schema/stores/2025052301-add-column-to-shippings.sql
+++ b/infra/tidb/schema/stores/2025052301-add-column-to-shippings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `stores`.`shippings` ADD COLUMN `deleted_at` DATETIME NULL DEFAULT NULL;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 配送設定に「名前」フィールドが追加され、配送設定名を登録・更新・表示できるようになりました。

- **データベース**
  - 配送設定テーブルに「name」カラム（必須、最大64文字）と「deleted_at」カラム（論理削除用）が追加されました。

- **バグ修正**
  - 配送設定の作成・更新時に「名前」フィールドのバリデーション（必須・最大64文字）が適用されます。

- **テスト**
  - 「名前」フィールドに対応したテストケースが追加・更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->