### PR TITLE
Release for v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v5.1.1](https://github.com/and-period/furumaru/compare/v5.1.0...v5.1.1) - 2025-08-20
+- [web] 注文内容情報の共用コンポーネントの実装 by @Copilot in https://github.com/and-period/furumaru/pull/2930
+- [web] Implement FmProductDetail shared component for product detail pages by @Copilot in https://github.com/and-period/furumaru/pull/2928
+- [shared] Implement FmCreditCardForm component for reusable credit card input by @Copilot in https://github.com/and-period/furumaru/pull/2936
+- [web] Implement LIFF product detail page using FmProductDetail component by @Copilot in https://github.com/and-period/furumaru/pull/2934
+- Add LIFF API client generation to Swagger build system by @Copilot in https://github.com/and-period/furumaru/pull/2941
+- feat: 買い物カゴのUIパーツの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2944
+- feat(OrderShow): 顧客情報と予約情報の表示を改善 by @hamachans in https://github.com/and-period/furumaru/pull/2947
+
 ## [v5.1.0](https://github.com/and-period/furumaru/compare/v5.0.11...v5.1.0) - 2025-08-19
 - build(deps): bump the dependencies group across 1 directory with 67 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2911
 - build(deps): bump the dependencies group across 1 directory with 130 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/2908


### PR DESCRIPTION
This pull request is for the next release as v5.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [web] 注文内容情報の共用コンポーネントの実装 by @Copilot in https://github.com/and-period/furumaru/pull/2930
* [web] Implement FmProductDetail shared component for product detail pages by @Copilot in https://github.com/and-period/furumaru/pull/2928
* [shared] Implement FmCreditCardForm component for reusable credit card input by @Copilot in https://github.com/and-period/furumaru/pull/2936
* [web] Implement LIFF product detail page using FmProductDetail component by @Copilot in https://github.com/and-period/furumaru/pull/2934
* Add LIFF API client generation to Swagger build system by @Copilot in https://github.com/and-period/furumaru/pull/2941
* feat: 買い物カゴのUIパーツの実装 by @wf-yamaday in https://github.com/and-period/furumaru/pull/2944
* feat(OrderShow): 顧客情報と予約情報の表示を改善 by @hamachans in https://github.com/and-period/furumaru/pull/2947


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.1.0...v5.1.1