### PR TITLE
Release for v5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v5.0.5](https://github.com/and-period/furumaru/compare/v5.0.4...v5.0.5) - 2025-06-23
+- 注文詳細取得のロジックの改修 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2860
+
 ## [v5.0.4](https://github.com/and-period/furumaru/compare/v5.0.3...v5.0.4) - 2025-06-21
 - fix: 現在地に戻る不具合の修正 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2857
 - feat(map): マップのジェスチャー処理を「greedy」に設定 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2859


### PR DESCRIPTION
This pull request is for the next release as v5.0.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 注文詳細取得のロジックの改修 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2860


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.4...v5.0.5