### PR TITLE
fix(ci): PR承認ラベリングワークフローの改善

### DIFF
--- a/.github/workflows/pr-approve.yaml
+++ b/.github/workflows/pr-approve.yaml
@@ -6,14 +6,68 @@ jobs:
   label_when_approved:
     name: label when approved
     runs-on: ${{ matrix.os }}
-
+    permissions:
+      pull-requests: write
     strategy:
       matrix:
         os: [ubuntu-latest]
 
     steps:
-    - uses: pullreminders/label-when-approved-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        APPROVALS: 1
-        ADD_LABEL: "mergeable"
+    - name: Approved
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const REQUIRED_APPROVALS = 1;
+          const LABEL_NAME = "mergeable";
+          const { data: reviews } = await github.rest.pulls.listReviews({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+          });
+
+          // Get the latest review state for each user
+          const latestReviews = {};
+          for (const review of reviews) {
+            if (!review.user) continue;
+
+            // Only consider reviews with meaningful states
+            if (["APPROVED", "CHANGES_REQUESTED", "DISMISSED"].includes(review.state)) {
+              if (!latestReviews[review.user.login] ||
+                  new Date(review.submitted_at) > new Date(latestReviews[review.user.login].submitted_at)) {
+                latestReviews[review.user.login] = review;
+              }
+            }
+          }
+
+          // Count current approvals
+          const approvalCount = Object.values(latestReviews)
+            .filter(review => review.state === "APPROVED")
+            .length;
+
+          console.log(`Current approvals: ${approvalCount}/${REQUIRED_APPROVALS}`);
+
+          if (approvalCount >= REQUIRED_APPROVALS) {
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [LABEL_NAME],
+            });
+            console.log(`Added label: ${LABEL_NAME}`);
+          } else {
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: LABEL_NAME
+              });
+              console.log(`Removed label: ${LABEL_NAME}`);
+            } catch (e) {
+              // Label doesn't exist (404) - ignore
+              if (e.status !== 404) {
+                throw e;
+              }
+              console.log(`Label ${LABEL_NAME} was not present`);
+            }
+          }


### PR DESCRIPTION
## 概要
GitHub ActionsのPR承認ラベリングワークフローを改善し、レビュー状態のトラッキング精度を向上させました。

## 変更内容
- レビューステートの正確な追跡（APPROVED/CHANGES_REQUESTED/DISMISSED）を実装
- 同一レビュワーの最新レビューのみをカウント対象に変更
- 承認数が不足した場合のラベル削除処理を追加
- 404エラー（ラベルが存在しない）の適切なハンドリング

## 背景・目的
現在のワークフローでは、レビュー承認が取り消された場合や変更要求があった場合でも、過去の承認がカウントされてしまう問題がありました。この改善により、最新のレビュー状態のみを正確に反映するようになります。

## 改善点の詳細
1. **レビュー状態の管理**: 各レビュワーの最新のレビュー状態のみを集計
2. **動的なラベル管理**: 承認数に応じてラベルを追加・削除
3. **エラーハンドリング**: ラベルが存在しない場合の404エラーを適切に処理

## テスト
- [x] GitHub Actionsの構文検証
- [x] ワークフローファイルのYAML lint通過
- [ ] PRでの実動作確認（マージ後のPRで検証）

## レビューポイント
- レビュー状態の集計ロジックの妥当性
- エラーハンドリングの適切性
- コンソールログ出力の有用性

## 関連情報
- GitHub Actions: [github-script v7.0.1](https://github.com/actions/github-script)
- PR Reviews API: [GitHub REST API documentation](https://docs.github.com/en/rest/pulls/reviews)

🤖 Generated with [Claude Code](https://claude.ai/code)