### PR TITLE
Release for v5.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v5.0.7](https://github.com/and-period/furumaru/compare/v5.0.6...v5.0.7) - 2025-07-26
+- docs: Add Claude Code configuration and project documentation by @taba2424 in https://github.com/and-period/furumaru/pull/2868
+- build(deps): bump the dependencies group across 1 directory with 55 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2865
+- build(deps): bump the dependencies group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2866
+- build(deps): bump the dependencies group across 1 directory with 68 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2867
+- build(deps): bump the dependencies group in /api with 19 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2870
+- LINEの友達追加のバナー追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2872
+- Add: when text is url change to link by @hamachans in https://github.com/and-period/furumaru/pull/2873
+- 管理者画面の商品管理における編集ボタンの改善 - 固定フッターへの移動 by @Copilot in https://github.com/and-period/furumaru/pull/2877
+- Fix map marker display for experiences with identical coordinates by @Copilot in https://github.com/and-period/furumaru/pull/2879
+- fix(web/admin): resolve Nuxt v4 startup errors and update Git workflow docs by @taba2424 in https://github.com/and-period/furumaru/pull/2882
+- LIFFアプリのひな型の配置 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2884
+- feat(api): add Google Merchant Center product feed endpoint by @taba2424 in https://github.com/and-period/furumaru/pull/2888
+- build(deps): bump the dependencies group across 1 directory with 67 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2889
+- build(deps): bump the dependencies group across 1 directory with 159 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2890
+
 ## [v5.0.6](https://github.com/and-period/furumaru/compare/v5.0.5...v5.0.6) - 2025-06-24
 - Fix/web/admin/order detail by @wf-yamaday in https://github.com/and-period/furumaru/pull/2862
 


### PR DESCRIPTION
This pull request is for the next release as v5.0.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* docs: Add Claude Code configuration and project documentation by @taba2424 in https://github.com/and-period/furumaru/pull/2868
* build(deps): bump the dependencies group across 1 directory with 55 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2865
* build(deps): bump the dependencies group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2866
* build(deps): bump the dependencies group across 1 directory with 68 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2867
* build(deps): bump the dependencies group in /api with 19 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2870
* LINEの友達追加のバナー追加 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2872
* Add: when text is url change to link by @hamachans in https://github.com/and-period/furumaru/pull/2873
* 管理者画面の商品管理における編集ボタンの改善 - 固定フッターへの移動 by @Copilot in https://github.com/and-period/furumaru/pull/2877
* Fix map marker display for experiences with identical coordinates by @Copilot in https://github.com/and-period/furumaru/pull/2879
* fix(web/admin): resolve Nuxt v4 startup errors and update Git workflow docs by @taba2424 in https://github.com/and-period/furumaru/pull/2882
* LIFFアプリのひな型の配置 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2884
* feat(api): add Google Merchant Center product feed endpoint by @taba2424 in https://github.com/and-period/furumaru/pull/2888
* build(deps): bump the dependencies group across 1 directory with 67 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2889
* build(deps): bump the dependencies group across 1 directory with 159 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2890

## New Contributors
* @Copilot made their first contribution in https://github.com/and-period/furumaru/pull/2877

**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.6...v5.0.7