### PR TITLE
chore(liff): LINE LIFF SDKを最新版へアップデート

### DIFF
--- a/web/liff/package.json
+++ b/web/liff/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fontsource-variable/inter": "^5.2.6",
-    "@line/liff": "^2.23.0",
+    "@line/liff": "^2.27.1",
     "@nuxt/devtools": "latest",
     "@nuxt/eslint-config": "^1.6.0",
     "@nuxt/test-utils": "^3.19.2",

--- a/web/liff/yarn.lock
+++ b/web/liff/yarn.lock
@@ -1294,548 +1294,580 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@liff/add-to-home-screen@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/add-to-home-screen/-/add-to-home-screen-2.23.0.tgz#8270eeeb87fe5ce85423aba05e6ebd6b58e79f8f"
-  integrity sha512-QILQIhFnPAxwoWQ+rl7WuWRGyZNJqSNIeAwLQ6Uq0nlDU1GgS2dKUnytC2qjwiMSdVpzxfeadpA+Ozw5EwFkeQ==
+"@liff/add-to-home-screen@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/add-to-home-screen/-/add-to-home-screen-2.27.1.tgz#2034b8f8ed4abcc24952f90c4b54497401085014"
+  integrity sha512-AKnlCuKZuuJxXs3ZFj/AYu8yiMBaWuGfADoAuRy2ivA4U4VPtep/bEgtHoSIMmSfZUgr7PC65UCi1cCLqDipIA==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/open-window" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/open-window" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/analytics@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/analytics/-/analytics-2.23.0.tgz#ceecd2e4e48db4bd004640d7ec6daf4398da7a76"
-  integrity sha512-gAR4Eefx9Ffj2Np4tiO/AUcdEE5xFmU5RFYNzAA/9sp+q5sMoBOaDQf+e85ff8XU/9v3Fa6KfVM6IP5XTyzHtA==
+"@liff/analytics@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/analytics/-/analytics-2.27.1.tgz#94099e683707caf41ca60640bca99cd4b0376f39"
+  integrity sha512-NFaLK4/JBSKpyyqIfjAMZJqyNQdFjoc4p/QFpj9LVw7fueImvM0WJF3N4iWz0SzIGaX94Qob2iePMeP0A9EGCA==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/core" "2.23.0"
-    "@liff/get-profile" "2.23.0"
-    "@liff/get-version" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/core" "2.27.1"
+    "@liff/get-profile" "2.27.1"
+    "@liff/get-version" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/check-availability@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/check-availability/-/check-availability-2.23.0.tgz#99cdbdd33fefd46d32b221b35c1b1523fb78c9b8"
-  integrity sha512-fOHj+KFmUgJZm5uOQyoxDoZuv0gNaqldZ9G45NBrK9yzIjt46ARLn0PCtKDsqckrJbfDqGOmQpin+6YdDjet8g==
+"@liff/check-availability@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/check-availability/-/check-availability-2.27.1.tgz#7cc9901d1fa2cd3af8cff9900e9c06b06856df56"
+  integrity sha512-oVswVCGxjH29/mKNFoJCUl7ym9Dpwy84o/1IqmvlkCgYu9/Gg+IGFQluuNHgeQVA/dN0f24SBIixTnLFmE/ckQ==
   dependencies:
-    "@liff/get-version" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/get-version" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/close-window@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/close-window/-/close-window-2.23.0.tgz#dad5fc060b242f7836c73034ad2d16984c32f5d3"
-  integrity sha512-7AsDob7OYyDiubX9joEEEcxxXJNzLeberqgaMCXs8T7IzPiJPHCZOFNlFng1Zh0W7qlnNxkwYd/sjXUNj7f6wA==
+"@liff/close-window@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/close-window/-/close-window-2.27.1.tgz#298b7f637a2fdc890b9b82dbcd0e83d1b1a6d630"
+  integrity sha512-JJuVCyxw7FI29YYemkisKjDnzQFbdP/h+RFzKi+CTFQ8qfSkDXQNzzosVO0Vn9MpDZunWTlIkdiD7Fb7ysFkfg==
   dependencies:
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/consts@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/consts/-/consts-2.23.0.tgz#b04f19f445e211ec80a04eca92cde4163066d829"
-  integrity sha512-HwvDQBxlxQXKn0w1SdjNttm5ti3Kgjb5f0GOc8P6MJsgU4+dcQPU6kSiBD8JFTlB1NNxHpdWt0fVBsrV+6SecQ==
+"@liff/consts@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/consts/-/consts-2.27.1.tgz#f25bf00baa54b6c5470c94571bc6439494af7e79"
+  integrity sha512-S7Fa7+CCUbYm/mbKv60Ao/vLJghT1fiUe6I7sU1c0OPNJ2XHIGpaQNBMXe6qIrh9vG6MRQTqFOcyMtSECqXUJA==
 
-"@liff/core@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/core/-/core-2.23.0.tgz#0bbca9aea5fcaeb24b9733f55eb2f94ab700c77c"
-  integrity sha512-gq7xUX0adw4eKY2Oy0mnXlEzZUohptBAb0/5ZNOYSv2K9ah5Z5jDpXluK+I+Hd1/gACdWgKiLvK7ZFkOtrFtCA==
+"@liff/core@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/core/-/core-2.27.1.tgz#1de7f895833979d5939accef6ab10216cf964c22"
+  integrity sha512-Zy/HxrRsXej5NKaT900uEJ7HcdTSXiayED151tca+E5u5kJjloQg74Epf5wN5PECV02XG6myPq2+svpSa51nMw==
   dependencies:
-    "@liff/get-version" "2.23.0"
-    "@liff/init" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/ready" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/get-version" "2.27.1"
+    "@liff/init" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/ready" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
 
-"@liff/create-shortcut-on-home-screen@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.23.0.tgz#b98beb8caa11b70bfb3c851bea7293df2bd4228a"
-  integrity sha512-JyofWvqtpme4kc5OT2lVI05kjj+CiJaU3rp7j08+ODYaZ0TIUl8vo7qbyN1ntiecg/rGVOq+HJzt5el2H+CzLw==
+"@liff/create-shortcut-on-home-screen@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.27.1.tgz#7c17d2127825e6dc2421f2cdfedac920c46460ff"
+  integrity sha512-yG65SDZ8ziLdaEiJggtwUR9OEgWUVj+/SijIiVlMsT7QCoIJi5T84zlfHWv7K+l7eOegKRPR7tXwbzlMZAcccw==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/open-window" "2.23.0"
-    "@liff/permanent-link" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/open-window" "2.27.1"
+    "@liff/permanent-link" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/extensions@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/extensions/-/extensions-2.23.0.tgz#0840069e4878f0651499e330e25c46893e12fe4f"
-  integrity sha512-ZkhQjlyPPqbTX8LBBnPitNV5qOoeg+BW34BOeX6iHSpNOQW0oPCjhl7k4cgZXYzqy0laC1y5vk9wG99bX9p9TQ==
+"@liff/extensions@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/extensions/-/extensions-2.27.1.tgz#a20e51aa28a717f4e80ef0e4f03de3efe0fda55a"
+  integrity sha512-xiJ4W/HUzOlamwzIQMLgE4XPPe3nowGmkOeWeisO1S+Xf7iqYs6Ftg3UCRm1lVSwkf2+pwQyAQ/0YkCw0VW85g==
   dependencies:
