### PR TITLE
feat(api): Add facility handlers and services for user gateway

### DIFF
--- a/api/internal/gateway/user/facility/handler/category.go
+++ b/api/internal/gateway/user/facility/handler/category.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/store"
+)
+
+func (h *handler) multiGetCategories(ctx context.Context, categoryIDs []string) (service.Categories, error) {
+	if len(categoryIDs) == 0 {
+		return service.Categories{}, nil
+	}
+	in := &store.MultiGetCategoriesInput{
+		CategoryIDs: categoryIDs,
+	}
+	categories, err := h.store.MultiGetCategories(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewCategories(categories), nil
+}
+
+func (h *handler) getCategory(ctx context.Context, categoryID string) (*service.Category, error) {
+	in := &store.GetCategoryInput{
+		CategoryID: categoryID,
+	}
+	category, err := h.store.GetCategory(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewCategory(category), nil
+}

--- a/api/internal/gateway/user/facility/handler/coordinator.go
+++ b/api/internal/gateway/user/facility/handler/coordinator.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/user"
+)
+
+func (h *handler) multiGetCoordinators(ctx context.Context, coordinatorIDs []string) (service.Coordinators, error) {
+	if len(coordinatorIDs) == 0 {
+		return service.Coordinators{}, nil
+	}
+	in := &user.MultiGetCoordinatorsInput{
+		CoordinatorIDs: coordinatorIDs,
+	}
+	coordinators, err := h.user.MultiGetCoordinators(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if len(coordinators) == 0 {
+		return service.Coordinators{}, nil
+	}
+	shops, err := h.listShopsByCoordinatorIDs(ctx, coordinatorIDs)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewCoordinators(coordinators, shops.MapByCoordinatorID()), nil
+}
+
+func (h *handler) getCoordinator(ctx context.Context, coordinatorID string) (*service.Coordinator, error) {
+	in := &user.GetCoordinatorInput{
+		CoordinatorID: coordinatorID,
+	}
+	coordinator, err := h.user.GetCoordinator(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	shop, err := h.getShopByCoordinatorID(ctx, coordinatorID)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewCoordinator(coordinator, shop), nil
+}

--- a/api/internal/gateway/user/facility/handler/producer.go
+++ b/api/internal/gateway/user/facility/handler/producer.go
@@ -3,10 +3,35 @@ package handler
 import (
 	"context"
 
-	"github.com/and-period/furumaru/api/internal/gateway/user/v1/service"
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
 	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/and-period/furumaru/api/internal/user"
 )
+
+func (h *handler) multiGetProducers(ctx context.Context, producerIDs []string) (service.Producers, error) {
+	if len(producerIDs) == 0 {
+		return service.Producers{}, nil
+	}
+	in := &user.MultiGetProducersInput{
+		ProducerIDs: producerIDs,
+	}
+	producers, err := h.user.MultiGetProducers(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if len(producers) == 0 {
+		return service.Producers{}, nil
+	}
+	shopsIn := &store.ListShopsInput{
+		ProducerIDs: producerIDs,
+		NoLimit:     true,
+	}
+	shops, _, err := h.store.ListShops(ctx, shopsIn)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProducers(producers, shops.GroupByProducerID()), nil
+}
 
 func (h *handler) getProducer(ctx context.Context, producerID string) (*service.Producer, error) {
 	in := &user.GetProducerInput{

--- a/api/internal/gateway/user/facility/handler/product.go
+++ b/api/internal/gateway/user/facility/handler/product.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/and-period/furumaru/api/internal/exception"
 	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/gateway/util"
+	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 )
 
 // @tag.name        Product
@@ -27,14 +33,106 @@ func (h *handler) productRoutes(rg *gin.RouterGroup) {
 // @Success     200 {object} response.ProductsResponse
 // @Failure     400 {object} util.ErrorResponse "バリデーションエラー"
 func (h *handler) ListProducts(ctx *gin.Context) {
-	// TODO: 詳細の実装
+	const (
+		defaultLimit  = 20
+		defaultOffset = 0
+	)
+
+	limit, err := util.GetQueryInt64(ctx, "limit", defaultLimit)
+	if err != nil {
+		h.badRequest(ctx, err)
+		return
+	}
+	offset, err := util.GetQueryInt64(ctx, "offset", defaultOffset)
+	if err != nil {
+		h.badRequest(ctx, err)
+		return
+	}
+
+	in := &store.ListProductsInput{
+		Limit:            limit,
+		Offset:           offset,
+		OnlyPublished:    true,
+		ExcludeOutOfSale: true,
+		ExcludeDeleted:   true,
+		ProducerID:       h.getProducerID(ctx),
+		Orders: []*store.ListProductsOrder{
+			// 売り切れでないもの順 && 公開日時が新しいもの順
+			{Key: store.ListProductsOrderBySoldOut, OrderByASC: true},
+			{Key: store.ListProductsOrderByStartAt, OrderByASC: false},
+		},
+	}
+	products, total, err := h.store.ListProducts(ctx, in)
+	if err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+	if len(products) == 0 {
+		res := &response.ProductsResponse{
+			Products:     []*response.Product{},
+			Coordinators: []*response.Coordinator{},
+			Producers:    []*response.Producer{},
+			Categories:   []*response.Category{},
+			ProductTypes: []*response.ProductType{},
+			ProductTags:  []*response.ProductTag{},
+		}
+		ctx.JSON(http.StatusOK, res)
+		return
+	}
+
+	var (
+		coordinators service.Coordinators
+		producers    service.Producers
+		categories   service.Categories
+		productTypes service.ProductTypes
+		productTags  service.ProductTags
+		productRates service.ProductRates
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		coordinators, err = h.multiGetCoordinators(ectx, products.CoordinatorIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		producers, err = h.multiGetProducers(ectx, products.ProducerIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		productTypes, err = h.multiGetProductTypes(ectx, products.ProductTypeIDs())
+		if err != nil || len(productTypes) == 0 {
+			return
+		}
+		categories, err = h.multiGetCategories(ectx, productTypes.CategoryIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		productTags, err = h.multiGetProductTags(ectx, products.ProductTagIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		productRates, err = h.aggregateProductRates(ectx, products.IDs()...)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+
+	details := &service.ProductDetailsParams{
+		Categories:   categories.Map(),
+		ProductTypes: productTypes.Map(),
+		ProductRates: productRates.MapByProductID(),
+	}
+	sproducts := service.NewProducts(products, details)
+
 	res := &response.ProductsResponse{
-		Products:     []*response.Product{},
-		Coordinators: []*response.Coordinator{},
-		Producers:    []*response.Producer{},
-		Categories:   []*response.Category{},
-		ProductTypes: []*response.ProductType{},
-		ProductTags:  []*response.ProductTag{},
+		Products:     sproducts.Response(),
+		Coordinators: coordinators.Response(),
+		Producers:    producers.Response(),
+		Categories:   categories.Response(),
+		ProductTypes: productTypes.Response(),
+		ProductTags:  productTags.Response(),
+		Total:        total,
 	}
 	ctx.JSON(http.StatusOK, res)
 }
@@ -49,9 +147,103 @@ func (h *handler) ListProducts(ctx *gin.Context) {
 // @Success     200 {object} response.ProductResponse
 // @Failure     404 {object} util.ErrorResponse "商品が見つからない"
 func (h *handler) GetProduct(ctx *gin.Context) {
-	// TODO: 詳細の実装
+	product, err := h.getProduct(ctx, util.GetParam(ctx, "productId"))
+	if err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+
+	var (
+		coordinator *service.Coordinator
+		producer    *service.Producer
+		category    *service.Category
+		productType *service.ProductType
+		productTags service.ProductTags
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		coordinator, err = h.getCoordinator(ectx, product.CoordinatorID)
+		return
+	})
+	eg.Go(func() (err error) {
+		producer, err = h.getProducer(ectx, product.ProducerID)
+		return
+	})
+	eg.Go(func() (err error) {
+		productType, err = h.getProductType(ectx, product.ProductTypeID)
+		if err != nil {
+			return
+		}
+		category, err = h.getCategory(ectx, productType.CategoryID)
+		return
+	})
+	eg.Go(func() (err error) {
+		productTags, err = h.multiGetProductTags(ectx, product.ProductTagIDs)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		h.httpError(ctx, err)
+		return
+	}
+
 	res := &response.ProductResponse{
-		ProductTags: []*response.ProductTag{},
+		Product:     product.Response(),
+		Coordinator: coordinator.Response(),
+		Producer:    producer.Response(),
+		Category:    category.Response(),
+		ProductType: productType.Response(),
+		ProductTags: productTags.Response(),
 	}
 	ctx.JSON(http.StatusOK, res)
+}
+
+func (h *handler) getProduct(ctx context.Context, productID string) (*service.Product, error) {
+	in := &store.GetProductInput{
+		ProductID: productID,
+	}
+	product, err := h.store.GetProduct(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if !product.Public {
+		// 非公開のものは利用者側に表示しない
+		return nil, exception.ErrNotFound
+	}
+	details, err := h.getProductDetails(ctx, productID)
+	if err != nil {
+		return nil, err
+	}
+	category := details.Categories[product.TypeID]
+	rate := details.ProductRates[productID]
+	return service.NewProduct(product, category, rate), nil
+}
+
+func (h *handler) getProductDetails(ctx context.Context, productIDs ...string) (*service.ProductDetailsParams, error) {
+	var (
+		categories   service.Categories
+		productTypes service.ProductTypes
+		productRates service.ProductRates
+	)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		productTypes, err = h.multiGetProductTypes(ectx, productIDs)
+		if err != nil {
+			return
+		}
+		categories, err = h.multiGetCategories(ectx, productTypes.CategoryIDs())
+		return
+	})
+	eg.Go(func() (err error) {
+		productRates, err = h.aggregateProductRates(ectx, productIDs...)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	res := &service.ProductDetailsParams{
+		Categories:   categories.Map(),
+		ProductTypes: productTypes.Map(),
+		ProductRates: productRates.MapByProductID(),
+	}
+	return res, nil
 }

--- a/api/internal/gateway/user/facility/handler/product_review.go
+++ b/api/internal/gateway/user/facility/handler/product_review.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/store"
+)
+
+func (h *handler) aggregateProductRates(ctx context.Context, productIDs ...string) (service.ProductRates, error) {
+	if len(productIDs) == 0 {
+		return service.ProductRates{}, nil
+	}
+	in := &store.AggregateProductReviewsInput{
+		ProductIDs: productIDs,
+	}
+	reviews, err := h.store.AggregateProductReviews(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProductRates(reviews), nil
+}

--- a/api/internal/gateway/user/facility/handler/product_tag.go
+++ b/api/internal/gateway/user/facility/handler/product_tag.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/store"
+)
+
+func (h *handler) multiGetProductTags(ctx context.Context, productTagIDs []string) (service.ProductTags, error) {
+	if len(productTagIDs) == 0 {
+		return service.ProductTags{}, nil
+	}
+	in := &store.MultiGetProductTagsInput{
+		ProductTagIDs: productTagIDs,
+	}
+	productTags, err := h.store.MultiGetProductTags(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProductTags(productTags), nil
+}

--- a/api/internal/gateway/user/facility/handler/product_type.go
+++ b/api/internal/gateway/user/facility/handler/product_type.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/store"
+)
+
+func (h *handler) multiGetProductTypes(ctx context.Context, productTypeIDs []string) (service.ProductTypes, error) {
+	if len(productTypeIDs) == 0 {
+		return service.ProductTypes{}, nil
+	}
+	in := &store.MultiGetProductTypesInput{
+		ProductTypeIDs: productTypeIDs,
+	}
+	sproductTypes, err := h.store.MultiGetProductTypes(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProductTypes(sproductTypes), nil
+}
+
+func (h *handler) getProductType(ctx context.Context, productTypeID string) (*service.ProductType, error) {
+	in := &store.GetProductTypeInput{
+		ProductTypeID: productTypeID,
+	}
+	sproductType, err := h.store.GetProductType(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProductType(sproductType), nil
+}

--- a/api/internal/gateway/user/facility/handler/shop.go
+++ b/api/internal/gateway/user/facility/handler/shop.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/store"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+)
+
+func (h *handler) listShopsByCoordinatorIDs(ctx context.Context, coordinatorIDs []string) (sentity.Shops, error) {
+	in := &store.ListShopsInput{
+		CoordinatorIDs: coordinatorIDs,
+		NoLimit:        true,
+	}
+	shops, _, err := h.store.ListShops(ctx, in)
+	return shops, err
+}
+
+func (h *handler) getShopByCoordinatorID(ctx context.Context, coordinatorID string) (*sentity.Shop, error) {
+	in := &store.GetShopByCoordinatorIDInput{
+		CoordinatorID: coordinatorID,
+	}
+	return h.store.GetShopByCoordinatorID(ctx, in)
+}

--- a/api/internal/gateway/user/facility/service/category.go
+++ b/api/internal/gateway/user/facility/service/category.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+)
+
+type Category struct {
+	response.Category
+}
+
+type Categories []*Category
+
+func NewCategory(category *entity.Category) *Category {
+	return &Category{
+		Category: response.Category{
+			ID:   category.ID,
+			Name: category.Name,
+		},
+	}
+}
+
+func (c *Category) Response() *response.Category {
+	return &c.Category
+}
+
+func NewCategories(categories entity.Categories) Categories {
+	res := make(Categories, len(categories))
+	for i := range categories {
+		res[i] = NewCategory(categories[i])
+	}
+	return res
+}
+
+func (cs Categories) Map() map[string]*Category {
+	res := make(map[string]*Category, len(cs))
+	for _, c := range cs {
+		res[c.ID] = c
+	}
+	return res
+}
+
+func (cs Categories) Response() []*response.Category {
+	res := make([]*response.Category, len(cs))
+	for i := range cs {
+		res[i] = cs[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/category_test.go
+++ b/api/internal/gateway/user/facility/service/category_test.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCategory(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		category *entity.Category
+		expect   *Category
+	}{
+		{
+			name: "success",
+			category: &entity.Category{
+				ID:        "category-id",
+				Name:      "野菜",
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+			expect: &Category{
+				Category: response.Category{
+					ID:   "category-id",
+					Name: "野菜",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewCategory(tt.category))
+		})
+	}
+}
+
+func TestCategory_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		category *Category
+		expect   *response.Category
+	}{
+		{
+			name: "success",
+			category: &Category{
+				Category: response.Category{
+					ID:   "category-id",
+					Name: "野菜",
+				},
+			},
+			expect: &response.Category{
+				ID:   "category-id",
+				Name: "野菜",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.category.Response())
+		})
+	}
+}
+
+func TestCategories(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		categories entity.Categories
+		expect     Categories
+	}{
+		{
+			name: "success",
+			categories: entity.Categories{
+				{
+					ID:        "category-id",
+					Name:      "野菜",
+					CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			expect: Categories{
+				{
+					Category: response.Category{
+						ID:   "category-id",
+						Name: "野菜",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewCategories(tt.categories))
+		})
+	}
+}
+
+func TestCategories_Map(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		categories Categories
+		expect     map[string]*Category
+	}{
+		{
+			name: "success",
+			categories: Categories{
+				{
+					Category: response.Category{
+						ID:   "category-id",
+						Name: "野菜",
+					},
+				},
+			},
+			expect: map[string]*Category{
+				"category-id": {
+					Category: response.Category{
+						ID:   "category-id",
+						Name: "野菜",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.categories.Map())
+		})
+	}
+}
+
+func TestCategories_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		categories Categories
+		expect     []*response.Category
+	}{
+		{
+			name: "success",
+			categories: Categories{
+				{
+					Category: response.Category{
+						ID:   "category-id",
+						Name: "野菜",
+					},
+				},
+			},
+			expect: []*response.Category{
+				{
+					ID:   "category-id",
+					Name: "野菜",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.categories.Response())
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/coordinator.go
+++ b/api/internal/gateway/user/facility/service/coordinator.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+	uentity "github.com/and-period/furumaru/api/internal/user/entity"
+)
+
+type Coordinator struct {
+	response.Coordinator
+	ShopID string
+}
+
+type Coordinators []*Coordinator
+
+func NewCoordinator(coordinator *uentity.Coordinator, shop *sentity.Shop) *Coordinator {
+	return &Coordinator{
+		Coordinator: response.Coordinator{
+			ID:                coordinator.ID,
+			Username:          coordinator.Username,
+			Profile:           coordinator.Profile,
+			ThumbnailURL:      coordinator.ThumbnailURL,
+			HeaderURL:         coordinator.HeaderURL,
+			PromotionVideoURL: coordinator.PromotionVideoURL,
+			InstagramID:       coordinator.InstagramID,
+			FacebookID:        coordinator.FacebookID,
+			Prefecture:        coordinator.Prefecture,
+			City:              coordinator.City,
+			MarcheName:        shop.Name,
+			ProductTypeIDs:    shop.ProductTypeIDs,
+			BusinessDays:      shop.BusinessDays,
+		},
+		ShopID: shop.ID,
+	}
+}
+
+func (c *Coordinator) Response() *response.Coordinator {
+	return &c.Coordinator
+}
+
+func NewCoordinators(coordinators uentity.Coordinators, shops map[string]*sentity.Shop) Coordinators {
+	res := make(Coordinators, len(coordinators))
+	for i := range coordinators {
+		res[i] = NewCoordinator(coordinators[i], shops[coordinators[i].ID])
+	}
+	return res
+}
+
+func (cs Coordinators) Map() map[string]*Coordinator {
+	res := make(map[string]*Coordinator, len(cs))
+	for i := range cs {
+		res[cs[i].ID] = cs[i]
+	}
+	return res
+}
+
+func (cs Coordinators) Response() []*response.Coordinator {
+	res := make([]*response.Coordinator, len(cs))
+	for i := range cs {
+		res[i] = cs[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/coordinator_test.go
+++ b/api/internal/gateway/user/facility/service/coordinator_test.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+	uentity "github.com/and-period/furumaru/api/internal/user/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoordinators(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		coordinators uentity.Coordinators
+		shops        map[string]*sentity.Shop
+		expect       Coordinators
+		response     []*response.Coordinator
+	}{
+		{
+			name: "success",
+			coordinators: uentity.Coordinators{
+				{
+					Admin: uentity.Admin{
+						ID:            "coordinator-id01",
+						Type:          uentity.AdminTypeCoordinator,
+						Status:        uentity.AdminStatusActivated,
+						Lastname:      "&.",
+						Firstname:     "管理者",
+						LastnameKana:  "あんどどっと",
+						FirstnameKana: "かんりしゃ",
+						Email:         "test-coordinator01@and-period.jp",
+					},
+					AdminID:           "coordinator-id01",
+					Username:          "&.農園",
+					Profile:           "紹介文です。",
+					ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+					HeaderURL:         "https://and-period.jp/header.png",
+					PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+					BonusVideoURL:     "https://and-period.jp/bonus.mp4",
+					InstagramID:       "instagram-id",
+					FacebookID:        "facebook-id",
+					PhoneNumber:       "+819012345678",
+					PostalCode:        "1000014",
+					Prefecture:        "東京都",
+					PrefectureCode:    13,
+					City:              "千代田区",
+					CreatedAt:         jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:         jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+				{
+					Admin: uentity.Admin{
+						ID:            "coordinator-id02",
+						Type:          uentity.AdminTypeCoordinator,
+						Status:        uentity.AdminStatusActivated,
+						Lastname:      "&.",
+						Firstname:     "管理者",
+						LastnameKana:  "あんどどっと",
+						FirstnameKana: "かんりしゃ",
+						Email:         "test-coordinator02@and-period.jp",
+					},
+					AdminID:           "coordinator-id02",
+					Username:          "&.農園",
+					Profile:           "紹介文です。",
+					ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+					HeaderURL:         "https://and-period.jp/header.png",
+					PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+					BonusVideoURL:     "https://and-period.jp/bonus.mp4",
+					InstagramID:       "instagram-id",
+					FacebookID:        "facebook-id",
+					PhoneNumber:       "+819012345678",
+					PostalCode:        "1000014",
+					Prefecture:        "東京都",
+					PrefectureCode:    13,
+					City:              "千代田区",
+					CreatedAt:         jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:         jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			shops: map[string]*sentity.Shop{
+				"coordinator-id01": {
+					ID:             "shop-id01",
+					CoordinatorID:  "coordinator-id01",
+					ProducerIDs:    []string{"producer-id01"},
+					ProductTypeIDs: []string{"product-type-ids"},
+					BusinessDays:   []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+					Name:           "&.マルシェ",
+					Activated:      true,
+					CreatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+				"coordinator-id02": {
+					ID:             "shop-id02",
+					CoordinatorID:  "coordinator-id02",
+					ProducerIDs:    []string{"producer-id02"},
+					ProductTypeIDs: []string{"product-type-ids"},
+					BusinessDays:   []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+					Name:           "&.マルシェ",
+					Activated:      true,
+					CreatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			expect: Coordinators{
+				{
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id01",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id01",
+				},
+				{
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id02",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id02",
+				},
+			},
+			response: []*response.Coordinator{
+				{
+					ID:                "coordinator-id01",
+					MarcheName:        "&.マルシェ",
+					Username:          "&.農園",
+					Profile:           "紹介文です。",
+					ProductTypeIDs:    []string{"product-type-ids"},
+					BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+					ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+					HeaderURL:         "https://and-period.jp/header.png",
+					PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+					InstagramID:       "instagram-id",
+					FacebookID:        "facebook-id",
+					Prefecture:        "東京都",
+					City:              "千代田区",
+				},
+				{
+					ID:                "coordinator-id02",
+					MarcheName:        "&.マルシェ",
+					Username:          "&.農園",
+					Profile:           "紹介文です。",
+					ProductTypeIDs:    []string{"product-type-ids"},
+					BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+					ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+					HeaderURL:         "https://and-period.jp/header.png",
+					PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+					InstagramID:       "instagram-id",
+					FacebookID:        "facebook-id",
+					Prefecture:        "東京都",
+					City:              "千代田区",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewCoordinators(tt.coordinators, tt.shops)
+			assert.Equal(t, tt.expect, actual)
+			assert.Equal(t, tt.response, actual.Response())
+		})
+	}
+}
+
+func TestCoordinators_Map(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		coordinators Coordinators
+		expect       map[string]*Coordinator
+	}{
+		{
+			name: "success",
+			coordinators: Coordinators{
+				{
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id01",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id01",
+				},
+				{
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id02",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id02",
+				},
+			},
+			expect: map[string]*Coordinator{
+				"coordinator-id01": {
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id01",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id01",
+				},
+				"coordinator-id02": {
+					Coordinator: response.Coordinator{
+						ID:                "coordinator-id02",
+						MarcheName:        "&.マルシェ",
+						Username:          "&.農園",
+						Profile:           "紹介文です。",
+						ProductTypeIDs:    []string{"product-type-ids"},
+						BusinessDays:      []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+						ThumbnailURL:      "https://and-period.jp/thumbnail.png",
+						HeaderURL:         "https://and-period.jp/header.png",
+						PromotionVideoURL: "https://and-period.jp/promotion.mp4",
+						InstagramID:       "instagram-id",
+						FacebookID:        "facebook-id",
+						Prefecture:        "東京都",
+						City:              "千代田区",
+					},
+					ShopID: "shop-id02",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.coordinators.Map()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/producer.go
+++ b/api/internal/gateway/user/facility/service/producer.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+	uentity "github.com/and-period/furumaru/api/internal/user/entity"
+)
+
+type Producer struct {
+	response.Producer
+}
+
+type Producers []*Producer
+
+func NewProducer(producer *uentity.Producer, shops sentity.Shops) *Producer {
+	var coordinatorID string
+	if len(shops) > 0 {
+		// クライアント側の実装互換のため、はじめのコーディネータのIDを設定
+		coordinatorID = shops[0].CoordinatorID
+	}
+	return &Producer{
+		Producer: response.Producer{
+			ID:                producer.ID,
+			Username:          producer.Username,
+			Profile:           producer.Profile,
+			ThumbnailURL:      producer.ThumbnailURL,
+			HeaderURL:         producer.HeaderURL,
+			PromotionVideoURL: producer.PromotionVideoURL,
+			InstagramID:       producer.InstagramID,
+			FacebookID:        producer.FacebookID,
+			Prefecture:        producer.Prefecture,
+			City:              producer.City,
+			CoordinatorID:     coordinatorID,
+		},
+	}
+}
+
+func (p *Producer) Response() *response.Producer {
+	return &p.Producer
+}
+
+func NewProducers(producers uentity.Producers, shops map[string]sentity.Shops) Producers {
+	res := make(Producers, len(producers))
+	for i := range producers {
+		res[i] = NewProducer(producers[i], shops[producers[i].ID])
+	}
+	return res
+}
+
+func (ps Producers) Map() map[string]*Producer {
+	res := make(map[string]*Producer, len(ps))
+	for i := range ps {
+		res[ps[i].ID] = ps[i]
+	}
+	return res
+}
+
+func (ps Producers) Response() []*response.Producer {
+	res := make([]*response.Producer, len(ps))
+	for i := range ps {
+		res[i] = ps[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/producer_test.go
+++ b/api/internal/gateway/user/facility/service/producer_test.go
@@ -1,0 +1,269 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	sentity "github.com/and-period/furumaru/api/internal/store/entity"
+	uentity "github.com/and-period/furumaru/api/internal/user/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProducers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		producers uentity.Producers
+		shops     map[string]sentity.Shops
+		expect    Producers
+		response  []*response.Producer
+	}{
+		{
+			name: "success",
+			producers: uentity.Producers{
+				{
+					Admin: uentity.Admin{
+						ID:            "producer-id01",
+						Type:          uentity.AdminTypeProducer,
+						Status:        uentity.AdminStatusActivated,
+						Lastname:      "&.",
+						Firstname:     "管理者",
+						LastnameKana:  "あんどどっと",
+						FirstnameKana: "かんりしゃ",
+						Email:         "test-producer01@and-period.jp",
+					},
+					AdminID:        "producer-id01",
+					CoordinatorID:  "coordinator-id",
+					Username:       "&.農園",
+					ThumbnailURL:   "https://and-period.jp/thumbnail.png",
+					HeaderURL:      "https://and-period.jp/header.png",
+					PhoneNumber:    "+819012345678",
+					PostalCode:     "1000014",
+					Prefecture:     "東京都",
+					PrefectureCode: 13,
+					City:           "千代田区",
+					CreatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+				{
+					Admin: uentity.Admin{
+						ID:            "producer-id02",
+						Type:          uentity.AdminTypeProducer,
+						Status:        uentity.AdminStatusActivated,
+						Lastname:      "&.",
+						Firstname:     "管理者",
+						LastnameKana:  "あんどどっと",
+						FirstnameKana: "かんりしゃ",
+						Email:         "test-producer02@and-period.jp",
+					},
+					AdminID:        "producer-id02",
+					CoordinatorID:  "coordinator-id",
+					Username:       "&.農園",
+					ThumbnailURL:   "https://and-period.jp/thumbnail.png",
+					HeaderURL:      "https://and-period.jp/header.png",
+					PhoneNumber:    "+819012345678",
+					PostalCode:     "1000014",
+					Prefecture:     "東京都",
+					PrefectureCode: 13,
+					City:           "千代田区",
+					CreatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:      jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			shops: map[string]sentity.Shops{
+				"producer-id01": {
+					{
+						ID:            "shop-id01",
+						CoordinatorID: "coordinator-id",
+						ProducerIDs:   []string{"producer-id01", "producer-id02"},
+						Name:          "&.農園",
+					},
+				},
+				"producer-id02": {
+					{
+						ID:            "shop-id01",
+						CoordinatorID: "coordinator-id",
+						ProducerIDs:   []string{"producer-id01", "producer-id02"},
+						Name:          "&.農園",
+					},
+				},
+			},
+			expect: Producers{
+				{
+					Producer: response.Producer{
+						ID:            "producer-id01",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						ThumbnailURL:  "https://and-period.jp/thumbnail.png",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+				{
+					Producer: response.Producer{
+						ID:            "producer-id02",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						ThumbnailURL:  "https://and-period.jp/thumbnail.png",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+			},
+			response: []*response.Producer{
+				{
+					ID:            "producer-id01",
+					CoordinatorID: "coordinator-id",
+					Username:      "&.農園",
+					ThumbnailURL:  "https://and-period.jp/thumbnail.png",
+					HeaderURL:     "https://and-period.jp/header.png",
+					Prefecture:    "東京都",
+					City:          "千代田区",
+				},
+				{
+					ID:            "producer-id02",
+					CoordinatorID: "coordinator-id",
+					Username:      "&.農園",
+					ThumbnailURL:  "https://and-period.jp/thumbnail.png",
+					HeaderURL:     "https://and-period.jp/header.png",
+					Prefecture:    "東京都",
+					City:          "千代田区",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewProducers(tt.producers, tt.shops)
+			assert.Equal(t, tt.expect, actual)
+			assert.Equal(t, tt.response, actual.Response())
+		})
+	}
+}
+
+func TestProducers_Map(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		producers Producers
+		expect    map[string]*Producer
+	}{
+		{
+			name: "success",
+			producers: Producers{
+				{
+					Producer: response.Producer{
+						ID:            "producer-id01",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+				{
+					Producer: response.Producer{
+						ID:            "producer-id02",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+			},
+			expect: map[string]*Producer{
+				"producer-id01": {
+					Producer: response.Producer{
+						ID:            "producer-id01",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+				"producer-id02": {
+					Producer: response.Producer{
+						ID:            "producer-id02",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.producers.Map()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestProducers_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		producers Producers
+		expect    []*response.Producer
+	}{
+		{
+			name: "success",
+			producers: Producers{
+				{
+					Producer: response.Producer{
+						ID:            "producer-id01",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+				{
+					Producer: response.Producer{
+						ID:            "producer-id02",
+						CoordinatorID: "coordinator-id",
+						Username:      "&.農園",
+						HeaderURL:     "https://and-period.jp/header.png",
+						Prefecture:    "東京都",
+						City:          "千代田区",
+					},
+				},
+			},
+			expect: []*response.Producer{
+				{
+					ID:            "producer-id01",
+					CoordinatorID: "coordinator-id",
+					Username:      "&.農園",
+					HeaderURL:     "https://and-period.jp/header.png",
+					Prefecture:    "東京都",
+					City:          "千代田区",
+				},
+				{
+					ID:            "producer-id02",
+					CoordinatorID: "coordinator-id",
+					Username:      "&.農園",
+					HeaderURL:     "https://and-period.jp/header.png",
+					Prefecture:    "東京都",
+					City:          "千代田区",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.producers.Response())
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/product.go
+++ b/api/internal/gateway/user/facility/service/product.go
@@ -1,0 +1,363 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/format"
+	"github.com/and-period/furumaru/api/pkg/set"
+	"github.com/shopspring/decimal"
+)
+
+// ProductStatus - 商品販売状況
+type ProductStatus int32
+
+const (
+	ProductStatusUnknown   ProductStatus = 0
+	ProductStatusPresale   ProductStatus = 1 // 予約受付中
+	ProductStatusForSale   ProductStatus = 2 // 販売中
+	ProductStatusOutOfSale ProductStatus = 3 // 販売期間外
+)
+
+func NewProductStatus(status entity.ProductStatus) ProductStatus {
+	switch status {
+	case entity.ProductStatusPrivate:
+		return ProductStatusUnknown
+	case entity.ProductStatusPresale:
+		return ProductStatusPresale
+	case entity.ProductStatusForSale:
+		return ProductStatusForSale
+	case entity.ProductStatusOutOfSale:
+		return ProductStatusOutOfSale
+	default:
+		return ProductStatusUnknown
+	}
+}
+
+func (s ProductStatus) Response() int32 {
+	return int32(s)
+}
+
+// StorageMethodType - 保存方法
+type StorageMethodType int32
+
+const (
+	StorageMethodTypeUnknown      StorageMethodType = 0
+	StorageMethodTypeNormal       StorageMethodType = 1 // 常温保存
+	StorageMethodTypeCoolDark     StorageMethodType = 2 // 冷暗所保存
+	StorageMethodTypeRefrigerated StorageMethodType = 3 // 冷蔵保存
+	StorageMethodTypeFrozen       StorageMethodType = 4 // 冷凍保存
+)
+
+func NewStorageMethodType(typ entity.StorageMethodType) StorageMethodType {
+	switch typ {
+	case entity.StorageMethodTypeNormal:
+		return StorageMethodTypeNormal
+	case entity.StorageMethodTypeCoolDark:
+		return StorageMethodTypeCoolDark
+	case entity.StorageMethodTypeRefrigerated:
+		return StorageMethodTypeRefrigerated
+	case entity.StorageMethodTypeFrozen:
+		return StorageMethodTypeFrozen
+	default:
+		return StorageMethodTypeUnknown
+	}
+}
+
+func (t StorageMethodType) Response() int32 {
+	return int32(t)
+}
+
+// DeliveryType - 配送方法
+type DeliveryType int32
+
+const (
+	DeliveryTypeUnknown      DeliveryType = 0
+	DeliveryTypeNormal       DeliveryType = 1 // 常温便
+	DeliveryTypeRefrigerated DeliveryType = 2 // 冷蔵便
+	DeliveryTypeFrozen       DeliveryType = 3 // 冷凍便
+)
+
+func NewDeliveryType(typ entity.DeliveryType) DeliveryType {
+	switch typ {
+	case entity.DeliveryTypeNormal:
+		return DeliveryTypeNormal
+	case entity.DeliveryTypeFrozen:
+		return DeliveryTypeFrozen
+	case entity.DeliveryTypeRefrigerated:
+		return DeliveryTypeRefrigerated
+	default:
+		return DeliveryTypeUnknown
+	}
+}
+
+func (t DeliveryType) Response() int32 {
+	return int32(t)
+}
+
+func NewProductWeight(weight int64, unit entity.WeightUnit) float64 {
+	const precision = 1
+	var exp int32
+	switch unit {
+	case entity.WeightUnitGram:
+		exp = 0
+	case entity.WeightUnitKilogram:
+		exp = 3 // 1kg = 1,000g
+	default:
+		return 0
+	}
+	gweight := decimal.New(weight, exp)                               // g単位に揃える
+	kgweight := gweight.DivRound(decimal.NewFromInt(1000), precision) // 少数第一位までを取得
+	fweight, _ := kgweight.Float64()
+	return fweight
+}
+
+type Product struct {
+	response.Product
+	revisionID int64
+	cost       int64
+	status     ProductStatus
+	media      MultiProductMedia
+}
+
+type Products []*Product
+
+type ProductDetailsParams struct {
+	Categories   map[string]*Category
+	ProductTypes map[string]*ProductType
+	ProductRates map[string]*ProductRate
+}
+
+func NewProduct(product *entity.Product, category *Category, rate *ProductRate) *Product {
+	var (
+		point1, point2, point3 string
+		categoryID             string
+	)
+	if len(product.RecommendedPoints) > 0 {
+		point1 = product.RecommendedPoints[0]
+	}
+	if len(product.RecommendedPoints) > 1 {
+		point2 = product.RecommendedPoints[1]
+	}
+	if len(product.RecommendedPoints) > 2 {
+		point3 = product.RecommendedPoints[2]
+	}
+	if category != nil {
+		categoryID = category.ID
+	}
+	media := NewMultiProductMedia(product.Media)
+	return &Product{
+		Product: response.Product{
+			ID:                product.ID,
+			CoordinatorID:     product.CoordinatorID,
+			ProducerID:        product.ProducerID,
+			CategoryID:        categoryID,
+			ProductTypeID:     product.TypeID,
+			ProductTagIDs:     product.TagIDs,
+			Name:              product.Name,
+			Description:       product.Description,
+			Status:            NewProductStatus(product.Status).Response(),
+			Inventory:         product.Inventory,
+			Weight:            NewProductWeight(product.Weight, product.WeightUnit),
+			ItemUnit:          product.ItemUnit,
+			ItemDescription:   product.ItemDescription,
+			ThumbnailURL:      product.ThumbnailURL,
+			Media:             media.Response(),
+			Price:             product.Price,
+			ExpirationDate:    product.ExpirationDate,
+			RecommendedPoint1: point1,
+			RecommendedPoint2: point2,
+			RecommendedPoint3: point3,
+			StorageMethodType: NewStorageMethodType(product.StorageMethodType).Response(),
+			DeliveryType:      NewDeliveryType(product.DeliveryType).Response(),
+			Box60Rate:         product.Box60Rate,
+			Box80Rate:         product.Box80Rate,
+			Box100Rate:        product.Box100Rate,
+			OriginPrefecture:  product.OriginPrefecture,
+			OriginCity:        product.OriginCity,
+			Rate:              rate.Response(),
+			StartAt:           product.StartAt.Unix(),
+			EndAt:             product.EndAt.Unix(),
+		},
+		revisionID: product.ProductRevision.ID,
+		status:     NewProductStatus(product.Status),
+		cost:       product.ProductRevision.Cost,
+		media:      media,
+	}
+}
+
+func (p *Product) MediaURLs() []string {
+	return p.media.URLs()
+}
+
+func (p *Product) MerchantCenterItemCondition() string {
+	switch p.status {
+	case ProductStatusPresale:
+		if p.Inventory > 0 {
+			return "preorder"
+		}
+		return "out_of_stock"
+	case ProductStatusForSale:
+		if p.Inventory > 0 {
+			return "in_stock"
+		}
+		return "out_of_stock"
+	case ProductStatusOutOfSale:
+		return "out_of_stock"
+	default:
+		return "new"
+	}
+}
+
+func (p *Product) Response() *response.Product {
+	return &p.Product
+}
+
+func NewProducts(products entity.Products, params *ProductDetailsParams) Products {
+	res := make(Products, len(products))
+	for i, product := range products {
+		var category *Category
+		typ, ok := params.ProductTypes[product.TypeID]
+		if ok {
+			category = params.Categories[typ.CategoryID]
+		}
+		res[i] = NewProduct(product, category, params.ProductRates[product.ID])
+	}
+	return res
+}
+
+func (ps Products) IDs() []string {
+	return set.UniqBy(ps, func(p *Product) string {
+		return p.ID
+	})
+}
+
+func (ps Products) MapByRevision() map[int64]*Product {
+	res := make(map[int64]*Product, len(ps))
+	for _, p := range ps {
+		res[p.revisionID] = p
+	}
+	return res
+}
+
+func (ps Products) Response() []*response.Product {
+	res := make([]*response.Product, len(ps))
+	for i := range ps {
+		res[i] = ps[i].Response()
+	}
+	return res
+}
+
+type ProductMedia struct {
+	response.ProductMedia
+}
+
+type MultiProductMedia []*ProductMedia
+
+func NewProductMedia(media *entity.ProductMedia) *ProductMedia {
+	return &ProductMedia{
+		ProductMedia: response.ProductMedia{
+			URL:         media.URL,
+			IsThumbnail: media.IsThumbnail,
+		},
+	}
+}
+
+func (m *ProductMedia) Response() *response.ProductMedia {
+	return &m.ProductMedia
+}
+
+func NewMultiProductMedia(media entity.MultiProductMedia) MultiProductMedia {
+	res := make(MultiProductMedia, len(media))
+	for i := range media {
+		res[i] = NewProductMedia(media[i])
+	}
+	return res
+}
+
+func (m MultiProductMedia) URLs() []string {
+	res := make([]string, 0, len(m))
+	for _, media := range m {
+		res = append(res, media.URL)
+	}
+	return res
+}
+
+func (m MultiProductMedia) Response() []*response.ProductMedia {
+	res := make([]*response.ProductMedia, len(m))
+	for i := range m {
+		res[i] = m[i].Response()
+	}
+	return res
+}
+
+type ProductRate struct {
+	response.ProductRate
+	productID string
+}
+
+type ProductRates []*ProductRate
+
+func newProductRate(review *entity.AggregatedProductReview) *ProductRate {
+	return &ProductRate{
+		ProductRate: response.ProductRate{
+			Count:   review.Count,
+			Average: format.Round(review.Average, 1),
+			Detail: map[int64]int64{
+				1: review.Rate1,
+				2: review.Rate2,
+				3: review.Rate3,
+				4: review.Rate4,
+				5: review.Rate5,
+			},
+		},
+		productID: review.ProductID,
+	}
+}
+
+func newEmptyProductRate() *ProductRate {
+	return &ProductRate{
+		ProductRate: response.ProductRate{
+			Count:   0,
+			Average: 0.0,
+			Detail: map[int64]int64{
+				1: 0,
+				2: 0,
+				3: 0,
+				4: 0,
+				5: 0,
+			},
+		},
+		productID: "",
+	}
+}
+
+func (r *ProductRate) Response() *response.ProductRate {
+	if r == nil {
+		return newEmptyProductRate().Response()
+	}
+	return &r.ProductRate
+}
+
+func NewProductRates(reviews entity.AggregatedProductReviews) ProductRates {
+	res := make(ProductRates, len(reviews))
+	for i, review := range reviews {
+		res[i] = newProductRate(review)
+	}
+	return res
+}
+
+func (rs ProductRates) MapByProductID() map[string]*ProductRate {
+	res := make(map[string]*ProductRate, len(rs))
+	for _, r := range rs {
+		res[r.productID] = r
+	}
+	return res
+}
+
+func (rs ProductRates) Response() []*response.ProductRate {
+	res := make([]*response.ProductRate, len(rs))
+	for i := range rs {
+		res[i] = rs[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/product_tag.go
+++ b/api/internal/gateway/user/facility/service/product_tag.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+)
+
+type ProductTag struct {
+	response.ProductTag
+}
+
+type ProductTags []*ProductTag
+
+func NewProductTag(tag *entity.ProductTag) *ProductTag {
+	return &ProductTag{
+		ProductTag: response.ProductTag{
+			ID:   tag.ID,
+			Name: tag.Name,
+		},
+	}
+}
+
+func (t *ProductTag) Response() *response.ProductTag {
+	return &t.ProductTag
+}
+
+func NewProductTags(tags entity.ProductTags) ProductTags {
+	res := make(ProductTags, len(tags))
+	for i := range tags {
+		res[i] = NewProductTag(tags[i])
+	}
+	return res
+}
+
+func (ts ProductTags) Response() []*response.ProductTag {
+	res := make([]*response.ProductTag, len(ts))
+	for i := range ts {
+		res[i] = ts[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/product_tag_test.go
+++ b/api/internal/gateway/user/facility/service/product_tag_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProductTag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		productTag *entity.ProductTag
+		expect     *ProductTag
+	}{
+		{
+			name: "success",
+			productTag: &entity.ProductTag{
+				ID:        "product-tag-id",
+				Name:      "野菜",
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+			expect: &ProductTag{
+				ProductTag: response.ProductTag{
+					ID:   "product-tag-id",
+					Name: "野菜",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductTag(tt.productTag))
+		})
+	}
+}
+
+func TestProductTag_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		productTag *ProductTag
+		expect     *response.ProductTag
+	}{
+		{
+			name: "success",
+			productTag: &ProductTag{
+				ProductTag: response.ProductTag{
+					ID:   "product-tag-id",
+					Name: "野菜",
+				},
+			},
+			expect: &response.ProductTag{
+				ID:   "product-tag-id",
+				Name: "野菜",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productTag.Response())
+		})
+	}
+}
+
+func TestProductTags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		productTags entity.ProductTags
+		expect      ProductTags
+	}{
+		{
+			name: "success",
+			productTags: entity.ProductTags{
+				{
+					ID:        "product-tag-id",
+					Name:      "野菜",
+					CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			expect: ProductTags{
+				{
+					ProductTag: response.ProductTag{
+						ID:   "product-tag-id",
+						Name: "野菜",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductTags(tt.productTags))
+		})
+	}
+}
+
+func TestProductTags_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		productTags ProductTags
+		expect      []*response.ProductTag
+	}{
+		{
+			name: "success",
+			productTags: ProductTags{
+				{
+					ProductTag: response.ProductTag{
+						ID:   "product-tag-id",
+						Name: "野菜",
+					},
+				},
+			},
+			expect: []*response.ProductTag{
+				{
+					ID:   "product-tag-id",
+					Name: "野菜",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productTags.Response())
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/product_test.go
+++ b/api/internal/gateway/user/facility/service/product_test.go
@@ -1,0 +1,1398 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProductStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status entity.ProductStatus
+		expect ProductStatus
+	}{
+		{
+			name:   "private",
+			status: entity.ProductStatusPrivate,
+			expect: ProductStatusUnknown,
+		},
+		{
+			name:   "presale",
+			status: entity.ProductStatusPresale,
+			expect: ProductStatusPresale,
+		},
+		{
+			name:   "for sale",
+			status: entity.ProductStatusForSale,
+			expect: ProductStatusForSale,
+		},
+		{
+			name:   "out of sale",
+			status: entity.ProductStatusOutOfSale,
+			expect: ProductStatusOutOfSale,
+		},
+		{
+			name:   "unknown",
+			status: entity.ProductStatusUnknown,
+			expect: ProductStatusUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductStatus(tt.status))
+		})
+	}
+}
+
+func TestStorageMethodType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		storageMethodType entity.StorageMethodType
+		expect            StorageMethodType
+	}{
+		{
+			name:              "success to normal",
+			storageMethodType: entity.StorageMethodTypeNormal,
+			expect:            StorageMethodTypeNormal,
+		},
+		{
+			name:              "success to cook dark",
+			storageMethodType: entity.StorageMethodTypeCoolDark,
+			expect:            StorageMethodTypeCoolDark,
+		},
+		{
+			name:              "success to refrigerated",
+			storageMethodType: entity.StorageMethodTypeRefrigerated,
+			expect:            StorageMethodTypeRefrigerated,
+		},
+		{
+			name:              "success to frozen",
+			storageMethodType: entity.StorageMethodTypeFrozen,
+			expect:            StorageMethodTypeFrozen,
+		},
+		{
+			name:              "success to unknown",
+			storageMethodType: entity.StorageMethodTypeUnknown,
+			expect:            StorageMethodTypeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewStorageMethodType(tt.storageMethodType))
+		})
+	}
+}
+
+func TestDeliveryType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		deliveryType entity.DeliveryType
+		expect       DeliveryType
+	}{
+		{
+			name:         "success to normal",
+			deliveryType: entity.DeliveryTypeNormal,
+			expect:       DeliveryTypeNormal,
+		},
+		{
+			name:         "success to frozen",
+			deliveryType: entity.DeliveryTypeFrozen,
+			expect:       DeliveryTypeFrozen,
+		},
+		{
+			name:         "success to refrigerated",
+			deliveryType: entity.DeliveryTypeRefrigerated,
+			expect:       DeliveryTypeRefrigerated,
+		},
+		{
+			name:         "success to unknown",
+			deliveryType: entity.DeliveryTypeUnknown,
+			expect:       DeliveryTypeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewDeliveryType(tt.deliveryType))
+		})
+	}
+}
+
+func TestDeliveryType_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		deliveryType DeliveryType
+		expect       int32
+	}{
+		{
+			name:         "success",
+			deliveryType: DeliveryTypeNormal,
+			expect:       1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.deliveryType.Response())
+		})
+	}
+}
+
+func TestProductWeight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		weight     int64
+		weightUnit entity.WeightUnit
+		expect     float64
+	}{
+		{
+			name:       "from 130g to 0.1kg",
+			weight:     130,
+			weightUnit: entity.WeightUnitGram,
+			expect:     0.1,
+		},
+		{
+			name:       "from 1300g to 1.3kg",
+			weight:     1300,
+			weightUnit: entity.WeightUnitGram,
+			expect:     1.3,
+		},
+		{
+			name:       "from 13500g to 13.5kg",
+			weight:     13500,
+			weightUnit: entity.WeightUnitGram,
+			expect:     13.5,
+		},
+		{
+			name:       "from 15kg to 15.0kg",
+			weight:     15,
+			weightUnit: entity.WeightUnitKilogram,
+			expect:     15.0,
+		},
+		{
+			name:       "unknown weight unit",
+			weight:     1500,
+			weightUnit: entity.WeightUnitUnknown,
+			expect:     0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewProductWeight(tt.weight, tt.weightUnit)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestProduct(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		product  *entity.Product
+		category *Category
+		rate     *ProductRate
+		expect   *Product
+	}{
+		{
+			name: "success",
+			product: &entity.Product{
+				ID:              "product-id",
+				CoordinatorID:   "coordinator-id",
+				ProducerID:      "producer-id",
+				TypeID:          "product-type-id",
+				TagIDs:          []string{"product-tag-id"},
+				Name:            "新鮮なじゃがいも",
+				Status:          entity.ProductStatusForSale,
+				Description:     "新鮮なじゃがいもをお届けします。",
+				Public:          true,
+				Inventory:       100,
+				Weight:          1300,
+				WeightUnit:      entity.WeightUnitGram,
+				Item:            1,
+				ItemUnit:        "袋",
+				ItemDescription: "1袋あたり100gのじゃがいも",
+				ThumbnailURL:    "https://example.com/thumbnail01.png",
+				Media: entity.MultiProductMedia{
+					{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+					{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+				RecommendedPoints:    []string{"ポイント1", "ポイント2", "ポイント3"},
+				StorageMethodType:    entity.StorageMethodTypeNormal,
+				DeliveryType:         entity.DeliveryTypeNormal,
+				Box60Rate:            50,
+				Box80Rate:            40,
+				Box100Rate:           30,
+				OriginPrefecture:     "滋賀県",
+				OriginPrefectureCode: 25,
+				OriginCity:           "彦根市",
+				StartAt:              jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				EndAt:                jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				ProductRevision: entity.ProductRevision{
+					ID:        1,
+					ProductID: "product-id",
+					Price:     400,
+					Cost:      300,
+					CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+			category: &Category{
+				Category: response.Category{
+					ID:   "category-id",
+					Name: "野菜",
+				},
+			},
+			rate: &ProductRate{
+				ProductRate: response.ProductRate{
+					Count:   4,
+					Average: 2.5,
+					Detail: map[int64]int64{
+						1: 2,
+						2: 0,
+						3: 1,
+						4: 0,
+						5: 1,
+					},
+				},
+				productID: "product-id",
+			},
+			expect: &Product{
+				Product: response.Product{
+					ID:              "product-id",
+					CoordinatorID:   "coordinator-id",
+					ProducerID:      "producer-id",
+					CategoryID:      "category-id",
+					ProductTypeID:   "product-type-id",
+					ProductTagIDs:   []string{"product-tag-id"},
+					Name:            "新鮮なじゃがいも",
+					Description:     "新鮮なじゃがいもをお届けします。",
+					Status:          int32(ProductStatusForSale),
+					Inventory:       100,
+					Weight:          1.3,
+					ItemUnit:        "袋",
+					ItemDescription: "1袋あたり100gのじゃがいも",
+					ThumbnailURL:    "https://example.com/thumbnail01.png",
+					Media: []*response.ProductMedia{
+						{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+						{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+					Price:             400,
+					RecommendedPoint1: "ポイント1",
+					RecommendedPoint2: "ポイント2",
+					RecommendedPoint3: "ポイント3",
+					StorageMethodType: int32(StorageMethodTypeNormal),
+					DeliveryType:      int32(DeliveryTypeNormal),
+					Box60Rate:         50,
+					Box80Rate:         40,
+					Box100Rate:        30,
+					OriginPrefecture:  "滋賀県",
+					OriginCity:        "彦根市",
+					Rate: &response.ProductRate{
+						Count:   4,
+						Average: 2.5,
+						Detail: map[int64]int64{
+							1: 2,
+							2: 0,
+							3: 1,
+							4: 0,
+							5: 1,
+						},
+					},
+					StartAt: 1640962800,
+					EndAt:   1640962800,
+				},
+				revisionID: 1,
+				cost:       300,
+				status:     ProductStatusForSale,
+				media: MultiProductMedia{
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+					},
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "success without additional values",
+			product: &entity.Product{
+				ID:              "product-id",
+				CoordinatorID:   "coordinator-id",
+				ProducerID:      "producer-id",
+				TypeID:          "product-type-id",
+				TagIDs:          []string{"product-tag-id"},
+				Name:            "新鮮なじゃがいも",
+				Status:          entity.ProductStatusForSale,
+				Description:     "新鮮なじゃがいもをお届けします。",
+				Public:          true,
+				Inventory:       100,
+				Weight:          1300,
+				WeightUnit:      entity.WeightUnitGram,
+				Item:            1,
+				ItemUnit:        "袋",
+				ItemDescription: "1袋あたり100gのじゃがいも",
+				ThumbnailURL:    "https://example.com/thumbnail01.png",
+				Media: entity.MultiProductMedia{
+					{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+					{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+				RecommendedPoints:    []string{"ポイント1", "ポイント2", "ポイント3"},
+				StorageMethodType:    entity.StorageMethodTypeNormal,
+				DeliveryType:         entity.DeliveryTypeNormal,
+				Box60Rate:            50,
+				Box80Rate:            40,
+				Box100Rate:           30,
+				OriginPrefecture:     "滋賀県",
+				OriginPrefectureCode: 25,
+				OriginCity:           "彦根市",
+				StartAt:              jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				EndAt:                jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				ProductRevision: entity.ProductRevision{
+					ID:        1,
+					ProductID: "product-id",
+					Price:     400,
+					Cost:      300,
+					CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+				CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+			category: nil,
+			rate:     nil,
+			expect: &Product{
+				Product: response.Product{
+					ID:              "product-id",
+					CoordinatorID:   "coordinator-id",
+					ProducerID:      "producer-id",
+					CategoryID:      "",
+					ProductTypeID:   "product-type-id",
+					ProductTagIDs:   []string{"product-tag-id"},
+					Name:            "新鮮なじゃがいも",
+					Description:     "新鮮なじゃがいもをお届けします。",
+					Status:          int32(ProductStatusForSale),
+					Inventory:       100,
+					Weight:          1.3,
+					ItemUnit:        "袋",
+					ItemDescription: "1袋あたり100gのじゃがいも",
+					ThumbnailURL:    "https://example.com/thumbnail01.png",
+					Media: []*response.ProductMedia{
+						{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+						{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+					Price:             400,
+					RecommendedPoint1: "ポイント1",
+					RecommendedPoint2: "ポイント2",
+					RecommendedPoint3: "ポイント3",
+					StorageMethodType: int32(StorageMethodTypeNormal),
+					DeliveryType:      int32(DeliveryTypeNormal),
+					Box60Rate:         50,
+					Box80Rate:         40,
+					Box100Rate:        30,
+					OriginPrefecture:  "滋賀県",
+					OriginCity:        "彦根市",
+					Rate: &response.ProductRate{
+						Count:   0,
+						Average: 0.0,
+						Detail: map[int64]int64{
+							1: 0,
+							2: 0,
+							3: 0,
+							4: 0,
+							5: 0,
+						},
+					},
+					StartAt: 1640962800,
+					EndAt:   1640962800,
+				},
+				revisionID: 1,
+				cost:       300,
+				status:     ProductStatusForSale,
+				media: MultiProductMedia{
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+					},
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProduct(tt.product, tt.category, tt.rate))
+		})
+	}
+}
+
+func TestProduct_MediaURLs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		product *Product
+		expect  []string
+	}{
+		{
+			name: "success",
+			product: &Product{
+				media: MultiProductMedia{
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+					},
+					{
+						ProductMedia: response.ProductMedia{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+				},
+			},
+			expect: []string{
+				"https://example.com/thumbnail01.png",
+				"https://example.com/thumbnail02.png",
+			},
+		},
+		{
+			name: "empty media",
+			product: &Product{
+				media: MultiProductMedia{},
+			},
+			expect: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.product.MediaURLs())
+		})
+	}
+}
+
+func TestProduct_MerchantCenterItemCondition(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		product *Product
+		expect  string
+	}{
+		{
+			name: "presale with inventory",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 100,
+				},
+				status: ProductStatusPresale,
+			},
+			expect: "preorder",
+		},
+		{
+			name: "presale without inventory",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 0,
+				},
+				status: ProductStatusPresale,
+			},
+			expect: "out_of_stock",
+		},
+		{
+			name: "for sale with inventory",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 100,
+				},
+				status: ProductStatusForSale,
+			},
+			expect: "in_stock",
+		},
+		{
+			name: "for sale without inventory",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 0,
+				},
+				status: ProductStatusForSale,
+			},
+			expect: "out_of_stock",
+		},
+		{
+			name: "out of sale",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 100,
+				},
+				status: ProductStatusOutOfSale,
+			},
+			expect: "out_of_stock",
+		},
+		{
+			name: "unknown status",
+			product: &Product{
+				Product: response.Product{
+					Inventory: 100,
+				},
+				status: ProductStatusUnknown,
+			},
+			expect: "new",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.product.MerchantCenterItemCondition())
+		})
+	}
+}
+
+func TestProduct_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		product *Product
+		expect  *response.Product
+	}{
+		{
+			name: "success",
+			product: &Product{
+				Product: response.Product{
+					ID:              "product-id",
+					ProductTypeID:   "product-type-id",
+					CategoryID:      "category-id",
+					CoordinatorID:   "coordinator-id",
+					ProducerID:      "producer-id",
+					Name:            "新鮮なじゃがいも",
+					Description:     "新鮮なじゃがいもをお届けします。",
+					Status:          int32(ProductStatusForSale),
+					Inventory:       100,
+					Weight:          1.3,
+					ItemUnit:        "袋",
+					ItemDescription: "1袋あたり100gのじゃがいも",
+					Media: []*response.ProductMedia{
+						{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+						{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+					Price:            400,
+					DeliveryType:     int32(DeliveryTypeNormal),
+					Box60Rate:        50,
+					Box80Rate:        40,
+					Box100Rate:       30,
+					OriginPrefecture: "滋賀県",
+					OriginCity:       "彦根市",
+					StartAt:          1640962800,
+					EndAt:            1640962800,
+				},
+			},
+			expect: &response.Product{
+				ID:              "product-id",
+				ProductTypeID:   "product-type-id",
+				CategoryID:      "category-id",
+				CoordinatorID:   "coordinator-id",
+				ProducerID:      "producer-id",
+				Name:            "新鮮なじゃがいも",
+				Description:     "新鮮なじゃがいもをお届けします。",
+				Status:          int32(ProductStatusForSale),
+				Inventory:       100,
+				Weight:          1.3,
+				ItemUnit:        "袋",
+				ItemDescription: "1袋あたり100gのじゃがいも",
+				Media: []*response.ProductMedia{
+					{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+					{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+				Price:            400,
+				DeliveryType:     int32(DeliveryTypeNormal),
+				Box60Rate:        50,
+				Box80Rate:        40,
+				Box100Rate:       30,
+				OriginPrefecture: "滋賀県",
+				OriginCity:       "彦根市",
+				StartAt:          1640962800,
+				EndAt:            1640962800,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.product.Response())
+		})
+	}
+}
+
+func TestProducts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		products entity.Products
+		params   *ProductDetailsParams
+		expect   Products
+	}{
+		{
+			name: "success",
+			products: entity.Products{
+				{
+					ID:              "product-id",
+					TypeID:          "product-type-id",
+					CoordinatorID:   "coordinator-id",
+					ProducerID:      "producer-id",
+					Name:            "新鮮なじゃがいも",
+					Description:     "新鮮なじゃがいもをお届けします。",
+					Public:          true,
+					Status:          entity.ProductStatusForSale,
+					Inventory:       100,
+					Weight:          1300,
+					WeightUnit:      entity.WeightUnitGram,
+					Item:            1,
+					ItemUnit:        "袋",
+					ItemDescription: "1袋あたり100gのじゃがいも",
+					ThumbnailURL:    "https://example.com/thumbnail01.png",
+					Media: entity.MultiProductMedia{
+						{
+							URL:         "https://example.com/thumbnail01.png",
+							IsThumbnail: true,
+						},
+						{
+							URL:         "https://example.com/thumbnail02.png",
+							IsThumbnail: false,
+						},
+					},
+					DeliveryType:         entity.DeliveryTypeNormal,
+					Box60Rate:            50,
+					Box80Rate:            40,
+					Box100Rate:           30,
+					OriginPrefecture:     "滋賀県",
+					OriginPrefectureCode: 25,
+					OriginCity:           "彦根市",
+					StartAt:              jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					EndAt:                jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					ProductRevision: entity.ProductRevision{
+						ID:        1,
+						ProductID: "product-id",
+						Price:     400,
+						Cost:      300,
+						CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+						UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					},
+					CreatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt: jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			params: &ProductDetailsParams{
+				ProductTypes: map[string]*ProductType{
+					"product-type-id": {
+						ProductType: response.ProductType{
+							ID:         "product-type-id",
+							CategoryID: "category-id",
+							Name:       "じゃがいも",
+						},
+					},
+				},
+				Categories: map[string]*Category{
+					"category-id": {
+						Category: response.Category{
+							ID:   "category-id",
+							Name: "野菜",
+						},
+					},
+				},
+				ProductRates: map[string]*ProductRate{
+					"product-id": {
+						ProductRate: response.ProductRate{
+							Count:   4,
+							Average: 2.5,
+							Detail: map[int64]int64{
+								1: 2,
+								2: 0,
+								3: 1,
+								4: 0,
+								5: 1,
+							},
+						},
+						productID: "product-id",
+					},
+				},
+			},
+			expect: Products{
+				{
+					Product: response.Product{
+						ID:              "product-id",
+						ProductTypeID:   "product-type-id",
+						CategoryID:      "category-id",
+						CoordinatorID:   "coordinator-id",
+						ProducerID:      "producer-id",
+						Name:            "新鮮なじゃがいも",
+						Description:     "新鮮なじゃがいもをお届けします。",
+						Status:          int32(ProductStatusForSale),
+						Inventory:       100,
+						Weight:          1.3,
+						ItemUnit:        "袋",
+						ItemDescription: "1袋あたり100gのじゃがいも",
+						ThumbnailURL:    "https://example.com/thumbnail01.png",
+						Media: []*response.ProductMedia{
+							{
+								URL:         "https://example.com/thumbnail01.png",
+								IsThumbnail: true,
+							},
+							{
+								URL:         "https://example.com/thumbnail02.png",
+								IsThumbnail: false,
+							},
+						},
+						Price:            400,
+						DeliveryType:     int32(DeliveryTypeNormal),
+						Box60Rate:        50,
+						Box80Rate:        40,
+						Box100Rate:       30,
+						OriginPrefecture: "滋賀県",
+						OriginCity:       "彦根市",
+						Rate: &response.ProductRate{
+							Count:   4,
+							Average: 2.5,
+							Detail: map[int64]int64{
+								1: 2,
+								2: 0,
+								3: 1,
+								4: 0,
+								5: 1,
+							},
+						},
+						StartAt: 1640962800,
+						EndAt:   1640962800,
+					},
+					revisionID: 1,
+					cost:       300,
+					status:     ProductStatusForSale,
+					media: MultiProductMedia{
+						{
+							ProductMedia: response.ProductMedia{
+								URL:         "https://example.com/thumbnail01.png",
+								IsThumbnail: true,
+							},
+						},
+						{
+							ProductMedia: response.ProductMedia{
+								URL:         "https://example.com/thumbnail02.png",
+								IsThumbnail: false,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewProducts(tt.products, tt.params)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestProducts_IDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		products Products
+		expect   []string
+	}{
+		{
+			name: "success",
+			products: Products{
+				{
+					Product: response.Product{
+						ID:              "product-id",
+						ProductTypeID:   "product-type-id",
+						CategoryID:      "category-id",
+						CoordinatorID:   "coordinator-id",
+						ProducerID:      "producer-id",
+						Name:            "新鮮なじゃがいも",
+						Description:     "新鮮なじゃがいもをお届けします。",
+						Inventory:       100,
+						Weight:          1.3,
+						ItemUnit:        "袋",
+						ItemDescription: "1袋あたり100gのじゃがいも",
+						Media: []*response.ProductMedia{
+							{URL: "https://example.com/thumbnail01.png", IsThumbnail: true},
+							{URL: "https://example.com/thumbnail02.png", IsThumbnail: false},
+						},
+						Price:        400,
+						DeliveryType: int32(DeliveryTypeNormal),
+						Box60Rate:    50,
+						Box80Rate:    40,
+						Box100Rate:   30,
+						OriginCity:   "彦根市",
+					},
+					revisionID: 1,
+				},
+			},
+			expect: []string{"product-id"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.products.IDs())
+		})
+	}
+}
+
+func TestProducts_MapByRevision(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		products Products
+		expect   map[int64]*Product
+	}{
+		{
+			name: "success",
+			products: Products{
+				{
+					Product: response.Product{
+						ID:              "product-id",
+						ProductTypeID:   "product-type-id",
+						CategoryID:      "category-id",
+						CoordinatorID:   "coordinator-id",
+						ProducerID:      "producer-id",
+						Name:            "新鮮なじゃがいも",
+						Description:     "新鮮なじゃがいもをお届けします。",
+						Inventory:       100,
+						Weight:          1.3,
+						ItemUnit:        "袋",
+						ItemDescription: "1袋あたり100gのじゃがいも",
+						Media: []*response.ProductMedia{
+							{URL: "https://example.com/thumbnail01.png", IsThumbnail: true},
+							{URL: "https://example.com/thumbnail02.png", IsThumbnail: false},
+						},
+						Price:        400,
+						DeliveryType: int32(DeliveryTypeNormal),
+						Box60Rate:    50,
+						Box80Rate:    40,
+						Box100Rate:   30,
+						OriginCity:   "彦根市",
+					},
+					revisionID: 1,
+				},
+			},
+			expect: map[int64]*Product{
+				1: {
+					Product: response.Product{
+						ID:              "product-id",
+						ProductTypeID:   "product-type-id",
+						CategoryID:      "category-id",
+						CoordinatorID:   "coordinator-id",
+						ProducerID:      "producer-id",
+						Name:            "新鮮なじゃがいも",
+						Description:     "新鮮なじゃがいもをお届けします。",
+						Inventory:       100,
+						Weight:          1.3,
+						ItemUnit:        "袋",
+						ItemDescription: "1袋あたり100gのじゃがいも",
+						Media: []*response.ProductMedia{
+							{URL: "https://example.com/thumbnail01.png", IsThumbnail: true},
+							{URL: "https://example.com/thumbnail02.png", IsThumbnail: false},
+						},
+						Price:        400,
+						DeliveryType: int32(DeliveryTypeNormal),
+						Box60Rate:    50,
+						Box80Rate:    40,
+						Box100Rate:   30,
+						OriginCity:   "彦根市",
+					},
+					revisionID: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.products.MapByRevision())
+		})
+	}
+}
+
+func TestProducts_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		products Products
+		expect   []*response.Product
+	}{
+		{
+			name: "success",
+			products: Products{
+				{
+					Product: response.Product{
+						ID:              "product-id",
+						ProductTypeID:   "product-type-id",
+						CategoryID:      "category-id",
+						CoordinatorID:   "coordinator-id",
+						ProducerID:      "producer-id",
+						Name:            "新鮮なじゃがいも",
+						Description:     "新鮮なじゃがいもをお届けします。",
+						Status:          int32(ProductStatusForSale),
+						Inventory:       100,
+						Weight:          1.3,
+						ItemUnit:        "袋",
+						ItemDescription: "1袋あたり100gのじゃがいも",
+						ThumbnailURL:    "https://example.com/thumbnail01.png",
+						Media: []*response.ProductMedia{
+							{URL: "https://example.com/thumbnail01.png", IsThumbnail: true},
+							{URL: "https://example.com/thumbnail02.png", IsThumbnail: false},
+						},
+						Price:            400,
+						DeliveryType:     int32(DeliveryTypeNormal),
+						Box60Rate:        50,
+						Box80Rate:        40,
+						Box100Rate:       30,
+						OriginPrefecture: "滋賀県",
+						OriginCity:       "彦根市",
+						StartAt:          1640962800,
+						EndAt:            1640962800,
+					},
+					revisionID: 1,
+				},
+			},
+			expect: []*response.Product{
+				{
+					ID:              "product-id",
+					ProductTypeID:   "product-type-id",
+					CategoryID:      "category-id",
+					CoordinatorID:   "coordinator-id",
+					ProducerID:      "producer-id",
+					Name:            "新鮮なじゃがいも",
+					Description:     "新鮮なじゃがいもをお届けします。",
+					Status:          int32(ProductStatusForSale),
+					Inventory:       100,
+					Weight:          1.3,
+					ItemUnit:        "袋",
+					ItemDescription: "1袋あたり100gのじゃがいも",
+					ThumbnailURL:    "https://example.com/thumbnail01.png",
+					Media: []*response.ProductMedia{
+						{URL: "https://example.com/thumbnail01.png", IsThumbnail: true},
+						{URL: "https://example.com/thumbnail02.png", IsThumbnail: false},
+					},
+					Price:            400,
+					DeliveryType:     int32(DeliveryTypeNormal),
+					Box60Rate:        50,
+					Box80Rate:        40,
+					Box100Rate:       30,
+					OriginPrefecture: "滋賀県",
+					OriginCity:       "彦根市",
+					StartAt:          1640962800,
+					EndAt:            1640962800,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.products.Response())
+		})
+	}
+}
+
+func TestProductMedia(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		media  *entity.ProductMedia
+		expect *ProductMedia
+	}{
+		{
+			name: "success",
+			media: &entity.ProductMedia{
+				URL:         "https://example.com/thumbnail01.png",
+				IsThumbnail: true,
+			},
+			expect: &ProductMedia{
+				ProductMedia: response.ProductMedia{
+					URL:         "https://example.com/thumbnail01.png",
+					IsThumbnail: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductMedia(tt.media))
+		})
+	}
+}
+
+func TestProductMedia_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		media  *ProductMedia
+		expect *response.ProductMedia
+	}{
+		{
+			name: "success",
+			media: &ProductMedia{
+				ProductMedia: response.ProductMedia{
+					URL:         "https://example.com/thumbnail01.png",
+					IsThumbnail: true,
+				},
+			},
+			expect: &response.ProductMedia{
+				URL:         "https://example.com/thumbnail01.png",
+				IsThumbnail: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.media.Response())
+		})
+	}
+}
+
+func TestMultiProductMedia(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		media  entity.MultiProductMedia
+		expect MultiProductMedia
+	}{
+		{
+			name: "success",
+			media: entity.MultiProductMedia{
+				{
+					URL:         "https://example.com/thumbnail01.png",
+					IsThumbnail: true,
+				},
+				{
+					URL:         "https://example.com/thumbnail02.png",
+					IsThumbnail: false,
+				},
+			},
+			expect: MultiProductMedia{
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+				},
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewMultiProductMedia(tt.media))
+		})
+	}
+}
+
+func TestMultiProductMedia_URLs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		media  MultiProductMedia
+		expect []string
+	}{
+		{
+			name: "success",
+			media: MultiProductMedia{
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+				},
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+			},
+			expect: []string{
+				"https://example.com/thumbnail01.png",
+				"https://example.com/thumbnail02.png",
+			},
+		},
+		{
+			name:   "empty media",
+			media:  MultiProductMedia{},
+			expect: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.media.URLs())
+		})
+	}
+}
+
+func TestMultiProductMedia_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		media  MultiProductMedia
+		expect []*response.ProductMedia
+	}{
+		{
+			name: "success",
+			media: MultiProductMedia{
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail01.png",
+						IsThumbnail: true,
+					},
+				},
+				{
+					ProductMedia: response.ProductMedia{
+						URL:         "https://example.com/thumbnail02.png",
+						IsThumbnail: false,
+					},
+				},
+			},
+			expect: []*response.ProductMedia{
+				{
+					URL:         "https://example.com/thumbnail01.png",
+					IsThumbnail: true,
+				},
+				{
+					URL:         "https://example.com/thumbnail02.png",
+					IsThumbnail: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.media.Response())
+		})
+	}
+}
+
+func TestProductRates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		reviews entity.AggregatedProductReviews
+		expect  ProductRates
+	}{
+		{
+			name: "success",
+			reviews: entity.AggregatedProductReviews{
+				{
+					ProductID: "product-id",
+					Count:     4,
+					Average:   2.5,
+					Rate1:     2,
+					Rate2:     0,
+					Rate3:     1,
+					Rate4:     0,
+					Rate5:     1,
+				},
+			},
+			expect: ProductRates{
+				{
+					ProductRate: response.ProductRate{
+						Count:   4,
+						Average: 2.5,
+						Detail: map[int64]int64{
+							1: 2,
+							2: 0,
+							3: 1,
+							4: 0,
+							5: 1,
+						},
+					},
+					productID: "product-id",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewProductRates(tt.reviews)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestProductRates_MapByProductID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		rates  ProductRates
+		expect map[string]*ProductRate
+	}{
+		{
+			name: "success",
+			rates: ProductRates{
+				{
+					ProductRate: response.ProductRate{
+						Count:   4,
+						Average: 2.5,
+						Detail: map[int64]int64{
+							1: 2,
+							2: 0,
+							3: 1,
+							4: 0,
+							5: 1,
+						},
+					},
+					productID: "product-id",
+				},
+			},
+			expect: map[string]*ProductRate{
+				"product-id": {
+					ProductRate: response.ProductRate{
+						Count:   4,
+						Average: 2.5,
+						Detail: map[int64]int64{
+							1: 2,
+							2: 0,
+							3: 1,
+							4: 0,
+							5: 1,
+						},
+					},
+					productID: "product-id",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.rates.MapByProductID()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestProductRates_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		rates  ProductRates
+		expect []*response.ProductRate
+	}{
+		{
+			name: "success",
+			rates: ProductRates{
+				{
+					ProductRate: response.ProductRate{
+						Count:   4,
+						Average: 2.5,
+						Detail: map[int64]int64{
+							1: 2,
+							2: 0,
+							3: 1,
+							4: 0,
+							5: 1,
+						},
+					},
+					productID: "product-id",
+				},
+			},
+			expect: []*response.ProductRate{
+				{
+					Count:   4,
+					Average: 2.5,
+					Detail: map[int64]int64{
+						1: 2,
+						2: 0,
+						3: 1,
+						4: 0,
+						5: 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.rates.Response()
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/product_type.go
+++ b/api/internal/gateway/user/facility/service/product_type.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/set"
+)
+
+type ProductType struct {
+	response.ProductType
+}
+
+type ProductTypes []*ProductType
+
+func NewProductType(productType *entity.ProductType) *ProductType {
+	return &ProductType{
+		ProductType: response.ProductType{
+			ID:         productType.ID,
+			CategoryID: productType.CategoryID,
+			Name:       productType.Name,
+			IconURL:    productType.IconURL,
+		},
+	}
+}
+
+func (t *ProductType) Response() *response.ProductType {
+	return &t.ProductType
+}
+
+func NewProductTypes(productTypes entity.ProductTypes) ProductTypes {
+	res := make(ProductTypes, len(productTypes))
+	for i := range productTypes {
+		res[i] = NewProductType(productTypes[i])
+	}
+	return res
+}
+
+func (ts ProductTypes) CategoryIDs() []string {
+	return set.UniqBy(ts, func(t *ProductType) string {
+		return t.CategoryID
+	})
+}
+
+func (ts ProductTypes) Map() map[string]*ProductType {
+	res := make(map[string]*ProductType, len(ts))
+	for _, t := range ts {
+		res[t.ID] = t
+	}
+	return res
+}
+
+func (ts ProductTypes) Response() []*response.ProductType {
+	res := make([]*response.ProductType, len(ts))
+	for i := range ts {
+		res[i] = ts[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/product_type_test.go
+++ b/api/internal/gateway/user/facility/service/product_type_test.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProductType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		productType *entity.ProductType
+		expect      *ProductType
+	}{
+		{
+			name: "success",
+			productType: &entity.ProductType{
+				ID:         "product-type-id",
+				CategoryID: "category-id",
+				Name:       "じゃがいも",
+				IconURL:    "https://and-period.jp/icon.png",
+				CreatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				UpdatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			},
+			expect: &ProductType{
+				ProductType: response.ProductType{
+					ID:         "product-type-id",
+					CategoryID: "category-id",
+					Name:       "じゃがいも",
+					IconURL:    "https://and-period.jp/icon.png",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductType(tt.productType))
+		})
+	}
+}
+
+func TestProductType_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		productType *ProductType
+		expect      *response.ProductType
+	}{
+		{
+			name: "success",
+			productType: &ProductType{
+				ProductType: response.ProductType{
+					ID:         "product-type-id",
+					CategoryID: "category-id",
+					Name:       "じゃがいも",
+					IconURL:    "https://and-period.jp/icon.png",
+				},
+			},
+			expect: &response.ProductType{
+				ID:         "product-type-id",
+				CategoryID: "category-id",
+				Name:       "じゃがいも",
+				IconURL:    "https://and-period.jp/icon.png",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productType.Response())
+		})
+	}
+}
+
+func TestProductTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		productTypes entity.ProductTypes
+		expect       ProductTypes
+	}{
+		{
+			name: "success",
+			productTypes: entity.ProductTypes{
+				{
+					ID:         "product-type-id",
+					CategoryID: "category-id",
+					Name:       "じゃがいも",
+					IconURL:    "https://and-period.jp/icon.png",
+					CreatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+					UpdatedAt:  jst.Date(2022, 1, 1, 0, 0, 0, 0),
+				},
+			},
+			expect: ProductTypes{
+				{
+					ProductType: response.ProductType{
+						ID:         "product-type-id",
+						CategoryID: "category-id",
+						Name:       "じゃがいも",
+						IconURL:    "https://and-period.jp/icon.png",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewProductTypes(tt.productTypes))
+		})
+	}
+}
+
+func TestProductTypes_CategoryIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		productTypes ProductTypes
+		expect       []string
+	}{
+		{
+			name: "success",
+			productTypes: ProductTypes{
+				{
+					ProductType: response.ProductType{
+						ID:         "product-type-id",
+						CategoryID: "category-id",
+						Name:       "じゃがいも",
+						IconURL:    "https://and-period.jp/icon.png",
+					},
+				},
+			},
+			expect: []string{"category-id"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productTypes.CategoryIDs())
+		})
+	}
+}
+
+func TestProductTypes_Map(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		productTypes ProductTypes
+		expect       map[string]*ProductType
+	}{
+		{
+			name: "success",
+			productTypes: ProductTypes{
+				{
+					ProductType: response.ProductType{
+						ID:         "product-type-id",
+						CategoryID: "category-id",
+						Name:       "じゃがいも",
+						IconURL:    "https://and-period.jp/icon.png",
+					},
+				},
+			},
+			expect: map[string]*ProductType{
+				"product-type-id": {
+					ProductType: response.ProductType{
+						ID:         "product-type-id",
+						CategoryID: "category-id",
+						Name:       "じゃがいも",
+						IconURL:    "https://and-period.jp/icon.png",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productTypes.Map())
+		})
+	}
+}
+
+func TestProductTypes_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		productTypes ProductTypes
+		expect       []*response.ProductType
+	}{
+		{
+			name: "success",
+			productTypes: ProductTypes{
+				{
+					ProductType: response.ProductType{
+						ID:         "product-type-id",
+						CategoryID: "category-id",
+						Name:       "じゃがいも",
+						IconURL:    "https://and-period.jp/icon.png",
+					},
+				},
+			},
+			expect: []*response.ProductType{
+				{
+					ID:         "product-type-id",
+					CategoryID: "category-id",
+					Name:       "じゃがいも",
+					IconURL:    "https://and-period.jp/icon.png",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.productTypes.Response())
+		})
+	}
+}


### PR DESCRIPTION
## 概要
購入者向けゲートウェイに施設関連のハンドラーとサービスを追加

## 変更内容
- 新しいハンドラーファイルの追加: category, coordinator, product_review, product_tag, product_type, shop
- 対応するテストを含むサービスファイルの追加: category, coordinator, producer, product, product_tag, product_type
- 既存のproducerとproductハンドラーの更新
- 購入者ゲートウェイの施設管理機能を完全実装

## 背景・目的
購入者向けサービスで施設に関する様々な機能（カテゴリ、コーディネーター、商品レビュー、商品タグ、商品タイプ、店舗）を提供するため

## テスト
- [ ] API: make test (Go)
- [ ] API: make lint-fix
- [ ] 手動テスト完了

## レビューポイント
- 新規追加されたハンドラーとサービスの実装
- テストケースの網羅性
- 既存コードとの一貫性

🤖 Generated with [Claude Code](https://claude.ai/code)