### PR TITLE
Release for v5.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v5.0.11](https://github.com/and-period/furumaru/compare/v5.0.10...v5.0.11) - 2025-08-12
+- feat(gateway): キャンプ施設向けのAPIハンドラの初期設定 by @taba2424 in https://github.com/and-period/furumaru/pull/2910
+- feat(store): Orderに配送方法をもたせる by @taba2424 in https://github.com/and-period/furumaru/pull/2912
+- 共通UIコンポーネントライブラリの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2905
+
 ## [v5.0.10](https://github.com/and-period/furumaru/compare/v5.0.9...v5.0.10) - 2025-08-06
 - build(deps): bump aws-actions/amazon-ecs-deploy-task-definition from 2.3.3 to 2.3.4 in the dependencies group by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2895
 - fix(gateway): OAuth関連エンドポイントのpathを変更 by @taba2424 in https://github.com/and-period/furumaru/pull/2898


### PR DESCRIPTION
This pull request is for the next release as v5.0.11 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.0.11 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.10" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(gateway): キャンプ施設向けのAPIハンドラの初期設定 by @taba2424 in https://github.com/and-period/furumaru/pull/2910
* feat(store): Orderに配送方法をもたせる by @taba2424 in https://github.com/and-period/furumaru/pull/2912
* 共通UIコンポーネントライブラリの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2905


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.10...v5.0.11