-    "@liff/add-to-home-screen" "2.23.0"
-    "@liff/check-availability" "2.23.0"
-    "@liff/consts" "2.23.0"
-    "@liff/get-advertising-id" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/scan-code" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/add-to-home-screen" "2.27.1"
+    "@liff/check-availability" "2.27.1"
+    "@liff/consts" "2.27.1"
+    "@liff/get-advertising-id" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/scan-code" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/get-advertising-id@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-advertising-id/-/get-advertising-id-2.23.0.tgz#2ab190b4de23425887b43b6b863db6c3cefc2bb7"
-  integrity sha512-HG58gxUXGEUQv5ooeLcezTGCRp2m03WO2mFPQIg/11/QLCLWMl+5OfOg3CTycR08kzoVPqV1eiJ5HVykx/jvmA==
+"@liff/get-advertising-id@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-advertising-id/-/get-advertising-id-2.27.1.tgz#78389e078e9f5ddc1424bbd0fcb2f599b9c0287a"
+  integrity sha512-3ZHcYcfVZQPqzoVDgsOzTBI05k7CK2FrT3iGtEWVUBL4rewOqVVlS8PDRXDm4zaaxyFejZ9vTQtJZksm29d3AA==
   dependencies:
-    "@liff/types" "2.23.0"
+    "@liff/types" "2.27.1"
 
-"@liff/get-friendship@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-friendship/-/get-friendship-2.23.0.tgz#04ff9c15c13b336c803cd0304d5d382fd5a45220"
-  integrity sha512-ttrKxb+EPhD13esgZqAb48jQlbOmE9Dc7uhHB30GAfsRjDYdCym2IM+QdYFFbwrkny6DIct1934QtUh6ZwIZng==
+"@liff/get-app-language@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-app-language/-/get-app-language-2.27.1.tgz#8582f90ce1dffde3be2c1038ed9640af288ec1ca"
+  integrity sha512-7r0mGPcn/y9G70PhK9Qv7irtYCnZUhPbXhmcbc0mXG/+dJL+IfP8kx17RQ4r/ZMniV7kvs9BYUfgreMFvb0dog==
   dependencies:
-    "@liff/permission" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/get-language@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-language/-/get-language-2.23.0.tgz#efc193292738816865c175d0c2543c8e6c9c370e"
-  integrity sha512-jJnN5oQowQGs43P2sN5l2vgsEQaXPso1AuudjtORuPb6hmmjXlyFrZgjpn4AykOXaE4d2uN66GfFgG2l6oqqEA==
+"@liff/get-friendship@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-friendship/-/get-friendship-2.27.1.tgz#8df00bbd7956fce1de922125ad28ff23da44ed4c"
+  integrity sha512-/9Wgz9vuUimo0Na+DJ4wEmpSNjV+TFPVrg+5SlP3Db9X5Z/O068FFwIkrCBtn7ERHiPh6lQtBEFS+wYQ3nYmHw==
   dependencies:
-    "@liff/use" "2.23.0"
+    "@liff/permission" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/use" "2.27.1"
 
-"@liff/get-line-version@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-line-version/-/get-line-version-2.23.0.tgz#cf461bba35e5a41d0eb24bd27bbfcfd73ff95166"
-  integrity sha512-jHG/Ah8WGINDnctBgkKu61htgJzhTtcPMx3yVUmgh1oF2VvWz9iRrDo5VT9Os/teBbls11uY4x5IxifKKlhSww==
+"@liff/get-language@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-language/-/get-language-2.27.1.tgz#1af7e40ec70c60207d652847df00f013583cb985"
+  integrity sha512-Uj+O2TFc9uvrvQarg865hBlafkJlk9AHncVa5kjesvemJOdGMjDo/HaNLbs+alfPYYLOrv9xKeksMkHTyy691g==
   dependencies:
-    "@liff/use" "2.23.0"
+    "@liff/use" "2.27.1"
 
-"@liff/get-os@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-os/-/get-os-2.23.0.tgz#14af4b562f5175ba672a9f0cf1857c35280fbcdd"
-  integrity sha512-iPJ9JNwXY5hPtBti2F6xRuMTF6QB4KR0mBVYWypV76NrrNvxr5fWKjnVxhSXMo6YcBId9giXJ0gbWqp8iKmZag==
+"@liff/get-line-version@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-line-version/-/get-line-version-2.27.1.tgz#15d1f0f39047ca762249646b44f2aa9d1faa9d9e"
+  integrity sha512-fs/ZYukxpMh1HVQUvYoDX/ynydm2SwWSuayx+WYhTkbRH34lBntPSNt3LkRDsc10ismRh9QJAfOzkqjvXnTQ+A==
   dependencies:
-    "@liff/use" "2.23.0"
+    "@liff/use" "2.27.1"
 
-"@liff/get-profile@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-profile/-/get-profile-2.23.0.tgz#7291f908387f39d4c3880720b84a447d81e27a28"
-  integrity sha512-GoTSkGCTo41zpBRZWWT/M3aPv6yLU0rs/6XE98gz8+WzoQ41J5zWmy0DF/Kr0hG7wTRCFNJdKyhM50nvf64JEw==
+"@liff/get-origins@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-origins/-/get-origins-2.27.1.tgz#eebe2fa2f2faa12a02bdbdc4d7c661ab3141aa54"
+  integrity sha512-XCK2pVGYEfNtyhLfrFUCRM1tyz+sdb4PUwRZvlOgIPt8TEwDJ2/jXChXw+4v2g/+ManWqeJwNjVosHnBX4wyGQ==
   dependencies:
-    "@liff/permission" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/use" "2.27.1"
 
-"@liff/get-version@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/get-version/-/get-version-2.23.0.tgz#57881dc323b80a1acff8ab05b4fc553f474a32ed"
-  integrity sha512-IweJCCTVqSRA6O1gMuDLzzTQWQwjg6xfHPZVZStNSMXdvW/b5ZbTZ5mdXng73aa9fhYbwDJysGZKh1NMSPfkGg==
+"@liff/get-os@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-os/-/get-os-2.27.1.tgz#3d4d018fa6be039789bebf76057f68be724ce1e3"
+  integrity sha512-88x3wXT1mUosjRY+6IsMmFUu4U7lanDXD+0kGdAKMS3qk5ENIBtLnX0p+6p3UbRHdWw8SzCvxFvzCI/Lz++h4w==
   dependencies:
