### PR TITLE
Release for v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v5.0.1](https://github.com/and-period/furumaru/compare/v5.0.0...v5.0.1) - 2025-06-04
+- build(deps): bump shell-quote from 1.8.2 to 1.8.3 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2834
+- fix: プロモーションコードが有効だった場合にpayloadに詰める処理を追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2836
+
 ## [v5.0.0](https://github.com/and-period/furumaru/compare/v4.4.16...v5.0.0) - 2025-05-30
 - feat(store): 配送設定のCRUD実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2800
 - feat(docs): 配送設定関連のAPI仕様書を追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2802


### PR DESCRIPTION
This pull request is for the next release as v5.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump shell-quote from 1.8.2 to 1.8.3 in /docs/swagger in the dependencies group by @dependabot in https://github.com/and-period/furumaru/pull/2834
* fix: プロモーションコードが有効だった場合にpayloadに詰める処理を追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2836


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.0...v5.0.1