### PR TITLE
chore(ci): GitHub ActionsでGoのテストキャッシュを有効化

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -20,7 +20,7 @@ runs:
       go-version-file: ${{ inputs.working-directory }}/go.mod
       cache: false
 
-  - name: Cache go modules
+  - name: Cache go modules and build cache
     id: modules-cache
     uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
     with:
@@ -28,6 +28,19 @@ runs:
         ~/.cache/go-build
         ~/go/pkg/mod
       key: ${{ inputs.service }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      restore-keys: |
+        ${{ inputs.service }}-${{ runner.os }}-go-
+
+  - name: Cache go test results
+    uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+    with:
+      path: |
+        ~/.cache/go-build
+        /tmp/go-test-cache
+      key: ${{ inputs.service }}-${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*.go') }}
+      restore-keys: |
+        ${{ inputs.service }}-${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}-
+        ${{ inputs.service }}-${{ runner.os }}-go-test-
 
   - name: Download modules
     if: steps.modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -82,6 +82,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+    env:
+      GOCACHE: /tmp/go-build-cache
+      GOFLAGS: -buildvcs=false
 
     steps:
     - name: Check out code
@@ -112,6 +115,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+    env:
+      GOCACHE: /tmp/go-test-cache
+      GOFLAGS: -buildvcs=false
 
     steps:
     - name: Check out code
@@ -133,8 +139,12 @@ jobs:
           -db-username=${DB_USERNAME} \
           -db-password=${DB_PASSWORD}
 
-    - name: Test
-      run: make test
+    - name: Test with cache
+      run: |
+        # テストキャッシュディレクトリを作成
+        mkdir -p /tmp/go-test-cache
+        # テストを実行（キャッシュが利用可能な場合は自動的に使用される）
+        make test
 
     - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
       with:


### PR DESCRIPTION
## 概要
GitHub ActionsのCI/CDパイプラインでGoのテストキャッシュを有効化し、テスト実行時間を短縮します。

## 変更内容
- setup-goアクションにテスト結果専用のキャッシュステップを追加
- testジョブとbuildジョブに環境変数を設定してキャッシュを活用
- キャッシュキーにrestore-keysを追加して段階的なヒット率を向上

## 背景・目的
現在のci-backend.yamlではテスト実行に時間がかかっているため、Goのビルドキャッシュとテストキャッシュを有効にすることで、CI/CDパイプラインの実行時間を短縮します。

## 期待される効果
- 初回実行: キャッシュが作成される（実行時間は変わらない）
- 2回目以降: 変更のないテストはキャッシュから結果が取得され、30-70%の実行時間短縮が期待できます

## テスト
- [x] YAMLの構文チェック完了
- [ ] GitHub Actions実行確認

## レビューポイント
- キャッシュパスの設定が適切か
- 環境変数の設定が妥当か
- restore-keysの段階的フォールバックが機能するか

🤖 Generated with [Claude Code](https://claude.ai/code)