-    "@liff/use" "2.23.0"
+    "@liff/use" "2.27.1"
 
-"@liff/hooks@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/hooks/-/hooks-2.23.0.tgz#a638e17db968169003cfda49e1562b3dcf31382b"
-  integrity sha512-T5kPg2xnfvV4tHtQnlmYawH9l0cK44ZS9pe1fVZYBFMANAbeXmbQuGWDO2w11mHYZuvODwwHyBx1/zXJaBoc9Q==
-
-"@liff/i18n@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/i18n/-/i18n-2.23.0.tgz#5dc7373dd07e984bca1ac9bfde28f15cf6f51eef"
-  integrity sha512-kv+ClJF0zun7MtXKYo3AMGJ4oIAY8yTFcFl/Xk3DwwrXFgRjKd1tuS3hC3fr7zsXCR0EDy2/gNSDUtl1bdZBvw==
+"@liff/get-profile@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-profile/-/get-profile-2.27.1.tgz#074186c49e254c6a829bc53f801082a990af81fe"
+  integrity sha512-Mr46E2ip5KHFjuIEybBEwFi+O8BC+n28tALKKFRTQUghARq6icYXyL17M/0wa+Un0hLr1hw9Ys3LEywghux0xw==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/permission" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/use" "2.27.1"
 
-"@liff/init@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/init/-/init-2.23.0.tgz#d6e16cf23a2b9458449129bd594f5eb6ca3ef41b"
-  integrity sha512-9DhqjHD7mXLXj3jysovbBU6PzVi7dXsh51RpgUXWQE53pdN8RCmlu94Gr5A9qnxZL1jtI6AS/RNHaPr0umRnIw==
+"@liff/get-version@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/get-version/-/get-version-2.27.1.tgz#870e986f40adcc90d8d842609f9a2fb935fbe592"
+  integrity sha512-rdyM7BRXv8f9kRyxHUiypvZC/9Ao+FokQwoxzwpcpGWgVPgmNs/zeIF3KDD7Q5T6XMJzYLFiRH1xABnE8wJHyg==
   dependencies:
-    "@liff/check-availability" "2.23.0"
-    "@liff/close-window" "2.23.0"
-    "@liff/consts" "2.23.0"
-    "@liff/extensions" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/hooks" "2.23.0"
-    "@liff/i18n" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/login" "2.23.0"
-    "@liff/logout" "2.23.0"
-    "@liff/message-bus" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/ready" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/use" "2.27.1"
 
-"@liff/is-api-available@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/is-api-available/-/is-api-available-2.23.0.tgz#a229d8b9303effe906a523da83968403af8d298a"
-  integrity sha512-RZMa0T7awjc8LKlL9ibZf89AfJ7R2znpIs/pE0rPvGPv9C+VX9BLu8x4oMIkiV9YJysV3eHd6sf4wuxoES2DUQ==
+"@liff/hooks@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/hooks/-/hooks-2.27.1.tgz#b6d287b0d169c6046edf292058e41c46caf664ba"
+  integrity sha512-Nm0rMqGy1VhkCc5Hxkn/J3HmcpHzt/ehmLOZkCbUbk/sQQaSmN1aQHmdZ9EkysYY2YSnvbLdypWqd5C/v7ejEw==
+
+"@liff/i18n@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/i18n/-/i18n-2.27.1.tgz#23cb62c271c60f2c56f836cb37387e6c3abd1f89"
+  integrity sha512-nGo3EloEacS4vj2ZbT0V8Nfwscd1ARN2LRJtxfGnqPqaN6AcfX+6XQrC0//+3Ik2cY4hQlIhVxfxFzodtniD0A==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/is-in-client@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/is-in-client/-/is-in-client-2.23.0.tgz#2580bfd6eaf91ed9f62b5897736e6946893bf9f3"
-  integrity sha512-eFpYGxzkmS5NLHaYoEp/4ydrrDLBG1zxbnQboP+F9u1RLkj5c9QTbfOX/3uwHAgI3Mca9Gh5tLPJpVFCQ/zrPg==
+"@liff/iap@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/iap/-/iap-2.27.1.tgz#d57b3dace5a8144d787d0314a6e5a59bc0d075f6"
+  integrity sha512-eFTL/XXmk1pn3sFWGaN7Pg4lIFyecWlik8m2N7Cx3VIeaIDLu/ftKoleM3L8lMV8wGbqN2U/w+xnMTsTFGKW0Q==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/is-logged-in@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/is-logged-in/-/is-logged-in-2.23.0.tgz#42c654409e5eeb4f47889a730d7b3b51d1548034"
-  integrity sha512-PqeTplhTmTo/xTIV5SDnJYV9eRQKQg7dUgAS+G5QpS84vicu4uFn0wuwswxpZH0JecU7SRCxH/DcW7U8T2qRJg==
+"@liff/init@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/init/-/init-2.27.1.tgz#4ba2153d640435320351a7fafa89fee4d1262f90"
+  integrity sha512-fhJNra0GpV2ztX5Z47IzHXAjjEO4LPMpvyutv9UObFd5AG9b5aOPzYs9oas5Jn5k2+bEJeRh07xXm6Y+BoA6pA==
   dependencies:
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/check-availability" "2.27.1"
+    "@liff/close-window" "2.27.1"
+    "@liff/consts" "2.27.1"
+    "@liff/extensions" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/hooks" "2.27.1"
+    "@liff/i18n" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/login" "2.27.1"
+    "@liff/logout" "2.27.1"
+    "@liff/message-bus" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/ready" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/is-sub-window@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/is-sub-window/-/is-sub-window-2.23.0.tgz#5434127d7f6fe9a887322540c01c73f75a37d7dd"
-  integrity sha512-xY/3dCSabo5OEw8m4I3++az8uVVjFSpEYncrm+qNfiOyqyWuNfe9MBEQ6sgWqtr7x559uBxM4fvpr7vaZn5NRw==
+"@liff/is-api-available@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/is-api-available/-/is-api-available-2.27.1.tgz#2fd9082ff3c57caf3c5550df5c359d2cb4b194eb"
+  integrity sha512-zGLgWWy1uNgzkaPs+lpcFGjWtDzi6oU25GNvqxruJ2sxOEj8sl/aVxr72XcLpzTlIExfl5XWyjfOU/yLexh3xQ==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/liff-types@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/liff-types/-/liff-types-2.23.0.tgz#4a86d234a098824840ba448be864fcdf4785af34"
-  integrity sha512-G3yI1CSlj9Ej8VAjjXirA92cwyZ9JlZY0W3qzKRC+skuEu9tmYmB3bzr4sI0y6xl+bo0ZMaJssg61x0m+DNV/Q==
+"@liff/is-in-client@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/is-in-client/-/is-in-client-2.27.1.tgz#9ab994db57e4ea65da51b8784791757736513b5c"
+  integrity sha512-UZ5nlnnhYFR19QHTfrXoAGnJbVXuhHAORiTnr7gHIayYHYCOo10XB9a+oZVMvHlal/2pFBmNSu3KS4nJTcLKXA==
   dependencies:
