### PR TITLE
feat(OrderShow): 顧客情報と予約情報の表示を改善

### DIFF
--- a/web/admin/src/components/templates/OrderShow.vue
+++ b/web/admin/src/components/templates/OrderShow.vue
@@ -875,7 +875,7 @@ const onSubmitRefund = (): void => {
             </template>
           </v-data-table>
 
-          <v-list v-if="props.order.type === OrderType.EXPERIENCE">
+          <v-list>
             <v-list-item class="mb-4">
               <v-list-item-subtitle class="mb-2">
                 顧客情報
@@ -883,7 +883,7 @@ const onSubmitRefund = (): void => {
               <div>{{ getCustomerName() }}</div>
               <div>{{ getCustomerNameKana() }}</div>
               <div class="mt-1">
-                &Mu; {{ props.customer.email }}
+                &#128231; {{ props.customer.email }}
               </div>
               <div>&phone; {{ props.customer.phoneNumber }}</div>
             </v-list-item>
@@ -899,7 +899,61 @@ const onSubmitRefund = (): void => {
           予約情報
         </v-card-title>
         <v-card-text>
-          TODO：必要な情報を表示する
+          <v-row>
+            <v-col cols="3">
+              大人:
+            </v-col>
+            <v-col cols="3">
+              {{ props.order.experience.adultCount }}人
+            </v-col>
+            <v-col cols="6">
+              合計: {{ props.order.experience.adultPrice * props.order.experience.adultCount }}円
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="3">
+              未就学児(3歳〜):
+            </v-col>
+            <v-col cols="3">
+              {{ props.order.experience.preschoolCount }}人
+            </v-col>
+            <v-col cols="6">
+              合計: {{ props.order.experience.preschoolPrice * props.order.experience.preschoolCount }}円
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="3">
+              小学生:
+            </v-col>
+            <v-col cols="3">
+              {{ props.order.experience.elementarySchoolCount }}人
+            </v-col>
+            <v-col cols="6">
+              合計: {{ props.order.experience.elementarySchoolPrice * props.order.experience.elementarySchoolCount }}円
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="3">
+              中学生:
+            </v-col>
+            <v-col cols="3">
+              {{ props.order.experience.juniorHighSchoolCount }}人
+            </v-col>
+            <v-col cols="6">
+              合計: {{ props.order.experience.juniorHighSchoolPrice * props.order.experience.juniorHighSchoolCount }}円
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="3">
+              シニア(65歳〜):
+            </v-col>
+            <v-col cols="3">
+              {{ props.order.experience.seniorCount }}人
+            </v-col>
+            <v-col cols="6">
+              合計: {{ props.order.experience.seniorPrice * props.order.experience.seniorCount }}円
+            </v-col>
+          </v-row>
         </v-card-text>
       </v-card>
     </v-col>
@@ -922,11 +976,14 @@ const onSubmitRefund = (): void => {
               <div>{{ getCustomerName() }}</div>
               <div>{{ getCustomerNameKana() }}</div>
               <div class="mt-1">
-                &Mu; {{ props.customer.email }}
+                &#128231; {{ props.customer.email }}
               </div>
               <div>&phone; {{ props.customer.phoneNumber }}</div>
             </v-list-item>
-            <v-list-item class="mb-4">
+            <v-list-item
+              v-if="props.order.type !== OrderType.EXPERIENCE"
+              class="mb-4"
+            >
               <v-list-item-subtitle class="pb-2">
                 請求先情報
               </v-list-item-subtitle>

--- a/web/admin/src/pages/orders/[id]/index.vue
+++ b/web/admin/src/pages/orders/[id]/index.vue
@@ -3,7 +3,7 @@ import { storeToRefs } from 'pinia'
 
 import { useAlert } from '~/lib/hooks'
 import { useCustomerStore, useOrderStore } from '~/store'
-import type { DraftOrderRequest, CompleteOrderRequest, RefundOrderRequest, UpdateOrderFulfillmentRequest, OrderFulfillment } from '~/types/api'
+import type { DraftOrderRequest, CompleteOrderRequest, RefundOrderRequest, UpdateOrderFulfillmentRequest, OrderFulfillment, User } from '~/types/api'
 import type { FulfillmentInput } from '~/types/props'
 
 const route = useRoute()
@@ -19,6 +19,7 @@ const { customer } = storeToRefs(customerStore)
 const loading = ref<boolean>(false)
 const cancelDialog = ref<boolean>(false)
 const refundDialog = ref<boolean>(false)
+const userData = ref<User>()
 const completeFormData = ref<CompleteOrderRequest>({
   shippingMessage: '',
 })
@@ -38,6 +39,7 @@ const { data, refresh, status, error } = useAsyncData(`order-${orderId}`, () => 
 watch(data, (newData) => {
   // 注文情報が更新されたら、フォームデータを初期化
   if (newData) {
+    userData.value = newData.user
     completeFormData.value = {
       shippingMessage: newData.order.shippingMessage,
     }
@@ -221,7 +223,7 @@ const handleSubmitUpdateFulfillment = async (fulfillmentId: string): Promise<voi
       :alert-text="alertText"
       :order="order"
       :coordinator="coordinator"
-      :customer="customer"
+      :customer="userData"
       :products="products"
       @submit:capture="handleSubmitCapture"
       @submit:draft="handleSubmitDraft"


### PR DESCRIPTION
fix(OrderIndex): ユーザーデータの取得と顧客情報のバインディングを修正

## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 予約情報（EXPERIENCE注文向け）を追加。年齢区分ごとの人数と合計を表示。
  - 請求先情報（EXPERIENCE以外の注文向け）を追加。氏名、電話、郵便番号、住所を表示。
- 改善
  - 顧客情報を常に表示するよう変更し、注文タイプに依存せず確認可能に。
  - 顧客情報のデータソースを更新し、注文詳細画面での表示精度を向上。
- スタイル
  - メールアイコンを適切な封筒絵文字に統一し、表示の一貫性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->