### PR TITLE
fix: 所用時間のラベルを所要時間に変更し、表示を分から時間に修正

### DIFF
--- a/web/admin/src/components/templates/ExperienceNew.vue
+++ b/web/admin/src/components/templates/ExperienceNew.vue
@@ -240,7 +240,7 @@ const onSubmit = async (): Promise<void> => {
               :min="0"
               :reverse="false"
               control-variant="default"
-              label="所用時間"
+              label="所要時間"
               :hide-input="false"
               :inset="true"
             />

--- a/web/user/src/pages/experiences/[...id].vue
+++ b/web/user/src/pages/experiences/[...id].vue
@@ -542,7 +542,7 @@ useSeoMeta({
                 {{ dt("estimatedTime") }}
               </p>
               <p class="col-span-3 md:col-span-4">
-                {{ data.experience.duration }}分
+                {{ data.experience.duration }}時間
               </p>
             </div>
             <div class="grid grid-cols-5 py-4">


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 体験詳細ページの所要時間の単位表示を「分」から「時間」に修正。表示値は変更なし。
- Style
  - 管理画面の新規作成フォームで入力ラベルを「所用時間」から「所要時間」に統一。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->