### PR TITLE
Release for v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v5.1.0](https://github.com/and-period/furumaru/compare/v5.0.11...v5.1.0) - 2025-08-19
+- build(deps): bump the dependencies group across 1 directory with 67 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2911
+- build(deps): bump the dependencies group across 1 directory with 130 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2908
+- [web] Simplify CI pipeline for web/shared and web/liff dependency handling by @Copilot in https://github.com/and-period/furumaru/pull/2916
+- Update README.md by @hamachans in https://github.com/and-period/furumaru/pull/2917
+- LFF用の商品一覧ページのモック実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2918
+- FmTextInputコンポーネントの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2919
+- feat(api): add order types, shipping types and metadata functionality by @taba2424 in https://github.com/and-period/furumaru/pull/2924
+- build(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2921
+- build(deps): bump the dependencies group in /web/admin with 33 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2922
+- Add: added check in register page by @hamachans in https://github.com/and-period/furumaru/pull/2923
+- Add: added purchase complete page by @hamachans in https://github.com/and-period/furumaru/pull/2925
+- Add: added checkin check page by @hamachans in https://github.com/and-period/furumaru/pull/2926
+- build(deps): bump the dependencies group in /api with 45 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2920
+
 ## [v5.0.11](https://github.com/and-period/furumaru/compare/v5.0.10...v5.0.11) - 2025-08-12
 - feat(gateway): キャンプ施設向けのAPIハンドラの初期設定 by @taba2424 in https://github.com/and-period/furumaru/pull/2910
 - feat(store): Orderに配送方法をもたせる by @taba2424 in https://github.com/and-period/furumaru/pull/2912


### PR DESCRIPTION
This pull request is for the next release as v5.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.0.11" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps): bump the dependencies group across 1 directory with 67 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2911
* build(deps): bump the dependencies group across 1 directory with 130 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2908
* [web] Simplify CI pipeline for web/shared and web/liff dependency handling by @Copilot in https://github.com/and-period/furumaru/pull/2916
* Update README.md by @hamachans in https://github.com/and-period/furumaru/pull/2917
* LFF用の商品一覧ページのモック実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2918
* FmTextInputコンポーネントの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2919
* feat(api): add order types, shipping types and metadata functionality by @taba2424 in https://github.com/and-period/furumaru/pull/2924
* build(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2921
* build(deps): bump the dependencies group in /web/admin with 33 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2922
* Add: added check in register page by @hamachans in https://github.com/and-period/furumaru/pull/2923
* Add: added purchase complete page by @hamachans in https://github.com/and-period/furumaru/pull/2925
* Add: added checkin check page by @hamachans in https://github.com/and-period/furumaru/pull/2926
* build(deps): bump the dependencies group in /api with 45 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2920


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.0.11...v5.1.0