### PR TITLE
Release for v5.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v5.0.6](https://github.com/and-period/furumaru/compare/v5.0.5...v5.0.6) - 2025-06-24
+- Fix/web/admin/order detail by @wf-yamaday in https://github.com/and-period/furumaru/pull/2862
+
 ## [v5.0.5](https://github.com/and-period/furumaru/compare/v5.0.4...v5.0.5) - 2025-06-23
 - 注文詳細取得のロジックの改修 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2860
 


### PR DESCRIPTION
This pull request is for the next release as v5.0.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix/web/admin/order detail by @wf-yamaday in https://github.com/and-period/furumaru/pull/2862


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.5...v5.0.6