-    "@liff/analytics" "2.23.0"
-    "@liff/close-window" "2.23.0"
-    "@liff/create-shortcut-on-home-screen" "2.23.0"
-    "@liff/get-friendship" "2.23.0"
-    "@liff/get-language" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/get-profile" "2.23.0"
-    "@liff/get-version" "2.23.0"
-    "@liff/i18n" "2.23.0"
-    "@liff/init" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/login" "2.23.0"
-    "@liff/logout" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/open-window" "2.23.0"
-    "@liff/permanent-link" "2.23.0"
-    "@liff/permission" "2.23.0"
-    "@liff/ready" "2.23.0"
-    "@liff/scan-code-v2" "2.23.0"
-    "@liff/send-messages" "2.23.0"
-    "@liff/share-target-picker" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/logger@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/logger/-/logger-2.23.0.tgz#d55b6445415d5a95a6a9772ca9c332a6c07a41e8"
-  integrity sha512-zIPjYkn3qKF01LIrxSskkHDFjrZ3626sZ2TKogGJYLVcDw7NXIOZ+rePUL7DP+Ss85d84DhdZ+KP9qTKJWYDmA==
-
-"@liff/login@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/login/-/login-2.23.0.tgz#bcd13d112326390a848db4e070f7ae1a4e44544c"
-  integrity sha512-RzpjvmL/ZKbukaZSRonnJTbbdIb7lafruvISpdTywsT0J3+iXGEYsUZRD5fA0kaeRtjSAGB69smL3Yjr1PVBbw==
+"@liff/is-logged-in@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/is-logged-in/-/is-logged-in-2.27.1.tgz#ec28343c279742cad6fc7e2e2e175b4d2a5feb5c"
+  integrity sha512-vm4w/6DXTOJFNlYwn3IYykYsSj86le19ez5uny+V1PHtK7hdzrDNfUcMRR/7hOkyh6U4tvxRgOFODyV/BpJDnA==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/get-version" "2.23.0"
-    "@liff/hooks" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+
+"@liff/is-sub-window@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/is-sub-window/-/is-sub-window-2.27.1.tgz#21659d86bff7ad1793bac4b7c64be4838126a8fa"
+  integrity sha512-v24umQ9GyHEJhVmQ+05Rv8wNC0lxXObwe3/cMpS+hKW34jNp8YJXoEOg+1v1jw1WLagmWlqUShlWekZjd4FP1w==
+  dependencies:
+    "@liff/consts" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
+
+"@liff/liff-types@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/liff-types/-/liff-types-2.27.1.tgz#69b4871ff8f2d593c32602d3ab90197c7f451acb"
+  integrity sha512-/zV34bSw2GGjeJ+Fc9Ql1Wo6RoDcGxnHRnl3doTFBWOCNaCCKs90O9UNFQW6vookQ9CYt/tJuiwUS8B5wq+h3w==
+  dependencies:
+    "@liff/analytics" "2.27.1"
+    "@liff/close-window" "2.27.1"
+    "@liff/create-shortcut-on-home-screen" "2.27.1"
+    "@liff/get-app-language" "2.27.1"
+    "@liff/get-friendship" "2.27.1"
+    "@liff/get-language" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-origins" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/get-profile" "2.27.1"
+    "@liff/get-version" "2.27.1"
+    "@liff/i18n" "2.27.1"
+    "@liff/iap" "2.27.1"
+    "@liff/init" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/login" "2.27.1"
+    "@liff/logout" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/open-window" "2.27.1"
+    "@liff/permanent-link" "2.27.1"
+    "@liff/permission" "2.27.1"
+    "@liff/ready" "2.27.1"
+    "@liff/scan-code-v2" "2.27.1"
+    "@liff/send-messages" "2.27.1"
+    "@liff/share-target-picker" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/use" "2.27.1"
+
+"@liff/logger@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/logger/-/logger-2.27.1.tgz#7ae88507c46897872fd55de23011b7085933d509"
+  integrity sha512-4z+zQWNtzPLiB3PQedLwQSy5zpLJVA4d6Hs8+MkUO3hJGd2tKYpSGhO3Xj5e7p04yg47iY0emZKWdwZWDA/3Jw==
+
+"@liff/login@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/login/-/login-2.27.1.tgz#874c63efbb2c63ea6d4ed7b57f9b45525fc84334"
+  integrity sha512-AwtiCpGPoVZj45wPpdz15FKUMQgXSEc9P9U3pRKjBJWkrHtgMAlqUe1rHRYQ5TC2ENm3YWAuGPIqUBMq3vsmuA==
+  dependencies:
+    "@liff/consts" "2.27.1"
+    "@liff/get-version" "2.27.1"
+    "@liff/hooks" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
     tiny-sha256 "^1.0.2"
 
-"@liff/logout@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/logout/-/logout-2.23.0.tgz#3f79ff41202127d5b5fa375a337c02779690a2c0"
-  integrity sha512-TOHc0MRPhNTJXkiC5vbd7bA5Pcn1ggOBjEibo2jm2OKiSBiIrt7y4OUtRuxS9ncd1FHdiIAoPMolKHisaxm2lQ==
+"@liff/logout@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/logout/-/logout-2.27.1.tgz#396e06c07c43345c6dc9d536f492efeaf898a619"
+  integrity sha512-MjTpsjp3vhfuWGpl3BMIIDTkfoqF6MWpovY4GZ+90BH5REoI7ReGX0L4iJBFVJ6aYOHShrD62iCdKtbZ56VJAg==
   dependencies:
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
 
