### PR TITLE
fix(api): facility認証トークンのテーブル名を修正

### DIFF
--- a/api/internal/gateway/user/facility/auth/auth.go
+++ b/api/internal/gateway/user/facility/auth/auth.go
@@ -115,7 +115,7 @@ func NewRefreshToken(params *RefreshTokenParams) (*RefreshToken, error) {
 }
 
 func (t *RefreshToken) TableName() string {
-	return "auth-tokens"
+	return "facility-user-auth-tokens"
 }
 
 func (t *RefreshToken) PrimaryKey() map[string]interface{} {


### PR DESCRIPTION
## 概要
Facility認証機能のRefreshTokenで使用するDynamoDBテーブル名を適切な名前に修正しました。

## 変更内容
- RefreshTokenのテーブル名を`auth-tokens`から`facility-user-auth-tokens`に変更
- 施設利用者専用の認証トークンテーブルであることを明確化

## 背景・目的
Facility認証機能は施設利用者向けの新機能であり、既存のユーザー認証とは別のテーブルを使用する必要があります。
テーブル名を明確にすることで、運用時の混乱を防ぎます。

## テスト
- [x] API: make test (Go) - 該当箇所のテスト確認
- [x] API: make lint-fix - lint通過確認
- [ ] 手動テスト完了

## レビューポイント
- テーブル名の命名規則が適切か
- 他のFacility関連テーブルとの整合性

## 関連情報
- 関連PR: #2983 (Facility gateway services初期実装)

🤖 Generated with [Claude Code](https://claude.ai/code)