### PR TITLE
feat(api): facility向けカート計算APIエンドポイントを追加

### DIFF
--- a/api/internal/gateway/user/facility/handler/cart.go
+++ b/api/internal/gateway/user/facility/handler/cart.go
@@ -21,6 +21,7 @@ func (h *handler) cartRoutes(rg *gin.RouterGroup) {
 	r := rg.Group("/carts", h.authentication)
 
 	r.GET("", h.GetCart)
+	r.GET("/:coordinatorId", h.CalcCart)
 	r.POST("/-/items", h.AddCartItem)
 	r.DELETE("/-/items/:productId", h.RemoveCartItem)
 }


### PR DESCRIPTION
## 概要
店舗受け取り（facility）機能において、特定のコーディネーターIDに基づくカート計算APIエンドポイントを追加しました。

## 変更内容
- facility gatewayのカートルーティングに新しいエンドポイント `GET /carts/:coordinatorId` を追加
- CalcCartハンドラーへのルーティングを設定

## 背景・目的
店舗受け取り機能の実装の一環として、特定のコーディネーター（店舗）の商品カートを計算する必要があります。
このエンドポイントにより、coordinatorIdを指定してカート内容の計算が可能になります。

## テスト
- [ ] API: make test (Go)
- [ ] API: make lint-fix
- [ ] 手動テスト完了

## レビューポイント
- ルーティングの命名規則が既存のエンドポイントと一致しているか
- RESTful APIの設計原則に沿っているか

## 関連情報
- 関連PR: #2986 (店舗受け取りでの注文機能を実装)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - コーディネーター別のカート計算が可能な新規GETエンドポイントを公開。指定したコーディネーターIDのカート合計や関連情報を即時算出できます。
  - 既存のカート取得やアイテム関連エンドポイントへの影響はなく、後方互換性を維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->