-"@liff/message-bus@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/message-bus/-/message-bus-2.23.0.tgz#5f517fe1186e885dd963962ed235259285013f26"
-  integrity sha512-M46+enb2ktW1cy+DrSU13YJwC/pwB1cCSQg7rX3cif2oqrTVXOJmOcIqMXOijVo1NvO/VbTlBja47PlDozK4ig==
+"@liff/message-bus@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/message-bus/-/message-bus-2.27.1.tgz#b86dbf9be959bb0ce1ec9c1edb8dedc80dcbcd41"
+  integrity sha512-abP2SP+TL6Q9SxD4p+rvG5dZ7lk6oMe5M3Y/1sLjf1oShECTj+mRUQ//viAR2MEvjrmrs/QgMdbfy42Qz8Bh7A==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/native-bridge@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/native-bridge/-/native-bridge-2.23.0.tgz#34d93ebee204d30efd3602ab05831600b4db68d3"
-  integrity sha512-78nGCefhW29zT5OiKVxgPsOBot0S0bDRERD7yiu0pUiVdZiyHeBuzt+wtB/M9rx/H72x54/kP63SARoQ8d1Aug==
+"@liff/native-bridge@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/native-bridge/-/native-bridge-2.27.1.tgz#f5f3d1422caceb10136336f05f900cd74ca491d7"
+  integrity sha512-ItlyctIDlgjY7Yq0Ma/sO8A48TPumNltcuYy54XCX+J9g2Y7/EWjewZNOHj2+GO4k/ejQaF4BRTVekSRTZD6tQ==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/open-window@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/open-window/-/open-window-2.23.0.tgz#03e515065f8e30c69146ed9b599b1d61df869281"
-  integrity sha512-tlVoS/1UujEyZ5jIQDBv9lo7SOWTgvoyWsPiEMb9oF1eWcUS+sS4VaFa3NNLh6Dth1BpuxP+N8JSJveK8WT9Ag==
+"@liff/open-window@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/open-window/-/open-window-2.27.1.tgz#3115fc5b3f122f939cab96eea84f8aba5259335e"
+  integrity sha512-4v+ISjJedw/C7xdRV1/GVqM0sL371YUwrLXd+1ddUxTADkXF4FTFEWF4j4TJ5rb9pCV4871BLfCdipEaJ7x+ZA==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/permanent-link@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/permanent-link/-/permanent-link-2.23.0.tgz#01d8314c4b188341fcd482432bb8ee8ff37cc52c"
-  integrity sha512-J1Zf9xUje12jzv0MpKmv4Gtu42VWdVJbxQO5SfszEJNbGDb06icrvG9Gb4EwVxS6S7rc4lH7BXLSr/6zydQj3w==
+"@liff/permanent-link@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/permanent-link/-/permanent-link-2.27.1.tgz#db96d9a333d5396582990bfdad1a26319c4d4f16"
+  integrity sha512-K57Z4wkb3oemXSCe3M5a7PXWUHmwLni0MV/POe8GBhepKrqtIiMr/Kh/2UruGDUIHj1SxDSRupPd8rhRYaWwFw==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/permission@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/permission/-/permission-2.23.0.tgz#fa20dc35c3b6481505e815e3b2372fab87a45fa9"
-  integrity sha512-BsCIYEt3txhF1HMCmBU9pg7BlNO3l7GDQLDSmTZl8n5LIiEFKZGEneYnifs8KXHaEL3Kp/xRnHo9jNhg1Zy+ww==
+"@liff/permission@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/permission/-/permission-2.27.1.tgz#20a1846910be8c4d1044cb66fcbc2ce031da5139"
+  integrity sha512-Ecfwb6BCCOJWA5MuSKTyOaskg+2QAQXDRERpMGfA/ePDFhoCn6OerX+VBKXFh6YJISmlIQnCwcRWM3BrcNdeHw==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/ready@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/ready/-/ready-2.23.0.tgz#4e161a9c43cefbfb3c3f9986fe01da6a513cb523"
-  integrity sha512-icucH65a2Sz8JkGBQlU6Zj1mMyFuHUF2az2bLmOzKkfUoxjbLmBHlI5IsWi1Ri852EhSA2/07Nnw5xE23Pw/1w==
+"@liff/ready@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/ready/-/ready-2.27.1.tgz#fc0836c9143c476c5849af91a14fd26be6a3cd26"
+  integrity sha512-Z6yJOburFqNktuvkhxU7JssTRnZSgvCFDW/nI0hi7vtnV42+0WdaHsb4AvLYLW43nruO3N/ZxTfidFkfHIdTZg==
 
-"@liff/scan-code-v2@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/scan-code-v2/-/scan-code-v2-2.23.0.tgz#4fc29a527a40c1496b18643a1a25c69f23840734"
-  integrity sha512-LDooN8yox0okLNXJnPB4gcBqjhuOSC2ZXEnsNXzc98sbJNBIkE3La0bELfXWDi5HySkMhIomx3KIx4ZFe2GmlA==
+"@liff/scan-code-v2@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/scan-code-v2/-/scan-code-v2-2.27.1.tgz#18ee7cc493002d1abd3c3605f92bacd54dfe13c6"
+  integrity sha512-PeX7Z4fvvNqIV8BtkRuSj87QEWWF0cAxaOKnQa6B03pStGDG5eRqQ+xY93eQUKjQTdKToI5uSJ154hPhf5noFg==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/scan-code@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/scan-code/-/scan-code-2.23.0.tgz#ddd3f7fce45201a147be13cbdff972e188f4effb"
-  integrity sha512-qVDKM501Ou66t1K3Vdj7bjSahxrWvbXaF7dvDCdKHC05v0sw3zuVrQFh/N8FelcCqrZGKjnrQlhNRSuA4zGhUQ==
+"@liff/scan-code@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/scan-code/-/scan-code-2.27.1.tgz#69295fb0136d52852c58c6b78cfa92890fe5a08c"
+  integrity sha512-6oS/VdDiwxaplouutNQVrAVTeQ0+Rs0AZXMKQ15f4GS2BF6gPfX1jvRlPEM6jAsdEucPUb4UEWs1dICWsPCkjQ==
   dependencies:
-    "@liff/types" "2.23.0"
+    "@liff/types" "2.27.1"
 
-"@liff/send-messages@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/send-messages/-/send-messages-2.23.0.tgz#be56ac70b7383aa4e3f388100d05e452ce633a85"
-  integrity sha512-J+Wt2TEfAj2L+RhDkck5bjmHH1eFzCZcrMbqQG0Jrb8j7mDKIE6HaDTsMgNB1AqLDzQtmIwnZrPujpiUOCUOUQ==
+"@liff/send-messages@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/send-messages/-/send-messages-2.27.1.tgz#116b66245784d90e55da009d6c01e52662a62047"
+  integrity sha512-8WxpuyUkF/Weu+zNOUCrZT9lY2R0aBjYwAHL605ife4xwShCUjwk/MWvZbc1bvYSmmuHJvwll7P9OpxZWIG49w==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/permission" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
-    "@line/bot-sdk" "^7.0.0"
+    "@liff/consts" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/permission" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
+    "@line/bot-sdk" "^10.0.0"
 
