### PR TITLE
Release for v5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v5.0.8](https://github.com/and-period/furumaru/compare/v5.0.7...v5.0.8) - 2025-07-26
+- fix(gateway): Google Merchant Center用のAPIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2891
+
 ## [v5.0.7](https://github.com/and-period/furumaru/compare/v5.0.6...v5.0.7) - 2025-07-26
 - docs: Add Claude Code configuration and project documentation by @taba2424 in https://github.com/and-period/furumaru/pull/2868
 - build(deps): bump the dependencies group across 1 directory with 55 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2865


### PR DESCRIPTION
This pull request is for the next release as v5.0.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(gateway): Google Merchant Center用のAPIの修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2891


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.7...v5.0.8