### PR TITLE
feat(api): Add facility gateway services and handlers

### DIFF
--- a/api/internal/gateway/user/facility/handler/handler.go
+++ b/api/internal/gateway/user/facility/handler/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/and-period/furumaru/api/internal/store"
 	"github.com/and-period/furumaru/api/internal/user"
 	"github.com/and-period/furumaru/api/pkg/sentry"
+	"github.com/and-period/furumaru/api/pkg/uuid"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,6 +26,7 @@ const (
 
 var (
 	errNotFoundFacility     = errors.New("handler: not found facility")
+	errNotFoundProduct      = errors.New("handler: not found product")
 	errFailedToCastFacility = errors.New("handler: failed to cast facility")
 )
 
@@ -38,6 +40,7 @@ var (
 type handler struct {
 	appName      string
 	env          string
+	generateID   func() string
 	sentry       sentry.Client
 	liffVerifier auth.OIDCVerifier[auth.LIFFClaims]
 	jwtGenerator auth.JWTGenerator
@@ -92,8 +95,11 @@ func NewHandler(params *Params, opts ...Option) gateway.Handler {
 		opts[i](dopts)
 	}
 	return &handler{
-		appName:      dopts.appName,
-		env:          dopts.env,
+		appName: dopts.appName,
+		env:     dopts.env,
+		generateID: func() string {
+			return uuid.Base58Encode(uuid.New())
+		},
 		sentry:       dopts.sentry,
 		liffVerifier: params.LiffVerifier,
 		jwtGenerator: params.JWTGenerator,

--- a/api/internal/gateway/user/facility/handler/product.go
+++ b/api/internal/gateway/user/facility/handler/product.go
@@ -197,6 +197,25 @@ func (h *handler) GetProduct(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, res)
 }
 
+func (h *handler) multiGetProducts(ctx context.Context, productIDs []string) (service.Products, error) {
+	if len(productIDs) == 0 {
+		return service.Products{}, nil
+	}
+	in := &store.MultiGetProductsInput{
+		ProductIDs: productIDs,
+	}
+	products, err := h.store.MultiGetProducts(ctx, in)
+	if err != nil || len(products) == 0 {
+		return service.Products{}, err
+	}
+	products = products.FilterByPublished()
+	details, err := h.getProductDetails(ctx, products.IDs()...)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewProducts(products, details), nil
+}
+
 func (h *handler) getProduct(ctx context.Context, productID string) (*service.Product, error) {
 	in := &store.GetProductInput{
 		ProductID: productID,

--- a/api/internal/gateway/user/facility/handler/promotion.go
+++ b/api/internal/gateway/user/facility/handler/promotion.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/service"
+	"github.com/and-period/furumaru/api/internal/store"
+)
+
+func (h *handler) getEnabledPromotion(ctx context.Context, code string) (*service.Promotion, error) {
+	in := &store.GetPromotionByCodeInput{
+		PromotionCode: code,
+		OnlyEnabled:   true,
+	}
+	promotion, err := h.store.GetPromotionByCode(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return service.NewPromotion(promotion), nil
+}

--- a/api/internal/gateway/user/facility/response/cart.go
+++ b/api/internal/gateway/user/facility/response/cart.go
@@ -21,3 +21,16 @@ type CartResponse struct {
 	Coordinators []*Coordinator `json:"coordinators"` // コーディネータ一覧
 	Products     []*Product     `json:"products"`     // 商品一覧
 }
+
+type CalcCartResponse struct {
+	RequestID   string       `json:"requestId"`   // 支払い時にAPIへ送信するキー(重複判定用)
+	Carts       []*Cart      `json:"carts"`       // カート一覧
+	Items       []*CartItem  `json:"items"`       // カート内の商品一覧(集計結果)
+	Products    []*Product   `json:"products"`    // 商品一覧
+	Coordinator *Coordinator `json:"coordinator"` // コーディネータ情報
+	Promotion   *Promotion   `json:"promotion"`   // プロモーション情報
+	SubTotal    int64        `json:"subtotal"`    // 購入金額(税込)
+	Discount    int64        `json:"discount"`    // 割引金額(税込)
+	ShippingFee int64        `json:"shippingFee"` // 配送手数料(税込)
+	Total       int64        `json:"total"`       // 合計金額(税込)
+}

--- a/api/internal/gateway/user/facility/service/cart.go
+++ b/api/internal/gateway/user/facility/service/cart.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+)
+
+type Cart struct {
+	response.Cart
+}
+
+type Carts []*Cart
+
+type CartItem struct {
+	response.CartItem
+}
+
+type CartItems []*CartItem
+
+func NewCart(basket *entity.CartBasket) *Cart {
+	return &Cart{
+		Cart: response.Cart{
+			Number:        basket.BoxNumber,
+			Type:          NewShippingType(basket.BoxType).Response(),
+			Size:          NewShippingSize(basket.BoxSize).Response(),
+			Rate:          basket.BoxRate,
+			Items:         NewCartItems(basket.Items).Response(),
+			CoordinatorID: basket.CoordinatorID,
+		},
+	}
+}
+
+func (c *Cart) Response() *response.Cart {
+	return &c.Cart
+}
+
+func NewCarts(cart *entity.Cart) Carts {
+	if cart == nil {
+		return Carts{}
+	}
+	res := make(Carts, len(cart.Baskets))
+	for i := range cart.Baskets {
+		res[i] = NewCart(cart.Baskets[i])
+	}
+	return res
+}
+
+func (cs Carts) Response() []*response.Cart {
+	res := make([]*response.Cart, len(cs))
+	for i := range cs {
+		res[i] = cs[i].Response()
+	}
+	return res
+}
+
+func NewCartItem(item *entity.CartItem) *CartItem {
+	return &CartItem{
+		CartItem: response.CartItem{
+			ProductID: item.ProductID,
+			Quantity:  item.Quantity,
+		},
+	}
+}
+
+func (i *CartItem) Response() *response.CartItem {
+	return &i.CartItem
+}
+
+func NewCartItems(items entity.CartItems) CartItems {
+	res := make(CartItems, len(items))
+	for i := range items {
+		res[i] = NewCartItem(items[i])
+	}
+	return res
+}
+
+func (is CartItems) Response() []*response.CartItem {
+	res := make([]*response.CartItem, len(is))
+	for i := range is {
+		res[i] = is[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/cart_test.go
+++ b/api/internal/gateway/user/facility/service/cart_test.go
@@ -1,0 +1,346 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCart(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		basket *entity.CartBasket
+		expect *Cart
+	}{
+		{
+			name: "success",
+			basket: &entity.CartBasket{
+				BoxNumber: 1,
+				BoxType:   entity.ShippingTypeNormal,
+				BoxSize:   entity.ShippingSize60,
+				BoxRate:   80,
+				Items: []*entity.CartItem{
+					{
+						ProductID: "product-id",
+						Quantity:  1,
+					},
+				},
+				CoordinatorID: "coordinator-id",
+			},
+			expect: &Cart{
+				Cart: response.Cart{
+					Number: 1,
+					Type:   ShippingTypeNormal.Response(),
+					Size:   ShippingSize60.Response(),
+					Rate:   80,
+					Items: []*response.CartItem{
+						{
+							ProductID: "product-id",
+							Quantity:  1,
+						},
+					},
+					CoordinatorID: "coordinator-id",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewCart(tt.basket)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestCart_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		cart   *Cart
+		expect *response.Cart
+	}{
+		{
+			name: "success",
+			cart: &Cart{
+				Cart: response.Cart{
+					Number: 1,
+					Type:   ShippingTypeNormal.Response(),
+					Size:   ShippingSize60.Response(),
+					Rate:   80,
+					Items: []*response.CartItem{
+						{
+							ProductID: "product-id",
+							Quantity:  1,
+						},
+					},
+					CoordinatorID: "coordinator-id",
+				},
+			},
+			expect: &response.Cart{
+				Number: 1,
+				Type:   ShippingTypeNormal.Response(),
+				Size:   ShippingSize60.Response(),
+				Rate:   80,
+				Items: []*response.CartItem{
+					{
+						ProductID: "product-id",
+						Quantity:  1,
+					},
+				},
+				CoordinatorID: "coordinator-id",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.cart.Response())
+		})
+	}
+}
+
+func TestCarts(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	tests := []struct {
+		name   string
+		cart   *entity.Cart
+		expect Carts
+	}{
+		{
+			name: "success",
+			cart: &entity.Cart{
+				SessionID: "session-id",
+				Baskets: entity.CartBaskets{
+					{
+						BoxNumber: 1,
+						BoxType:   entity.ShippingTypeNormal,
+						BoxSize:   entity.ShippingSize60,
+						BoxRate:   80,
+						Items: []*entity.CartItem{
+							{
+								ProductID: "product-id",
+								Quantity:  1,
+							},
+						},
+						CoordinatorID: "coordinator-id",
+					},
+				},
+				ExpiredAt: now.AddDate(0, 0, 14),
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			expect: Carts{
+				{
+					Cart: response.Cart{
+						Number: 1,
+						Type:   ShippingTypeNormal.Response(),
+						Size:   ShippingSize60.Response(),
+						Rate:   80,
+						Items: []*response.CartItem{
+							{
+								ProductID: "product-id",
+								Quantity:  1,
+							},
+						},
+						CoordinatorID: "coordinator-id",
+					},
+				},
+			},
+		},
+		{
+			name:   "empty",
+			cart:   nil,
+			expect: Carts{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewCarts(tt.cart)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestCarts_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		carts  Carts
+		expect []*response.Cart
+	}{
+		{
+			name: "success",
+			carts: Carts{
+				{
+					Cart: response.Cart{
+						Number: 1,
+						Type:   ShippingTypeNormal.Response(),
+						Size:   ShippingSize60.Response(),
+						Rate:   80,
+						Items: []*response.CartItem{
+							{
+								ProductID: "product-id",
+								Quantity:  1,
+							},
+						},
+						CoordinatorID: "coordinator-id",
+					},
+				},
+			},
+			expect: []*response.Cart{
+				{
+					Number: 1,
+					Type:   ShippingTypeNormal.Response(),
+					Size:   ShippingSize60.Response(),
+					Rate:   80,
+					Items: []*response.CartItem{
+						{
+							ProductID: "product-id",
+							Quantity:  1,
+						},
+					},
+					CoordinatorID: "coordinator-id",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.carts.Response())
+		})
+	}
+}
+
+func TestCartItem(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		item   *entity.CartItem
+		expect *CartItem
+	}{
+		{
+			name: "success",
+			item: &entity.CartItem{
+				ProductID: "product-id",
+				Quantity:  1,
+			},
+			expect: &CartItem{
+				CartItem: response.CartItem{
+					ProductID: "product-id",
+					Quantity:  1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewCartItem(tt.item)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestCartItem_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		item   *CartItem
+		expect *response.CartItem
+	}{
+		{
+			name: "success",
+			item: &CartItem{
+				CartItem: response.CartItem{
+					ProductID: "product-id",
+					Quantity:  1,
+				},
+			},
+			expect: &response.CartItem{
+				ProductID: "product-id",
+				Quantity:  1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.item.Response())
+		})
+	}
+}
+
+func TestCartItems(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		items  entity.CartItems
+		expect CartItems
+	}{
+		{
+			name: "success",
+			items: entity.CartItems{
+				{
+					ProductID: "product-id",
+					Quantity:  1,
+				},
+			},
+			expect: CartItems{
+				{
+					CartItem: response.CartItem{
+						ProductID: "product-id",
+						Quantity:  1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewCartItems(tt.items)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestCartItems_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		items  CartItems
+		expect []*response.CartItem
+	}{
+		{
+			name: "success",
+			items: CartItems{
+				{
+					CartItem: response.CartItem{
+						ProductID: "product-id",
+						Quantity:  1,
+					},
+				},
+			},
+			expect: []*response.CartItem{
+				{
+					ProductID: "product-id",
+					Quantity:  1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.items.Response())
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/order_fulfillment.go
+++ b/api/internal/gateway/user/facility/service/order_fulfillment.go
@@ -1,0 +1,54 @@
+package service
+
+import "github.com/and-period/furumaru/api/internal/store/entity"
+
+// ShippingSize - 配送時の箱の大きさ
+type ShippingSize int32
+
+const (
+	ShippingSizeUnknown ShippingSize = 0
+	ShippingSize60      ShippingSize = 1 // 箱のサイズ:60
+	ShippingSize80      ShippingSize = 2 // 箱のサイズ:80
+	ShippingSize100     ShippingSize = 3 // 箱のサイズ:100
+)
+
+// ShippingType - 配送方法
+type ShippingType int32
+
+const (
+	ShippingTypeUnknown ShippingType = 0
+	ShippingTypeNormal  ShippingType = 1 // 常温・冷蔵便
+	ShippingTypeFrozen  ShippingType = 2 // 冷凍便
+)
+
+func NewShippingSize(size entity.ShippingSize) ShippingSize {
+	switch size {
+	case entity.ShippingSize60:
+		return ShippingSize60
+	case entity.ShippingSize80:
+		return ShippingSize80
+	case entity.ShippingSize100:
+		return ShippingSize100
+	default:
+		return ShippingSizeUnknown
+	}
+}
+
+func (s ShippingSize) Response() int32 {
+	return int32(s)
+}
+
+func NewShippingType(typ entity.ShippingType) ShippingType {
+	switch typ {
+	case entity.ShippingTypeNormal:
+		return ShippingTypeNormal
+	case entity.ShippingTypeFrozen:
+		return ShippingTypeFrozen
+	default:
+		return ShippingTypeUnknown
+	}
+}
+
+func (t ShippingType) Response() int32 {
+	return int32(t)
+}

--- a/api/internal/gateway/user/facility/service/order_fulfillment_test.go
+++ b/api/internal/gateway/user/facility/service/order_fulfillment_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShippingSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status entity.ShippingSize
+		expect ShippingSize
+	}{
+		{
+			name:   "size 60",
+			status: entity.ShippingSize60,
+			expect: ShippingSize60,
+		},
+		{
+			name:   "size 80",
+			status: entity.ShippingSize80,
+			expect: ShippingSize80,
+		},
+		{
+			name:   "size 100",
+			status: entity.ShippingSize100,
+			expect: ShippingSize100,
+		},
+		{
+			name:   "unknown",
+			status: entity.ShippingSizeUnknown,
+			expect: ShippingSizeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewShippingSize(tt.status))
+		})
+	}
+}
+
+func TestShippingSize_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status ShippingSize
+		expect int32
+	}{
+		{
+			name:   "success",
+			status: ShippingSize60,
+			expect: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.status.Response())
+		})
+	}
+}
+
+func TestShippingType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status entity.ShippingType
+		expect ShippingType
+	}{
+		{
+			name:   "normal",
+			status: entity.ShippingTypeNormal,
+			expect: ShippingTypeNormal,
+		},
+		{
+			name:   "frozen",
+			status: entity.ShippingTypeFrozen,
+			expect: ShippingTypeFrozen,
+		},
+		{
+			name:   "unknown",
+			status: entity.ShippingTypeUnknown,
+			expect: ShippingTypeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewShippingType(tt.status))
+		})
+	}
+}
+
+func TestShippingType_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status ShippingType
+		expect int32
+	}{
+		{
+			name:   "success",
+			status: ShippingTypeNormal,
+			expect: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.status.Response())
+		})
+	}
+}

--- a/api/internal/gateway/user/facility/service/promotion.go
+++ b/api/internal/gateway/user/facility/service/promotion.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+)
+
+// PromotionStatus - プロモーションの状態
+type PromotionStatus int32
+
+const (
+	PromotionStatusUnknown  PromotionStatus = 0
+	PromotionStatusPrivate  PromotionStatus = 1 // 非公開
+	PromotionStatusWaiting  PromotionStatus = 2 // 利用開始前
+	PromotionStatusEnabled  PromotionStatus = 3 // 利用可能
+	PromotionStatusFinished PromotionStatus = 4 // 利用終了
+)
+
+// DiscountType - 割引計算方法
+type DiscountType int32
+
+const (
+	DiscountTypeUnknown      DiscountType = 0
+	DiscountTypeAmount       DiscountType = 1 // 固定額(円)
+	DiscountTypeRate         DiscountType = 2 // 料率計算(%)
+	DiscountTypeFreeShipping DiscountType = 3 // 送料無料
+)
+
+type Promotion struct {
+	response.Promotion
+}
+
+type Promotions []*Promotion
+
+func NewPromotionStatus(typ entity.PromotionStatus) PromotionStatus {
+	switch typ {
+	case entity.PromotionStatusPrivate:
+		return PromotionStatusPrivate
+	case entity.PromotionStatusWaiting:
+		return PromotionStatusWaiting
+	case entity.PromotionStatusEnabled:
+		return PromotionStatusEnabled
+	case entity.PromotionStatusFinished:
+		return PromotionStatusFinished
+	default:
+		return PromotionStatusUnknown
+	}
+}
+
+func (s PromotionStatus) Response() int32 {
+	return int32(s)
+}
+
+func NewDiscountType(typ entity.DiscountType) DiscountType {
+	switch typ {
+	case entity.DiscountTypeAmount:
+		return DiscountTypeAmount
+	case entity.DiscountTypeRate:
+		return DiscountTypeRate
+	case entity.DiscountTypeFreeShipping:
+		return DiscountTypeFreeShipping
+	default:
+		return DiscountTypeUnknown
+	}
+}
+
+func (t DiscountType) StoreEntity() entity.DiscountType {
+	switch t {
+	case DiscountTypeAmount:
+		return entity.DiscountTypeAmount
+	case DiscountTypeRate:
+		return entity.DiscountTypeRate
+	case DiscountTypeFreeShipping:
+		return entity.DiscountTypeFreeShipping
+	default:
+		return entity.DiscountTypeUnknown
+	}
+}
+
+func (t DiscountType) Response() int32 {
+	return int32(t)
+}
+
+func NewPromotion(promotion *entity.Promotion) *Promotion {
+	return &Promotion{
+		Promotion: response.Promotion{
+			ID:           promotion.ID,
+			Title:        promotion.Title,
+			Description:  promotion.Description,
+			Status:       NewPromotionStatus(promotion.Status).Response(),
+			DiscountType: NewDiscountType(promotion.DiscountType).Response(),
+			DiscountRate: promotion.DiscountRate,
+			Code:         promotion.Code,
+			StartAt:      promotion.StartAt.Unix(),
+			EndAt:        promotion.EndAt.Unix(),
+		},
+	}
+}
+
+func (p *Promotion) Response() *response.Promotion {
+	if p == nil {
+		return nil
+	}
+	return &p.Promotion
+}
+
+func NewPromotions(promotions entity.Promotions) Promotions {
+	res := make(Promotions, len(promotions))
+	for i := range promotions {
+		res[i] = NewPromotion(promotions[i])
+	}
+	return res
+}
+
+func (ps Promotions) Response() []*response.Promotion {
+	res := make([]*response.Promotion, len(ps))
+	for i := range ps {
+		res[i] = ps[i].Response()
+	}
+	return res
+}

--- a/api/internal/gateway/user/facility/service/promotion_test.go
+++ b/api/internal/gateway/user/facility/service/promotion_test.go
@@ -1,0 +1,361 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/and-period/furumaru/api/internal/gateway/user/facility/response"
+	"github.com/and-period/furumaru/api/internal/store/entity"
+	"github.com/and-period/furumaru/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromotionStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status entity.PromotionStatus
+		expect PromotionStatus
+	}{
+		{
+			name:   "private",
+			status: entity.PromotionStatusPrivate,
+			expect: PromotionStatusPrivate,
+		},
+		{
+			name:   "waiting",
+			status: entity.PromotionStatusWaiting,
+			expect: PromotionStatusWaiting,
+		},
+		{
+			name:   "enabled",
+			status: entity.PromotionStatusEnabled,
+			expect: PromotionStatusEnabled,
+		},
+		{
+			name:   "finisihed",
+			status: entity.PromotionStatusFinished,
+			expect: PromotionStatusFinished,
+		},
+		{
+			name:   "unknown",
+			status: entity.PromotionStatusUnknown,
+			expect: PromotionStatusUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewPromotionStatus(tt.status)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestPromotionStatus_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status PromotionStatus
+		expect int32
+	}{
+		{
+			name:   "success",
+			status: PromotionStatusEnabled,
+			expect: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.status.Response())
+		})
+	}
+}
+
+func TestDiscountType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		discountType entity.DiscountType
+		expect       DiscountType
+	}{
+		{
+			name:         "success to amount",
+			discountType: entity.DiscountTypeAmount,
+			expect:       DiscountTypeAmount,
+		},
+		{
+			name:         "success to rate",
+			discountType: entity.DiscountTypeRate,
+			expect:       DiscountTypeRate,
+		},
+		{
+			name:         "success to free shipping",
+			discountType: entity.DiscountTypeFreeShipping,
+			expect:       DiscountTypeFreeShipping,
+		},
+		{
+			name:         "success to unknown",
+			discountType: entity.DiscountTypeUnknown,
+			expect:       DiscountTypeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewDiscountType(tt.discountType))
+		})
+	}
+}
+
+func TestDiscountType_StoreEntity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		discountType DiscountType
+		expect       entity.DiscountType
+	}{
+		{
+			name:         "success to amount",
+			discountType: DiscountTypeAmount,
+			expect:       entity.DiscountTypeAmount,
+		},
+		{
+			name:         "success to rate",
+			discountType: DiscountTypeRate,
+			expect:       entity.DiscountTypeRate,
+		},
+		{
+			name:         "success to free shipping",
+			discountType: DiscountTypeFreeShipping,
+			expect:       entity.DiscountTypeFreeShipping,
+		},
+		{
+			name:         "success to unknown",
+			discountType: DiscountTypeUnknown,
+			expect:       entity.DiscountTypeUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.discountType.StoreEntity())
+		})
+	}
+}
+
+func TestDiscountType_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		discountType DiscountType
+		expect       int32
+	}{
+		{
+			name:         "success",
+			discountType: DiscountTypeAmount,
+			expect:       1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.discountType.Response())
+		})
+	}
+}
+
+func TestPromotion(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 1, 0, 0, 0, 0)
+	tests := []struct {
+		name      string
+		promotion *entity.Promotion
+		expect    *Promotion
+	}{
+		{
+			name: "success",
+			promotion: &entity.Promotion{
+				ID:           "promotion-id",
+				Title:        "夏の採れたて野菜マルシェを開催!!",
+				Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+				Status:       entity.PromotionStatusEnabled,
+				Public:       true,
+				DiscountType: entity.DiscountTypeFreeShipping,
+				DiscountRate: 0,
+				Code:         "code0001",
+				CodeType:     entity.PromotionCodeTypeOnce,
+				StartAt:      now,
+				EndAt:        now.AddDate(0, 1, 0),
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			},
+			expect: &Promotion{
+				Promotion: response.Promotion{
+					ID:           "promotion-id",
+					Title:        "夏の採れたて野菜マルシェを開催!!",
+					Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+					Status:       int32(PromotionStatusEnabled),
+					DiscountType: DiscountTypeFreeShipping.Response(),
+					DiscountRate: 0,
+					Code:         "code0001",
+					StartAt:      1640962800,
+					EndAt:        1643641200,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewPromotion(tt.promotion))
+		})
+	}
+}
+
+func TestPromotion_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		promotion *Promotion
+		expect    *response.Promotion
+	}{
+		{
+			name: "success",
+			promotion: &Promotion{
+				Promotion: response.Promotion{
+					ID:           "promotion-id",
+					Title:        "夏の採れたて野菜マルシェを開催!!",
+					Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+					Status:       int32(PromotionStatusEnabled),
+					DiscountType: DiscountTypeFreeShipping.Response(),
+					DiscountRate: 0,
+					Code:         "code0001",
+					StartAt:      1640962800,
+					EndAt:        1643641200,
+				},
+			},
+			expect: &response.Promotion{
+				ID:           "promotion-id",
+				Title:        "夏の採れたて野菜マルシェを開催!!",
+				Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+				Status:       int32(PromotionStatusEnabled),
+				DiscountType: DiscountTypeFreeShipping.Response(),
+				DiscountRate: 0,
+				Code:         "code0001",
+				StartAt:      1640962800,
+				EndAt:        1643641200,
+			},
+		},
+		{
+			name:      "empty",
+			promotion: nil,
+			expect:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.promotion.Response())
+		})
+	}
+}
+
+func TestPromotions(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 1, 0, 0, 0, 0)
+	tests := []struct {
+		name       string
+		promotions entity.Promotions
+		expect     Promotions
+	}{
+		{
+			name: "success",
+			promotions: entity.Promotions{
+				{
+					ID:           "promotion-id",
+					Title:        "夏の採れたて野菜マルシェを開催!!",
+					Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+					Status:       entity.PromotionStatusEnabled,
+					Public:       true,
+					DiscountType: entity.DiscountTypeFreeShipping,
+					DiscountRate: 0,
+					Code:         "code0001",
+					CodeType:     entity.PromotionCodeTypeOnce,
+					StartAt:      now,
+					EndAt:        now.AddDate(0, 1, 0),
+					CreatedAt:    now,
+					UpdatedAt:    now,
+				},
+			},
+			expect: Promotions{
+				{
+					Promotion: response.Promotion{
+						ID:           "promotion-id",
+						Title:        "夏の採れたて野菜マルシェを開催!!",
+						Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+						Status:       int32(PromotionStatusEnabled),
+						DiscountType: DiscountTypeFreeShipping.Response(),
+						DiscountRate: 0,
+						Code:         "code0001",
+						StartAt:      1640962800,
+						EndAt:        1643641200,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewPromotions(tt.promotions))
+		})
+	}
+}
+
+func TestPromotions_Response(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		promotions Promotions
+		expect     []*response.Promotion
+	}{
+		{
+			name: "success",
+			promotions: Promotions{
+				{
+					Promotion: response.Promotion{
+						ID:           "promotion-id",
+						Title:        "夏の採れたて野菜マルシェを開催!!",
+						Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+						Status:       int32(PromotionStatusEnabled),
+						DiscountType: DiscountTypeFreeShipping.Response(),
+						DiscountRate: 0,
+						Code:         "code0001",
+						StartAt:      1640962800,
+						EndAt:        1643641200,
+					},
+				},
+			},
+			expect: []*response.Promotion{
+				{
+					ID:           "promotion-id",
+					Title:        "夏の採れたて野菜マルシェを開催!!",
+					Description:  "採れたての夏野菜を紹介するマルシェを開催ます!!",
+					Status:       int32(PromotionStatusEnabled),
+					DiscountType: DiscountTypeFreeShipping.Response(),
+					DiscountRate: 0,
+					Code:         "code0001",
+					StartAt:      1640962800,
+					EndAt:        1643641200,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.promotions.Response())
+		})
+	}
+}