-"@liff/server-api@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/server-api/-/server-api-2.23.0.tgz#d737b32cb26d0f3ffc6f8d6b064874be22fea49e"
-  integrity sha512-5MuCUpdy/FxQAWaICaNptvNXn0w25bqhEn4dzgge9qaVln6Y9g1W5rhpU5YamWRKntKK85G1SrUMHW4lb2jSEg==
+"@liff/server-api@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/server-api/-/server-api-2.27.1.tgz#128f066e6888e2b46dd3ed3f122ae1f5a742c117"
+  integrity sha512-RGdPVd0i2F/RAErt+ZX64ODMqSvJQE+0H5jR8uhwuyypqKwe3TXPwQJRxAzVZSBliblaZfwN4ALHWLIfL7vmyQ==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/share-target-picker@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/share-target-picker/-/share-target-picker-2.23.0.tgz#c1da2661899c5e7ec24c927830bd5d31cc240bdb"
-  integrity sha512-rkYmA2OCROS/O2+VnadgahosUNjROIWW2G2j8pKJ7LeJpYKezgvjDtxaf0uJx/R+/QYUapPHbBwK3xxI+u0NCw==
+"@liff/share-target-picker@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/share-target-picker/-/share-target-picker-2.27.1.tgz#d133e47829271c046ead465448a2345272e37ab9"
+  integrity sha512-lup5E/9NMhyu4Vk5lNhSsZjvgrKxeWoJj+ybIm0vpzx2wLwlXauYpqm95y7R4hApmzxfA3o2jz3QoZesuq07Ag==
   dependencies:
-    "@liff/analytics" "2.23.0"
-    "@liff/consts" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/send-messages" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
-    "@liff/window-postmessage" "2.23.0"
+    "@liff/analytics" "2.27.1"
+    "@liff/consts" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/send-messages" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
+    "@liff/window-postmessage" "2.27.1"
 
-"@liff/store@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/store/-/store-2.23.0.tgz#8ee63a7092c6ecf35336f8fa4ef44ba7b0ba7c1e"
-  integrity sha512-wVJlzOycrIKeGmu2wxIcQ336YWI13dDoIA/vp+jonfbr1YBpX1vVjxbVBVhlNjdZEpHSSnWUYwZLMM3mVVlQqQ==
+"@liff/store@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/store/-/store-2.27.1.tgz#e317e740bd988761ce317fd3623ca317053f5963"
+  integrity sha512-90JofVh4ojrfgorun5h1HESk/taglLiUJa90h3DvbDh+YEDZXp7yYL90NP+mZJF1Y6uhxTdhkwMeX3XHTqAB5A==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/types" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/types" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/sub-window@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/sub-window/-/sub-window-2.23.0.tgz#70bccf490aa5a72154dd2d5d253aa31c6bc8401c"
-  integrity sha512-/giuWQfdyw5rk40kU3UhbfZV8GT1JeAYRPWNf5kxAybuXTC1nN4snRU1jI3FmEdaozJxs/bzL2WHl/mcR8ugsw==
+"@liff/sub-window@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/sub-window/-/sub-window-2.27.1.tgz#fa0ba9c4edf3320f2c791045acce2f1f2aca10d5"
+  integrity sha512-+iMLg92i9Qy1Zcxqs6F1A0BDURUF//hYwstu5uPK190KwBduXZhDEolV2bakfValt4xUCgYe9mdLcrF4Jk3k0w==
   dependencies:
-    "@liff/close-window" "2.23.0"
-    "@liff/consts" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/message-bus" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/close-window" "2.27.1"
+    "@liff/consts" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/message-bus" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@liff/types@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/types/-/types-2.23.0.tgz#d453896af7fe177d52bb082873dace7d6833aa36"
-  integrity sha512-252OCqSzLSsbE3Z7LoBtrOSSx86MKjCtYN/h1hLj+CCR3HGMU7w2zabKJcm2sv++oz5sjfVnxERuao9dnNqWuA==
+"@liff/types@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/types/-/types-2.27.1.tgz#843a394abaf452caa38c9588793d6caec0bccab6"
+  integrity sha512-gWgjZtsFD5BFAtMLwnoPqZHD3AbQeXaihVkABfPZwQ0i40w1v0/cQ/CRwYJq7RiJ4yYKzEmKkEAuW/cYxqtuyQ==
 
-"@liff/use@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/use/-/use-2.23.0.tgz#e33fc86340deab783b71c1c7ec4736614d969014"
-  integrity sha512-t0HcetrRWOQFbYys/60BIlAL6+rcQnqLl0pTLj3BYPnU9s2lbp5s+kEz0/tjcui0pVeE/ejrBu/uy+YkJpJkAQ==
+"@liff/use@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/use/-/use-2.27.1.tgz#914eea20f77fa5c8e156f60b48ea2638b81746a9"
+  integrity sha512-2DRHozshQm5Ho1Sic8Il38R9575tNRPQ4ACJpfILuIw+wYJFCyR90agBXFwYVMSKmXsdV8WzGDpXfDKbZoc9Nw==
   dependencies:
-    "@liff/hooks" "2.23.0"
-    "@liff/logger" "2.23.0"
+    "@liff/hooks" "2.27.1"
+    "@liff/logger" "2.27.1"
 
-"@liff/util@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/util/-/util-2.23.0.tgz#bfa7cc678e235e1f7f85c510c8c34abd4f2a6268"
-  integrity sha512-FCq4SxSbeZhIMvPArRhRkeoYjJ5xWWlVUdEmL/bjukHYqbON+bAA1qfWZ9AXXh9qwmRzvKofdxH/bvc24vbsbA==
+"@liff/util@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/util/-/util-2.27.1.tgz#dcd285454dff923252a366c3c0dfdce7fd1cfd34"
+  integrity sha512-yl4NHlI42UaLxW8b3XI9SobZoQ8WCnWWx2SDgf78N3hMmk4fKMkHE+t9YVFjHIu+c4o40k+ZCxRazS+azjb2XA==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/logger" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/logger" "2.27.1"
 
-"@liff/window-postmessage@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@liff/window-postmessage/-/window-postmessage-2.23.0.tgz#b6a99a811bb19eb3c30ef61cb372bd9ebb152415"
-  integrity sha512-Vq3xyfRjVD+BGOQu1xJX80RtnI0OnusnV9QXbelY9FPeZdoLzN9THXnpCbGYSWorE+wkR77gMWzt6pJblwTT4Q==
+"@liff/window-postmessage@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@liff/window-postmessage/-/window-postmessage-2.27.1.tgz#4e550b33c2b26fb8cb568ad7eb15a69409dc5017"
+  integrity sha512-szhIpmmjFUmGsd/c12wtwTsZi6+8Rw5bTNaXZJan4Gpo374PZ9vzKYo/n/CPhNU+01M214QLXwRZrOVl/0kWjQ==
   dependencies:
-    "@liff/consts" "2.23.0"
-    "@liff/logger" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/consts" "2.27.1"
+    "@liff/logger" "2.27.1"
+    "@liff/util" "2.27.1"
 
