### PR TITLE
Release for v5.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v5.0.10](https://github.com/and-period/furumaru/compare/v5.0.9...v5.0.10) - 2025-08-06
+- build(deps): bump aws-actions/amazon-ecs-deploy-task-definition from 2.3.3 to 2.3.4 in the dependencies group by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2895
+- fix(gateway): OAuth関連エンドポイントのpathを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2898
+- refactor(gateway): ファイル構成を変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2900
+- feat(*): 起動時処理でslogを初期化するように by @taba2424 in https://github.com/and-period/furumaru/pull/2901
+- refactor(*): zapからslogへの移行 by @taba2424 in https://github.com/and-period/furumaru/pull/2903
+- build(deps): bump aws-actions/amazon-ecs-render-task-definition from 1.7.4 to 1.7.5 in the dependencies group by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2907
+- Fix/web/user/seo by @wf-yamaday in https://github.com/and-period/furumaru/pull/2906
+
 ## [v5.0.9](https://github.com/and-period/furumaru/compare/v5.0.8...v5.0.9) - 2025-07-29
 - test(gateway): Google Merchant Center用APIのテストコード追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2893
 


### PR DESCRIPTION
This pull request is for the next release as v5.0.10 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.10 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.9" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump aws-actions/amazon-ecs-deploy-task-definition from 2.3.3 to 2.3.4 in the dependencies group by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2895
* fix(gateway): OAuth関連エンドポイントのpathを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2898
* refactor(gateway): ファイル構成を変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2900
* feat(*): 起動時処理でslogを初期化するように by @taba2424 in https://github.com/and-period/furumaru/pull/2901
* refactor(*): zapからslogへの移行 by @taba2424 in https://github.com/and-period/furumaru/pull/2903
* build(deps): bump aws-actions/amazon-ecs-render-task-definition from 1.7.4 to 1.7.5 in the dependencies group by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2907
* Fix/web/user/seo by @wf-yamaday in https://github.com/and-period/furumaru/pull/2906


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.9...v5.0.10