--- a/api/internal/store/entity/order_payment_summary.go
+++ b/api/internal/store/entity/order_payment_summary.go
@@ -24,6 +24,7 @@ type OrderPaymentSummary struct {
 
 type NewProductOrderPaymentSummaryParams struct {
 	PrefectureCode int32
+	Pickup         bool
 	Baskets        CartBaskets
 	Products       Products
 	Shipping       *Shipping
@@ -52,6 +53,9 @@ func NewProductOrderPaymentSummary(params *NewProductOrderPaymentSummaryParams) 
 	}
 	// 商品配送料金の算出
 	for _, basket := range params.Baskets {
+		if params.Pickup {
+			break // 店頭受取の場合、配送料金は算出しない
+		}
 		if params.PrefectureCode == 0 {
 			break // 配送先都道府県の指定がない場合、配送料金は算出しない
 		}

--- a/api/internal/store/entity/order_payment_summary_test.go
+++ b/api/internal/store/entity/order_payment_summary_test.go
@@ -262,6 +262,76 @@ func TestProductOrderPaymentSummary(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name: "success with pickup",
+			params: &NewProductOrderPaymentSummaryParams{
+				PrefectureCode: 13,
+				Pickup:         true,
+				Baskets: CartBaskets{
+					{
+						BoxNumber: 1,
+						BoxType:   ShippingTypeNormal,
+						BoxSize:   ShippingSize60,
+						Items: []*CartItem{
+							{
+								ProductID: "product-id01",
+								Quantity:  1,
+							},
+							{
+								ProductID: "product-id02",
+								Quantity:  2,
+							},
+						},
+						CoordinatorID: "coordinator-id",
+					},
+				},
+				Products: []*Product{
+					{
+						ID:   "product-id01",
+						Name: "じゃがいも",
+						ProductRevision: ProductRevision{
+							ID:        1,
+							ProductID: "product-id01",
+							Price:     500,
+						},
+					},
+					{
+						ID:   "product-id02",
+						Name: "人参",
+						ProductRevision: ProductRevision{
+							ID:        2,
+							ProductID: "product-id02",
+							Price:     1980,
+						},
+					},
+				},
+				Shipping: &Shipping{
+					ID:            "coordinator-id",
+					CoordinatorID: "coordinator-id",
+					ShippingRevision: ShippingRevision{
+						ShippingID:        "coordinator-id",
+						Box60Rates:        rates,
+						Box60Frozen:       800,
+						Box80Rates:        rates,
+						Box80Frozen:       800,
+						Box100Rates:       rates,
+						Box100Frozen:      800,
+						HasFreeShipping:   true,
+						FreeShippingRates: 3000,
+					},
+				},
+				Promotion: nil,
+			},
+			expect: &OrderPaymentSummary{
+				Subtotal:    4460,
+				Discount:    0,
+				ShippingFee: 0,
+				Tax:         405,
+				TaxRate:     10,
+				Total:       4460,
+			},
+			expectErr: nil,
+		},
+		{
 			name: "failed to calc total price",
 			params: &NewProductOrderPaymentSummaryParams{
 				PrefectureCode: 13,

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -20,6 +20,7 @@ type CalcCartInput struct {
 	BoxNumber      int64  `validate:"min=0"`
 	PromotionCode  string `validate:"omitempty,len=8"`
 	PrefectureCode int32  `validate:"min=0,max=47"`
+	Pickup         bool   `validate:""`
 }
 
 type AddCartItemInput struct {

--- a/api/internal/store/service/cart.go
+++ b/api/internal/store/service/cart.go
@@ -86,6 +86,7 @@ func (s *service) CalcCart(ctx context.Context, in *store.CalcCartInput) (*entit
 	}
 	params := &entity.NewProductOrderPaymentSummaryParams{
 		PrefectureCode: in.PrefectureCode,
+		Pickup:         in.Pickup,
 		Baskets:        baskets,
 		Products:       products,
 		Shipping:       shipping,


### PR DESCRIPTION
## 概要
施設向けゲートウェイに新しいサービスとハンドラを追加し、カート管理、一括注文処理、プロモーション機能を実装しました。

## 変更内容
- 施設向けカートサービス（GetCart、UpdateCart）の実装
- 一括注文処理のための注文履行サービスの追加
- 施設専用プロモーションサービスの実装
- カートハンドラーにUpdateCartエンドポイントを追加
- プロモーションハンドラーの新規作成
- 全サービスに対する包括的なユニットテストを追加
- 注文決済サマリーに施設向けメソッドを追加

## 背景・目的
施設ユーザーが効率的に商品を管理し、一括で注文処理を行えるようにするため、専用のAPIエンドポイントとビジネスロジックが必要でした。

## テスト
- [x] API: make test (Go) - テスト実装済み
- [ ] API: make lint-fix
- [ ] 手動テスト完了

## レビューポイント
- 新しいサービス層の設計パターンが既存の実装と一貫しているか
- エラーハンドリングが適切に実装されているか
- テストカバレッジが十分か

## 関連情報
- 施設向け機能拡張の一環として実装

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - カート計算APIを追加（小計・割引・送料・合計、プロモーションコード、requestId対応）
  - 店舗受取（ピックアップ）指定で送料0円に対応
- 改善
  - カート取得が実データを返却
  - カート商品の追加・削除APIを実装（バリデーションと適切なエラーハンドリング）
- パフォーマンス
  - 関連データの並行取得でレスポンスを高速化
- バグ修正
  - 空配列を返していたレスポンスを修正

<!-- end of auto-generated comment: release notes by coderabbit.ai -->