-"@line/bot-sdk@^7.0.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@line/bot-sdk/-/bot-sdk-7.4.0.tgz#c657fed7fb3eec42f0c352dd5278c953bf0d49d0"
-  integrity sha512-MNnE9Ew/NRhZIvSchWRaStJGVDcPIGhG7tiZ5Oz3DO+KOgbUffS1Pn+j4aatcBcULLysv0fgp2anIllc+N+hmA==
+"@line/bot-sdk@^10.0.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@line/bot-sdk/-/bot-sdk-10.2.0.tgz#5c5a91fb204e9332877dc848d6b772001753689a"
+  integrity sha512-UbYONriZspwEiLhHP+RODMHaXxdhkj35KWoRXP7ysSU8G+2QULvBIBRLo6dmjUgPD5CaTj881zghMMdOg5mVrg==
   dependencies:
-    "@types/body-parser" "^1.19.0"
-    "@types/node" "^14.10.0"
-    axios "^0.21.1"
-    body-parser "^1.19.0"
-    file-type "^15.0.0"
-    form-data "^3.0.0"
+    "@types/node" "^22.0.0"
+  optionalDependencies:
+    axios "^1.7.4"
 
-"@line/liff@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@line/liff/-/liff-2.23.0.tgz#26b7a576fcd2c3ae430b73c6dc451ed7d0be0d2b"
-  integrity sha512-sVg/ffiDZGc/Qhedp6ug3xqj/U9yAmZzCebfeKuqQGuxGBa2QnDUWGVrbH0GzIgVj9uAVKhLGwxbwXbL7NEZ0A==
+"@line/liff@^2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@line/liff/-/liff-2.27.1.tgz#a478b6fc866b59ed2f9b6b94b392351caf38e5c0"
+  integrity sha512-8rBGOFQa+CPZkiVjddBnrzKhg6wGhty989n1d5juX47JmDAyTudHv1Br6EAoI7EncSxPcdPgYhLMXOm1yamF5Q==
   dependencies:
-    "@liff/analytics" "2.23.0"
-    "@liff/close-window" "2.23.0"
-    "@liff/consts" "2.23.0"
-    "@liff/core" "2.23.0"
-    "@liff/create-shortcut-on-home-screen" "2.23.0"
-    "@liff/extensions" "2.23.0"
-    "@liff/get-friendship" "2.23.0"
-    "@liff/get-language" "2.23.0"
-    "@liff/get-line-version" "2.23.0"
-    "@liff/get-os" "2.23.0"
-    "@liff/get-profile" "2.23.0"
-    "@liff/get-version" "2.23.0"
-    "@liff/hooks" "2.23.0"
-    "@liff/i18n" "2.23.0"
-    "@liff/init" "2.23.0"
-    "@liff/is-api-available" "2.23.0"
-    "@liff/is-in-client" "2.23.0"
-    "@liff/is-logged-in" "2.23.0"
-    "@liff/is-sub-window" "2.23.0"
-    "@liff/liff-types" "2.23.0"
-    "@liff/login" "2.23.0"
-    "@liff/logout" "2.23.0"
-    "@liff/native-bridge" "2.23.0"
-    "@liff/open-window" "2.23.0"
-    "@liff/permanent-link" "2.23.0"
-    "@liff/permission" "2.23.0"
-    "@liff/ready" "2.23.0"
-    "@liff/scan-code-v2" "2.23.0"
-    "@liff/send-messages" "2.23.0"
-    "@liff/server-api" "2.23.0"
-    "@liff/share-target-picker" "2.23.0"
-    "@liff/store" "2.23.0"
-    "@liff/sub-window" "2.23.0"
-    "@liff/use" "2.23.0"
-    "@liff/util" "2.23.0"
+    "@liff/analytics" "2.27.1"
+    "@liff/close-window" "2.27.1"
+    "@liff/consts" "2.27.1"
+    "@liff/core" "2.27.1"
+    "@liff/create-shortcut-on-home-screen" "2.27.1"
+    "@liff/extensions" "2.27.1"
+    "@liff/get-app-language" "2.27.1"
+    "@liff/get-friendship" "2.27.1"
+    "@liff/get-language" "2.27.1"
+    "@liff/get-line-version" "2.27.1"
+    "@liff/get-origins" "2.27.1"
+    "@liff/get-os" "2.27.1"
+    "@liff/get-profile" "2.27.1"
+    "@liff/get-version" "2.27.1"
+    "@liff/hooks" "2.27.1"
+    "@liff/i18n" "2.27.1"
+    "@liff/iap" "2.27.1"
+    "@liff/init" "2.27.1"
+    "@liff/is-api-available" "2.27.1"
+    "@liff/is-in-client" "2.27.1"
+    "@liff/is-logged-in" "2.27.1"
+    "@liff/is-sub-window" "2.27.1"
+    "@liff/liff-types" "2.27.1"
+    "@liff/login" "2.27.1"
+    "@liff/logout" "2.27.1"
+    "@liff/native-bridge" "2.27.1"
+    "@liff/open-window" "2.27.1"
+    "@liff/permanent-link" "2.27.1"
+    "@liff/permission" "2.27.1"
+    "@liff/ready" "2.27.1"
+    "@liff/scan-code-v2" "2.27.1"
+    "@liff/send-messages" "2.27.1"
+    "@liff/server-api" "2.27.1"
+    "@liff/share-target-picker" "2.27.1"
+    "@liff/store" "2.27.1"
+    "@liff/sub-window" "2.27.1"
+    "@liff/use" "2.27.1"
+    "@liff/util" "2.27.1"
     tslib "^2.3.0"
     whatwg-fetch "^3.0.0"
 
@@ -3558,16 +3590,6 @@
     "@tailwindcss/oxide" "4.1.11"
     tailwindcss "4.1.11"
 
-"@tokenizer/token@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
-  integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
-
-"@tokenizer/token@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
-  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
-
 "@tufjs/canonical-json@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz#a52f61a3d7374833fca945b2549bc30a2dd40d0a"
@@ -3595,27 +3617,12 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/body-parser@^1.19.0":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
-  integrity sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
 "@types/chai@^5.2.2":
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.2.tgz#6f14cea18180ffc4416bc0fd12be05fdd73bdd6b"
   integrity sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==
   dependencies:
     "@types/deep-eql" "*"
-
-"@types/connect@*":
-  version "3.4.35"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
-  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/deep-eql@*":
   version "4.0.2"
@@ -3649,15 +3656,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.1.tgz#2e50a649a50fc403433a14f829eface1a3443e97"
   integrity sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==
 
-"@types/node@^14.10.0":
-  version "14.17.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.27.tgz#5054610d37bb5f6e21342d0e6d24c494231f3b85"
-  integrity sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==
-
 "@types/node@^20.0.0":
   version "20.19.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.9.tgz#ca9a58193fec361cc6e859d88b52261853f1f0d3"
   integrity sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@types/node@^22.0.0":
