### PR TITLE
Release for v5.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v5.1.2](https://github.com/and-period/furumaru/compare/v5.1.1...v5.1.2) - 2025-08-24
+- [liff] Implement API client integration for product listing page by @Copilot in https://github.com/and-period/furumaru/pull/2943
+- [liff] 買い物カゴのUIを共通レイアウトに実装 by @Copilot in https://github.com/and-period/furumaru/pull/2946
+- fix(gateway): path prefixに生産者IDを含めるように by @taba2424 in https://github.com/and-period/furumaru/pull/2949
+- feat(gateway): キャンプ施設向けの注文APIの仕様追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2931
+- fix(gateway): user.goの変更に合わせてテストを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2952
+
 ## [v5.1.1](https://github.com/and-period/furumaru/compare/v5.1.0...v5.1.1) - 2025-08-20
 - [web] 注文内容情報の共用コンポーネントの実装 by @Copilot in https://github.com/and-period/furumaru/pull/2930
 - [web] Implement FmProductDetail shared component for product detail pages by @Copilot in https://github.com/and-period/furumaru/pull/2928


### PR DESCRIPTION
This pull request is for the next release as v5.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v5.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v5.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [liff] Implement API client integration for product listing page by @Copilot in https://github.com/and-period/furumaru/pull/2943
* [liff] 買い物カゴのUIを共通レイアウトに実装 by @Copilot in https://github.com/and-period/furumaru/pull/2946
* fix(gateway): path prefixに生産者IDを含めるように by @taba2424 in https://github.com/and-period/furumaru/pull/2949
* feat(gateway): キャンプ施設向けの注文APIの仕様追加 by @taba2424 in https://github.com/and-period/furumaru/pull/2931
* fix(gateway): user.goの変更に合わせてテストを修正 by @taba2424 in https://github.com/and-period/furumaru/pull/2952


**Full Changelog**: https://github.com/and-period/furumaru/compare/v5.1.1...v5.1.2