### PR TITLE
FmTextInputコンポーネントの実装

### DIFF
--- a/web/shared/src/assets/main.css
+++ b/web/shared/src/assets/main.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @theme {
+	--color-placeholder: oklch(0.6633 0 0);
 	--color-main: oklch(0.4335 0.0341 54.63);
 	--color-orange: oklch(0.739 0.1632 59);
 }

--- a/web/shared/src/components/FmProductItem.vue
+++ b/web/shared/src/components/FmProductItem.vue
@@ -2,13 +2,13 @@
 import { computed, ref } from 'vue';
 
 interface Props {
-	name: string;
-	price: number
+  name: string;
+  price: number
   thumbnailUrl: string
   stock: number
   soldOutText?: string
-	addToCartButtonText?: string;
-	selectLabelText?: string
+  addToCartButtonText?: string;
+  selectLabelText?: string
 }
 
 interface Emits {
@@ -16,8 +16,8 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	addToCartButtonText: 'カゴに入れる',
-	selectLabelText: '数量',
+  addToCartButtonText: 'カゴに入れる',
+  selectLabelText: '数量',
   soldOutText: '在庫なし',
 });
 
@@ -55,7 +55,7 @@ const stokeValues = computed<number>(() => {
   if (props.stock > 10) {
     return 10
   }
-	return props.stock
+  return props.stock
 })
 
 /**

--- a/web/shared/src/components/FmTextInput.stories.ts
+++ b/web/shared/src/components/FmTextInput.stories.ts
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import FmTextInput from './FmTextInput.vue';
+
+const meta: Meta = {
+  title: 'FmTextInput',
+  component: FmTextInput,
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof FmTextInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text',
+  },
+}
+
+export const Secret: Story = {
+  args: {
+    type: 'password',
+    placeholder: 'Enter secret',
+  },
+}
+
+export const Labelled: Story = {
+  args: {
+    label: 'Username',
+    placeholder: 'Enter your username',
+  },
+}
+
+export const WithMessage: Story = {
+  args: {
+    label: 'Email',
+    type: 'email',
+    placeholder: 'Enter your email',
+    message: 'Please enter a valid email address.',
+  },
+}
+
+
+export const HasError: Story = {
+  args: {
+    label: 'Email',
+    type: 'email',
+    placeholder: 'Enter your email',
+    message: 'Please enter a valid email address.',
+    error: true,
+    errorMessage: 'Invalid email address.',
+  },
+}

--- a/web/shared/src/components/FmTextInput.vue
+++ b/web/shared/src/components/FmTextInput.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+interface Props {
+  name: string
+  id?: string
+  label?: string
+  type?: 'text' | 'password' | 'email' | 'number'
+  placeholder?: string
+  required?: boolean
+  message?: string
+  error?: boolean
+  errorMessage?: string
+  pattern?: string
+  maxLength?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  id: '',
+  label: '',
+  type: 'text',
+  placeholder: '',
+  required: false,
+  message: '',
+  error: false,
+  errorMessage: '',
+  pattern: '',
+  maxLength: undefined,
+})
+
+
+const modelValue = defineModel<string | number>('modelValue', {
+  type: [String, Number],
+})
+
+/**
+ * パスワードの表示切り替え
+ * props.type === 'password'の場合のみ使用
+ */
+const showSecretValue = ref<boolean>(false)
+
+/**
+ * フォームのtype属性
+ */
+const formType = computed(() => {
+  if (props.type === 'password') {
+    if (showSecretValue.value) {
+      return 'text'
+    }
+    else {
+      return 'password'
+    }
+  }
+  else {
+    return props.type
+  }
+})
+
+
+/**
+ * エラーの判定
+ * errorMessageが渡されている場合はエラー状態にする
+ */
+const hasError = computed(() => {
+  if (props.error) {
+    return true
+  }
+  if (props.errorMessage !== '') {
+    return true
+  }
+  return false
+})
+
+/**
+ * メッセージエリアに表示する文字列
+ * errorMessageを優先する
+ */
+const viewMessage = computed(() => {
+  if (props.errorMessage !== '') {
+    return props.errorMessage
+  }
+  else {
+    return props.message
+  }
+})
+</script>
+
+<template>
+  <div>
+    <div class="w-full text-main">
+      <label
+        v-if="label"
+        class="inline-block"
+        :for="id"
+      >
+        {{ label }}
+      </label>
+      <div class="relative w-full">
+        <input
+          :id="id"
+          v-model="modelValue"
+          :name="name"
+          :type="formType"
+          :placeholder="placeholder"
+          :required="required"
+          :pattern="pattern || undefined"
+          :maxlength="maxLength || undefined"
+          :class="{
+            'block w-full appearance-none rounded-none border-b border-main bg-transparent px-2 leading-10 outline-none ring-0 focus:outline-none placeholder:text-placeholder': true,
+            'border-b-2 border-orange': hasError,
+            'pr-8': type === 'password',
+          }"
+        >
+        <button
+          v-if="type === 'password'"
+          class="absolute right-0 top-0 h-full px-2"
+          type="button"
+          :aria-label="showSecretValue ? 'パスワードを隠す' : 'パスワードを表示'"
+          @click="showSecretValue = !showSecretValue"
+        >
+          <template v-if="showSecretValue">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="h-5 w-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+              />
+            </svg>
+          </template>
+          <template v-else>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="h-5 w-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"
+              />
+            </svg>
+          </template>
+        </button>
+      </div>
+    </div>
+    <p :class="{ 'text-orange': hasError, 'text-left text-sm text-main': true }">
+      {{ viewMessage }}
+    </p>
+  </div>
+</template>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 再利用可能なテキスト入力コンポーネントを追加。ラベル、プレースホルダー、エラーメッセージ、入力制限、パスワード表示切替に対応。
- ドキュメント
  - Storybookにテキスト入力のデモを追加（標準/パスワード/ラベル付き/メッセージ/エラー）。
- スタイル
  - テーマにプレースホルダー用の色トークンを追加。
  - 一部コンポーネントの整形を実施（挙動変更なし）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->