+  version "22.18.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.1.tgz#cc85ee6999b2a2928739281d2f56ff410a140c52"
+  integrity sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==
   dependencies:
     undici-types "~6.21.0"
 
@@ -4732,12 +4741,14 @@ autoprefixer@^10.4.21:
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^1.7.4:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 b4a@^1.6.4:
   version "1.6.4"
@@ -4780,22 +4791,6 @@ birpc@^2.3.0, birpc@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/birpc/-/birpc-2.5.0.tgz#3a014e54c17eceba0ce15738d484ea371dbf6527"
   integrity sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==
-
-body-parser@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
-  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
-  dependencies:
-    bytes "3.1.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.2"
-    http-errors "1.7.2"
-    iconv-lite "0.4.24"
-    on-finished "~2.3.0"
-    qs "6.7.0"
-    raw-body "2.4.0"
-    type-is "~1.6.17"
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -4932,11 +4927,6 @@ bundle-name@^4.1.0:
   integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
   dependencies:
     run-applescript "^7.0.0"
-
-bytes@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
-  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 c12@^1.5.1:
   version "1.5.1"
@@ -5377,11 +5367,6 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -5736,11 +5721,6 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
 destr@^2.0.0, destr@^2.0.1, destr@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.2.tgz#8d3c0ee4ec0a76df54bc8b819bca215592a8c218"
@@ -6086,6 +6066,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild@0.25.5:
   version "0.25.5"
@@ -6634,16 +6624,6 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-file-type@^15.0.0:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-15.0.1.tgz#54175484953d48b970c095ba8737d4e0c3a9b407"
-  integrity sha512-0LieQlSA3bWUdErNrxzxfI4rhsvNAVPBO06R8pTc1hp9SE6nhqlVyvhcaXoMmtXkBTPnQenbMPLW9X76hH76oQ==
-  dependencies:
-    readable-web-to-node-stream "^2.0.0"
-    strtok3 "^6.0.3"
-    token-types "^2.0.0"
-    typedarray-to-buffer "^3.1.5"
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -6713,10 +6693,10 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 foreground-child@^3.1.0:
   version "3.1.1"
@@ -6726,13 +6706,15 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
@@ -6838,7 +6820,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -7139,10 +7121,17 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has-unicode@^2.0.1:
   version "2.0.1"
@@ -7199,17 +7188,6 @@ http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
-
-http-errors@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
-  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
 
 http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
@@ -7283,13 +7261,6 @@ human-signals@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
-
-iconv-lite@0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.6.2:
   version "0.6.3"
@@ -7386,11 +7357,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@4.1.1:
   version "4.1.1"
@@ -7585,11 +7551,6 @@ is-stream@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
   integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
-
-is-typedarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
 is-url-superb@^4.0.0:
   version "4.0.0"
@@ -8230,11 +8191,6 @@ mdn-data@2.12.2:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.12.2.tgz#9ae6c41a9e65adf61318b32bff7b64fbfb13f8cf"
   integrity sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
 merge-options@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
@@ -8291,7 +8247,7 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@~2.1.24:
+mime-types@^2.1.12:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
@@ -9149,13 +9105,6 @@ on-finished@2.4.1, on-finished@^2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-on-finished@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  dependencies:
-    ee-first "1.1.1"
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -9543,11 +9492,6 @@ pathval@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
-
-peek-readable@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.1.tgz#9a045f291db254111c3412c1ce4fec27ddd4d202"
-  integrity sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==
 
 pend@~1.2.0:
   version "1.2.0"
@@ -9938,6 +9882,11 @@ protocols@^2.0.0, protocols@^2.0.1:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.1.tgz#8f155da3fc0f32644e83c5782c8e8212ccf70a86"
   integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 pump@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.3.tgz#151d979f1a29668dc0025ec589a455b53282268d"
@@ -9950,11 +9899,6 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-qs@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 qs@^6.9.6:
   version "6.14.0"
@@ -10004,16 +9948,6 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
-
-raw-body@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
-  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
-  dependencies:
-    bytes "3.1.0"
-    http-errors "1.7.2"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
 
 rc9@^2.1.1:
   version "2.1.1"
@@ -10111,11 +10045,6 @@ readable-stream@^4.0.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readable-web-to-node-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz#751e632f466552ac0d5c440cc01470352f93c4b7"
-  integrity sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==
 
 readdir-glob@^1.1.2:
   version "1.1.3"
@@ -10377,7 +10306,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10516,11 +10445,6 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
-
-setprototypeof@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
-  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -10811,11 +10735,6 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-"statuses@>= 1.5.0 < 2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
-
 statuses@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
@@ -10936,14 +10855,6 @@ strip-literal@^3.0.0:
   integrity sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==
   dependencies:
     js-tokens "^9.0.1"
-
-strtok3@^6.0.3:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.2.4.tgz#302aea64c0fa25d12a0385069ba66253fdc38a81"
-  integrity sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    peek-readable "^4.0.1"
 
 structured-clone-es@^1.0.0:
   version "1.0.0"
@@ -11161,23 +11072,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
-
-token-types@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.1.1.tgz#bd585d64902aaf720b8979d257b4b850b4d45c45"
-  integrity sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==
-  dependencies:
-    "@tokenizer/token" "^0.1.1"
-    ieee754 "^1.2.1"
 
 toml@^3.0.0:
   version "3.0.0"
@@ -11240,25 +11138,10 @@ type-fest@^4.18.2, type-fest@^4.39.1, type-fest@^4.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
-type-is@~1.6.17:
-  version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
-
 type-level-regexp@~0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/type-level-regexp/-/type-level-regexp-0.1.17.tgz#ec1bf7dd65b85201f9863031d6f023bdefc2410f"
   integrity sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==
-
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
 
 typescript@^5.7.3:
   version "5.9.2"
@@ -11443,11 +11326,6 @@ unixify@^1.0.0:
   integrity sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==
   dependencies:
     normalize-path "^2.1.1"
-
-unpipe@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 unplugin-utils@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
## 概要
LINE LIFF SDK（@line/liff）を v2.23.0 から v2.27.1 へアップデートしました。

## 変更内容
- `web/liff/package.json`: @line/liff パッケージのバージョンを更新
- `web/liff/yarn.lock`: 依存関係を更新

## 背景・目的
LINE LIFF SDKを最新安定版に保つことで、セキュリティ修正や新機能を取り入れます。

## テスト
- [ ] yarn install での正常インストール確認
- [ ] ビルドの成功確認
- [ ] LIFF機能の動作確認

## レビューポイント
- パッケージバージョンの更新のみで、コード変更は含まれません
- yarn.lockファイルが正しく更新されていることをご確認ください

🤖 Generated with [Claude Code](https://claude.ai/code)