### PR TITLE
fix(api): メッセンジャーサービスで注文確定時の顧客情報取得を修正

### DIFF
--- a/api/internal/gateway/user/facility/handler/checkout.go
+++ b/api/internal/gateway/user/facility/handler/checkout.go
@@ -32,6 +32,7 @@ func (h *handler) checkoutRoutes(rg *gin.RouterGroup) {
 // @Tags        Checkout
 // @Router      /facilities/{facilityId}/checkouts [post]
 // @Param       facilityId path string true "施設ID"
+// @Security    bearerauth
 // @Accept      json
 // @Param				request body request.CheckoutRequest true "チェックアウト情報"
 // @Produce     json

--- a/api/internal/messenger/service/notify_test.go
+++ b/api/internal/messenger/service/notify_test.go
@@ -396,7 +396,16 @@ func TestNotifyOrderCaptured(t *testing.T) {
 				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
-				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).Times(2)
+				mocks.user.EXPECT().GetUser(gomock.Any(), &user.GetUserInput{UserID: "user-id"}).Return(&uentity.User{
+					ID:   "user-id",
+					Type: uentity.UserTypeMember,
+					Member: uentity.Member{
+						UserID:    "user-id",
+						Lastname:  "&.",
+						Firstname: "太郎",
+					},
+				}, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
 				mocks.db.ReceivedQueue.EXPECT().
 					MultiCreate(ctx, gomock.Any()).
 					DoAndReturn(func(ctx context.Context, queues ...*entity.ReceivedQueue) error {
@@ -485,7 +494,8 @@ func TestNotifyOrderCaptured(t *testing.T) {
 				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(nil, assert.AnError)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
-				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).AnyTimes()
+				mocks.user.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&uentity.User{}, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
 			},
 			input: &messenger.NotifyOrderCapturedInput{
 				OrderID: "order-id",
@@ -498,7 +508,22 @@ func TestNotifyOrderCaptured(t *testing.T) {
 				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
-				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).AnyTimes()
+				mocks.user.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&uentity.User{}, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
+			},
+			input: &messenger.NotifyOrderCapturedInput{
+				OrderID: "order-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "product failed to get user",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
+				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
+				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
+				mocks.user.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
 			},
 			input: &messenger.NotifyOrderCapturedInput{
 				OrderID: "order-id",
@@ -511,7 +536,8 @@ func TestNotifyOrderCaptured(t *testing.T) {
 				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
-				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError).MinTimes(1)
+				mocks.user.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&uentity.User{}, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
 			input: &messenger.NotifyOrderCapturedInput{
 				OrderID: "order-id",
@@ -524,7 +550,8 @@ func TestNotifyOrderCaptured(t *testing.T) {
 				mocks.store.EXPECT().GetOrder(ctx, orderIn).Return(order(sentity.OrderTypeProduct), nil)
 				mocks.user.EXPECT().GetCoordinator(gomock.Any(), coordinatorIn).Return(coordinator, nil)
 				mocks.store.EXPECT().MultiGetProductsByRevision(gomock.Any(), gomock.Any()).Return(products, nil)
-				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil).Times(2)
+				mocks.user.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&uentity.User{}, nil)
+				mocks.user.EXPECT().MultiGetAddressesByRevision(gomock.Any(), gomock.Any()).Return(addresses, nil)
 				mocks.db.ReceivedQueue.EXPECT().MultiCreate(ctx, gomock.Any()).Return(assert.AnError)
 			},
 			input: &messenger.NotifyOrderCapturedInput{

--- a/docs/swagger/gen/admin/v1/swagger.yaml
+++ b/docs/swagger/gen/admin/v1/swagger.yaml
@@ -1276,6 +1276,28 @@ components:
                     description: 営業曜日(発送可能日)
                     items:
                         type: integer
+                        x-enum-varnames:
+                            - Sunday
+                            - Monday
+                            - Tuesday
+                            - Wednesday
+                            - Thursday
+                            - Friday
+                            - Saturday
+                            - Sunday
+                            - Monday
+                            - Tuesday
+                            - Wednesday
+                            - Thursday
+                            - Friday
+                            - Saturday
+                            - Sunday
+                            - Monday
+                            - Tuesday
+                            - Wednesday
+                            - Thursday
+                            - Friday
+                            - Saturday
                     type: array
                     uniqueItems: false
                 name:
@@ -2537,9 +2559,6 @@ components:
                 shippingMessage:
                     description: 発送連絡時のメッセージ
                     type: string
-                shippingType:
-                    description: 発送方法
-                    type: integer
                 status:
                     description: 注文ステータス
                     type: integer
@@ -3495,7 +3514,7 @@ components:
                 businessDays:
                     description: 営業曜日(発送可能日)
                     items:
-                        type: integer
+                        $ref: '#/components/schemas/time.Weekday'
                     type: array
                     uniqueItems: false
                 coordinatorId:
@@ -4108,6 +4127,30 @@ components:
                     type: array
                     uniqueItems: false
             type: object
+        time.Weekday:
+            type: integer
+            x-enum-varnames:
+                - Sunday
+                - Monday
+                - Tuesday
+                - Wednesday
+                - Thursday
+                - Friday
+                - Saturday
+                - Sunday
+                - Monday
+                - Tuesday
+                - Wednesday
+                - Thursday
+                - Friday
+                - Saturday
+                - Sunday
+                - Monday
+                - Tuesday
+                - Wednesday
+                - Thursday
+                - Friday
+                - Saturday
         util.ErrorResponse:
             properties:
                 detail:

--- a/docs/swagger/gen/user/facility/swagger.yaml
+++ b/docs/swagger/gen/user/facility/swagger.yaml
@@ -1,640 +1,5 @@
 components:
   schemas:
-    AuthResponse:
-      properties:
-        accessToken:
-          description: アクセストークン
-          type: string
-        expiresIn:
-          description: 有効期限
-          type: integer
-        refreshToken:
-          description: 更新トークン
-          type: string
-        tokenType:
-          description: トークン種別
-          type: string
-        userId:
-          description: ユーザーID
-          type: string
-      type: object
-    AuthUserResponse:
-      properties:
-        email:
-          description: メールアドレス
-          type: string
-        firstname:
-          description: 名
-          type: string
-        firstnameKana:
-          description: 名（かな）
-          type: string
-        id:
-          description: ユーザーID
-          type: string
-        lastCheckInAt:
-          description: 最新のチェックイン日時
-          type: integer
-        lastname:
-          description: 姓
-          type: string
-        lastnameKana:
-          description: 姓（かな）
-          type: string
-        phoneNumber:
-          description: 電話番号
-          type: string
-      type: object
-    CalcCartResponse:
-      properties:
-        carts:
-          description: カート一覧
-          items:
-            $ref: '#/components/schemas/Cart'
-          type: array
-          uniqueItems: false
-        coordinator:
-          $ref: '#/components/schemas/Coordinator'
-        discount:
-          description: 割引金額(税込)
-          type: integer
-        items:
-          description: カート内の商品一覧(集計結果)
-          items:
-            $ref: '#/components/schemas/CartItem'
-          type: array
-          uniqueItems: false
-        products:
-          description: 商品一覧
-          items:
-            $ref: '#/components/schemas/Product'
-          type: array
-          uniqueItems: false
-        promotion:
-          $ref: '#/components/schemas/Promotion'
-        requestId:
-          description: 支払い時にAPIへ送信するキー(重複判定用)
-          type: string
-        shippingFee:
-          description: 配送手数料(税込)
-          type: integer
-        subtotal:
-          description: 購入金額(税込)
-          type: integer
-        total:
-          description: 合計金額(税込)
-          type: integer
-      type: object
-    Cart:
-      properties:
-        coordinatorId:
-          description: コーディネータID
-          type: string
-        items:
-          description: 箱の商品一覧
-          items:
-            $ref: '#/components/schemas/CartItem'
-          type: array
-          uniqueItems: false
-        number:
-          description: 箱の通番
-          type: integer
-        rate:
-          description: 箱の占有率
-          type: integer
-        size:
-          description: 箱のサイズ
-          type: integer
-        type:
-          description: 箱の種別
-          type: integer
-      type: object
-    CartItem:
-      properties:
-        productId:
-          description: 商品ID
-          type: string
-        quantity:
-          description: 数量
-          type: integer
-      type: object
-    CartResponse:
-      properties:
-        carts:
-          description: カート一覧
-          items:
-            $ref: '#/components/schemas/Cart'
-          type: array
-          uniqueItems: false
-        coordinators:
-          description: コーディネータ一覧
-          items:
-            $ref: '#/components/schemas/Coordinator'
-          type: array
-          uniqueItems: false
-        products:
-          description: 商品一覧
-          items:
-            $ref: '#/components/schemas/Product'
-          type: array
-          uniqueItems: false
-      type: object
-    Category:
-      description: 商品種別情報
-      properties:
-        id:
-          description: 商品種別ID
-          type: string
-        name:
-          description: 商品種別名
-          type: string
-      type: object
-    CheckoutResponse:
-      properties:
-        url:
-          description: 遷移先URL
-          type: string
-      type: object
-    CheckoutStateResponse:
-      properties:
-        orderId:
-          description: 注文履歴ID
-          type: string
-        status:
-          description: 注文ステータス
-          type: integer
-      type: object
-    Coordinator:
-      description: コーディネータ情報
-      properties:
-        businessDays:
-          description: 営業曜日(発送可能日)
-          items:
-            $ref: '#/components/schemas/time.Weekday'
-          type: array
-          uniqueItems: false
-        city:
-          description: 市区町村
-          type: string
-        facebookId:
-          description: Facebookアカウント
-          type: string
-        headerUrl:
-          description: ヘッダー画像URL
-          type: string
-        id:
-          description: コーディネータID
-          type: string
-        instagramId:
-          description: Instagramアカウント
-          type: string
-        marcheName:
-          description: マルシェ名
-          type: string
-        prefecture:
-          description: 都道府県
-          type: string
-        productTypeIds:
-          description: 取り扱い品目一覧
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        profile:
-          description: 紹介文
-          type: string
-        promotionVideoUrl:
-          description: 紹介映像URL
-          type: string
-        thumbnailUrl:
-          description: サムネイルURL
-          type: string
-        username:
-          description: 表示名
-          type: string
-      type: object
-    Order:
-      description: 注文履歴情報
-      properties:
-        coordinatorId:
-          description: コーディネータID
-          type: string
-        id:
-          description: 注文履歴ID
-          type: string
-        items:
-          description: 注文商品一覧
-          items:
-            $ref: '#/components/schemas/OrderItem'
-          type: array
-          uniqueItems: false
-        payment:
-          $ref: '#/components/schemas/OrderPayment'
-        pickupAt:
-          description: 受け取り日時
-          type: integer
-        pickupLocation:
-          description: 受け取り場所
-          type: string
-        promotionId:
-          description: プロモーションID
-          type: string
-        refund:
-          $ref: '#/components/schemas/OrderRefund'
-        status:
-          description: 注文ステータス
-          type: integer
-        type:
-          description: 注文種別
-          type: integer
-      type: object
-    OrderItem:
-      properties:
-        fulfillmentId:
-          description: 配送情報ID
-          type: string
-        price:
-          description: 購入価格(税込)
-          type: integer
-        productId:
-          description: 商品ID
-          type: string
-        quantity:
-          description: 購入数量
-          type: integer
-      type: object
-    OrderPayment:
-      description: 支払い情報
-      properties:
-        discount:
-          description: 割引金額(税込)
-          type: integer
-        methodType:
-          description: 決済手段種別
-          type: integer
-        orderedAt:
-          description: 注文日時
-          type: integer
-        paidAt:
-          description: 支払日時
-          type: integer
-        shippingFee:
-          description: 配送手数料(税込)
-          type: integer
-        status:
-          description: 支払い状況
-          type: integer
-        subtotal:
-          description: 購入金額(税込)
-          type: integer
-        total:
-          description: 合計金額(税込)
-          type: integer
-        transactionId:
-          description: 取引ID
-          type: string
-      type: object
-    OrderRefund:
-      description: 注文キャンセル情報
-      properties:
-        canceled:
-          description: 注文キャンセルフラグ
-          type: boolean
-        canceledAt:
-          description: 注文キャンセル日時
-          type: integer
-        reason:
-          description: 注文キャンセル理由
-          type: string
-        total:
-          description: 返金金額
-          type: integer
-        type:
-          description: 注文キャンセル種別
-          type: integer
-      type: object
-    OrderResponse:
-      properties:
-        coordinator:
-          $ref: '#/components/schemas/Coordinator'
-        order:
-          $ref: '#/components/schemas/Order'
-        products:
-          description: 商品一覧
-          items:
-            $ref: '#/components/schemas/Product'
-          type: array
-          uniqueItems: false
-        promotion:
-          $ref: '#/components/schemas/Promotion'
-      type: object
-    OrdersResponse:
-      properties:
-        coordinators:
-          description: コーディネータ一覧
-          items:
-            $ref: '#/components/schemas/Coordinator'
-          type: array
-          uniqueItems: false
-        orders:
-          description: 注文履歴一覧
-          items:
-            $ref: '#/components/schemas/Order'
-          type: array
-          uniqueItems: false
-        products:
-          description: 商品一覧
-          items:
-            $ref: '#/components/schemas/Product'
-          type: array
-          uniqueItems: false
-        promotions:
-          description: プロモーション一覧
-          items:
-            $ref: '#/components/schemas/Promotion'
-          type: array
-          uniqueItems: false
-        total:
-          description: 合計数
-          type: integer
-      type: object
-    Producer:
-      description: 生産者情報
-      properties:
-        city:
-          description: 市区町村
-          type: string
-        coordinatorId:
-          description: 担当コーディネータID
-          type: string
-        facebookId:
-          description: Facebookアカウント
-          type: string
-        headerUrl:
-          description: ヘッダー画像URL
-          type: string
-        id:
-          description: 生産者ID
-          type: string
-        instagramId:
-          description: Instagramアカウント
-          type: string
-        prefecture:
-          description: 都道府県
-          type: string
-        profile:
-          description: 紹介文
-          type: string
-        promotionVideoUrl:
-          description: 紹介映像URL
-          type: string
-        thumbnailUrl:
-          description: サムネイルURL
-          type: string
-        username:
-          description: 生産者名
-          type: string
-      type: object
-    Product:
-      description: 商品情報
-      properties:
-        box60Rate:
-          description: 箱の占有率(サイズ:60)
-          type: integer
-        box80Rate:
-          description: 箱の占有率(サイズ:80)
-          type: integer
-        box100Rate:
-          description: 箱の占有率(サイズ:100)
-          type: integer
-        categoryId:
-          description: 商品種別ID
-          type: string
-        coordinatorId:
-          description: コーディネータID
-          type: string
-        deliveryType:
-          description: 配送方法
-          type: integer
-        description:
-          description: 商品説明
-          type: string
-        endAt:
-          description: 販売終了日時
-          type: integer
-        expirationDate:
-          description: 賞味期限(単位:日)
-          type: integer
-        id:
-          description: 商品ID
-          type: string
-        inventory:
-          description: 在庫数
-          type: integer
-        itemDescription:
-          description: 数量単位説明
-          type: string
-        itemUnit:
-          description: 数量単位
-          type: string
-        media:
-          description: メディア一覧
-          items:
-            $ref: '#/components/schemas/ProductMedia'
-          type: array
-          uniqueItems: false
-        name:
-          description: 商品名
-          type: string
-        originCity:
-          description: 原産地(市区町村)
-          type: string
-        originPrefecture:
-          description: 原産地(都道府県)
-          type: string
-        price:
-          description: 販売価格(税込)
-          type: integer
-        producerId:
-          description: 生産者ID
-          type: string
-        productTagIds:
-          description: 商品タグID一覧
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        productTypeId:
-          description: 品目ID
-          type: string
-        rate:
-          $ref: '#/components/schemas/ProductRate'
-        recommendedPoint1:
-          description: おすすめポイント1
-          type: string
-        recommendedPoint2:
-          description: おすすめポイント2
-          type: string
-        recommendedPoint3:
-          description: おすすめポイント3
-          type: string
-        startAt:
-          description: 販売開始日時
-          type: integer
-        status:
-          description: 販売状況
-          type: integer
-        storageMethodType:
-          description: 保存方法
-          type: integer
-        thumbnailUrl:
-          description: サムネイルURL
-          type: string
-        weight:
-          description: 重量(kg,少数第一位まで)
-          type: number
-      type: object
-    ProductMedia:
-      properties:
-        isThumbnail:
-          description: サムネイルとして使用
-          type: boolean
-        url:
-          description: メディアURL
-          type: string
-      type: object
-    ProductRate:
-      description: 商品評価
-      properties:
-        average:
-          description: 平均評価
-          type: number
-        count:
-          description: 合計評価数
-          type: integer
-        detail:
-          additionalProperties:
-            type: integer
-          description: 評価詳細
-          type: object
-      type: object
-    ProductResponse:
-      properties:
-        category:
-          $ref: '#/components/schemas/Category'
-        coordinator:
-          $ref: '#/components/schemas/Coordinator'
-        producer:
-          $ref: '#/components/schemas/Producer'
-        product:
-          $ref: '#/components/schemas/Product'
-        productTags:
-          description: 商品タグ一覧
-          items:
-            $ref: '#/components/schemas/ProductTag'
-          type: array
-          uniqueItems: false
-        productType:
-          $ref: '#/components/schemas/ProductType'
-      type: object
-    ProductTag:
-      properties:
-        id:
-          description: 商品タグID
-          type: string
-        name:
-          description: 商品タグ名
-          type: string
-      type: object
-    ProductType:
-      description: 品目情報
-      properties:
-        categoryId:
-          description: 商品種別ID
-          type: string
-        iconUrl:
-          description: アイコンURL
-          type: string
-        id:
-          description: 品目ID
-          type: string
-        name:
-          description: 品目名
-          type: string
-      type: object
-    ProductsResponse:
-      properties:
-        categories:
-          description: 商品種別一覧
-          items:
-            $ref: '#/components/schemas/Category'
-          type: array
-          uniqueItems: false
-        coordinators:
-          description: コーディネータ一覧
-          items:
-            $ref: '#/components/schemas/Coordinator'
-          type: array
-          uniqueItems: false
-        producers:
-          description: 生産者一覧
-          items:
-            $ref: '#/components/schemas/Producer'
-          type: array
-          uniqueItems: false
-        productTags:
-          description: 商品タグ一覧
-          items:
-            $ref: '#/components/schemas/ProductTag'
-          type: array
-          uniqueItems: false
-        productTypes:
-          description: 品目一覧
-          items:
-            $ref: '#/components/schemas/ProductType'
-          type: array
-          uniqueItems: false
-        products:
-          description: 商品一覧
-          items:
-            $ref: '#/components/schemas/Product'
-          type: array
-          uniqueItems: false
-        total:
-          description: 商品合計数
-          type: integer
-      type: object
-    Promotion:
-      description: プロモーション情報
-      properties:
-        code:
-          description: クーポンコード
-          type: string
-        description:
-          description: 詳細説明
-          type: string
-        discountRate:
-          description: 割引額(%/円)
-          type: integer
-        discountType:
-          description: 割引計算方法
-          type: integer
-        endAt:
-          description: クーポン使用可能日時(終了)
-          type: integer
-        id:
-          description: プロモーションID
-          type: string
-        startAt:
-          description: クーポン使用可能日時(開始)
-          type: integer
-        status:
-          description: ステータス
-          type: integer
-        title:
-          description: タイトル
-          type: string
-      type: object
     request.AddCartItemRequest:
       properties:
         productId:
@@ -768,9 +133,651 @@ components:
       - lastnameKana
       - phoneNumber
       type: object
+    response.AuthResponse:
+      properties:
+        accessToken:
+          description: アクセストークン
+          type: string
+        expiresIn:
+          description: 有効期限
+          type: integer
+        refreshToken:
+          description: 更新トークン
+          type: string
+        tokenType:
+          description: トークン種別
+          type: string
+        userId:
+          description: ユーザーID
+          type: string
+      type: object
+    response.AuthUserResponse:
+      properties:
+        email:
+          description: メールアドレス
+          type: string
+        firstname:
+          description: 名
+          type: string
+        firstnameKana:
+          description: 名（かな）
+          type: string
+        id:
+          description: ユーザーID
+          type: string
+        lastCheckInAt:
+          description: 最新のチェックイン日時
+          type: integer
+        lastname:
+          description: 姓
+          type: string
+        lastnameKana:
+          description: 姓（かな）
+          type: string
+        phoneNumber:
+          description: 電話番号
+          type: string
+      type: object
+    response.CalcCartResponse:
+      properties:
+        carts:
+          description: カート一覧
+          items:
+            $ref: '#/components/schemas/response.Cart'
+          type: array
+          uniqueItems: false
+        coordinator:
+          $ref: '#/components/schemas/response.Coordinator'
+        discount:
+          description: 割引金額(税込)
+          type: integer
+        items:
+          description: カート内の商品一覧(集計結果)
+          items:
+            $ref: '#/components/schemas/response.CartItem'
+          type: array
+          uniqueItems: false
+        products:
+          description: 商品一覧
+          items:
+            $ref: '#/components/schemas/response.Product'
+          type: array
+          uniqueItems: false
+        promotion:
+          $ref: '#/components/schemas/response.Promotion'
+        requestId:
+          description: 支払い時にAPIへ送信するキー(重複判定用)
+          type: string
+        shippingFee:
+          description: 配送手数料(税込)
+          type: integer
+        subtotal:
+          description: 購入金額(税込)
+          type: integer
+        total:
+          description: 合計金額(税込)
+          type: integer
+      type: object
+    response.Cart:
+      properties:
+        coordinatorId:
+          description: コーディネータID
+          type: string
+        items:
+          description: 箱の商品一覧
+          items:
+            $ref: '#/components/schemas/response.CartItem'
+          type: array
+          uniqueItems: false
+        number:
+          description: 箱の通番
+          type: integer
+        rate:
+          description: 箱の占有率
+          type: integer
+        size:
+          description: 箱のサイズ
+          type: integer
+        type:
+          description: 箱の種別
+          type: integer
+      type: object
+    response.CartItem:
+      properties:
+        productId:
+          description: 商品ID
+          type: string
+        quantity:
+          description: 数量
+          type: integer
+      type: object
+    response.CartResponse:
+      properties:
+        carts:
+          description: カート一覧
+          items:
+            $ref: '#/components/schemas/response.Cart'
+          type: array
+          uniqueItems: false
+        coordinators:
+          description: コーディネータ一覧
+          items:
+            $ref: '#/components/schemas/response.Coordinator'
+          type: array
+          uniqueItems: false
+        products:
+          description: 商品一覧
+          items:
+            $ref: '#/components/schemas/response.Product'
+          type: array
+          uniqueItems: false
+      type: object
+    response.Category:
+      description: 商品種別情報
+      properties:
+        id:
+          description: 商品種別ID
+          type: string
+        name:
+          description: 商品種別名
+          type: string
+      type: object
+    response.CheckoutResponse:
+      properties:
+        url:
+          description: 遷移先URL
+          type: string
+      type: object
+    response.CheckoutStateResponse:
+      properties:
+        orderId:
+          description: 注文履歴ID
+          type: string
+        status:
+          description: 注文ステータス
+          type: integer
+      type: object
+    response.Coordinator:
+      description: コーディネータ情報
+      properties:
+        businessDays:
+          description: 営業曜日(発送可能日)
+          items:
+            $ref: '#/components/schemas/time.Weekday'
+          type: array
+          uniqueItems: false
+        city:
+          description: 市区町村
+          type: string
+        facebookId:
+          description: Facebookアカウント
+          type: string
+        headerUrl:
+          description: ヘッダー画像URL
+          type: string
+        id:
+          description: コーディネータID
+          type: string
+        instagramId:
+          description: Instagramアカウント
+          type: string
+        marcheName:
+          description: マルシェ名
+          type: string
+        prefecture:
+          description: 都道府県
+          type: string
+        productTypeIds:
+          description: 取り扱い品目一覧
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        profile:
+          description: 紹介文
+          type: string
+        promotionVideoUrl:
+          description: 紹介映像URL
+          type: string
+        thumbnailUrl:
+          description: サムネイルURL
+          type: string
+        username:
+          description: 表示名
+          type: string
+      type: object
+    response.Order:
+      description: 注文履歴情報
+      properties:
+        coordinatorId:
+          description: コーディネータID
+          type: string
+        id:
+          description: 注文履歴ID
+          type: string
+        items:
+          description: 注文商品一覧
+          items:
+            $ref: '#/components/schemas/response.OrderItem'
+          type: array
+          uniqueItems: false
+        payment:
+          $ref: '#/components/schemas/response.OrderPayment'
+        pickupAt:
+          description: 受け取り日時
+          type: integer
+        pickupLocation:
+          description: 受け取り場所
+          type: string
+        promotionId:
+          description: プロモーションID
+          type: string
+        refund:
+          $ref: '#/components/schemas/response.OrderRefund'
+        status:
+          description: 注文ステータス
+          type: integer
+        type:
+          description: 注文種別
+          type: integer
+      type: object
+    response.OrderItem:
+      properties:
+        fulfillmentId:
+          description: 配送情報ID
+          type: string
+        price:
+          description: 購入価格(税込)
+          type: integer
+        productId:
+          description: 商品ID
+          type: string
+        quantity:
+          description: 購入数量
+          type: integer
+      type: object
+    response.OrderPayment:
+      description: 支払い情報
+      properties:
+        discount:
+          description: 割引金額(税込)
+          type: integer
+        methodType:
+          description: 決済手段種別
+          type: integer
+        orderedAt:
+          description: 注文日時
+          type: integer
+        paidAt:
+          description: 支払日時
+          type: integer
+        shippingFee:
+          description: 配送手数料(税込)
+          type: integer
+        status:
+          description: 支払い状況
+          type: integer
+        subtotal:
+          description: 購入金額(税込)
+          type: integer
+        total:
+          description: 合計金額(税込)
+          type: integer
+        transactionId:
+          description: 取引ID
+          type: string
+      type: object
+    response.OrderRefund:
+      description: 注文キャンセル情報
+      properties:
+        canceled:
+          description: 注文キャンセルフラグ
+          type: boolean
+        canceledAt:
+          description: 注文キャンセル日時
+          type: integer
+        reason:
+          description: 注文キャンセル理由
+          type: string
+        total:
+          description: 返金金額
+          type: integer
+        type:
+          description: 注文キャンセル種別
+          type: integer
+      type: object
+    response.OrderResponse:
+      properties:
+        coordinator:
+          $ref: '#/components/schemas/response.Coordinator'
+        order:
+          $ref: '#/components/schemas/response.Order'
+        products:
+          description: 商品一覧
+          items:
+            $ref: '#/components/schemas/response.Product'
+          type: array
+          uniqueItems: false
+        promotion:
+          $ref: '#/components/schemas/response.Promotion'
+      type: object
+    response.OrdersResponse:
+      properties:
+        coordinators:
+          description: コーディネータ一覧
+          items:
+            $ref: '#/components/schemas/response.Coordinator'
+          type: array
+          uniqueItems: false
+        orders:
+          description: 注文履歴一覧
+          items:
+            $ref: '#/components/schemas/response.Order'
+          type: array
+          uniqueItems: false
+        products:
+          description: 商品一覧
+          items:
+            $ref: '#/components/schemas/response.Product'
+          type: array
+          uniqueItems: false
+        promotions:
+          description: プロモーション一覧
+          items:
+            $ref: '#/components/schemas/response.Promotion'
+          type: array
+          uniqueItems: false
+        total:
+          description: 合計数
+          type: integer
+      type: object
+    response.Producer:
+      description: 生産者情報
+      properties:
+        city:
+          description: 市区町村
+          type: string
+        coordinatorId:
+          description: 担当コーディネータID
+          type: string
+        facebookId:
+          description: Facebookアカウント
+          type: string
+        headerUrl:
+          description: ヘッダー画像URL
+          type: string
+        id:
+          description: 生産者ID
+          type: string
+        instagramId:
+          description: Instagramアカウント
+          type: string
+        prefecture:
+          description: 都道府県
+          type: string
+        profile:
+          description: 紹介文
+          type: string
+        promotionVideoUrl:
+          description: 紹介映像URL
+          type: string
+        thumbnailUrl:
+          description: サムネイルURL
+          type: string
+        username:
+          description: 生産者名
+          type: string
+      type: object
+    response.Product:
+      description: 商品情報
+      properties:
+        box60Rate:
+          description: 箱の占有率(サイズ:60)
+          type: integer
+        box80Rate:
+          description: 箱の占有率(サイズ:80)
+          type: integer
+        box100Rate:
+          description: 箱の占有率(サイズ:100)
+          type: integer
+        categoryId:
+          description: 商品種別ID
+          type: string
+        coordinatorId:
+          description: コーディネータID
+          type: string
+        deliveryType:
+          description: 配送方法
+          type: integer
+        description:
+          description: 商品説明
+          type: string
+        endAt:
+          description: 販売終了日時
+          type: integer
+        expirationDate:
+          description: 賞味期限(単位:日)
+          type: integer
+        id:
+          description: 商品ID
+          type: string
+        inventory:
+          description: 在庫数
+          type: integer
+        itemDescription:
+          description: 数量単位説明
+          type: string
+        itemUnit:
+          description: 数量単位
+          type: string
+        media:
+          description: メディア一覧
+          items:
+            $ref: '#/components/schemas/response.ProductMedia'
+          type: array
+          uniqueItems: false
+        name:
+          description: 商品名
+          type: string
+        originCity:
+          description: 原産地(市区町村)
+          type: string
+        originPrefecture:
+          description: 原産地(都道府県)
+          type: string
+        price:
+          description: 販売価格(税込)
+          type: integer
+        producerId:
+          description: 生産者ID
+          type: string
+        productTagIds:
+          description: 商品タグID一覧
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        productTypeId:
+          description: 品目ID
+          type: string
+        rate:
+          $ref: '#/components/schemas/response.ProductRate'
+        recommendedPoint1:
+          description: おすすめポイント1
+          type: string
+        recommendedPoint2:
+          description: おすすめポイント2
+          type: string
+        recommendedPoint3:
+          description: おすすめポイント3
+          type: string
+        startAt:
+          description: 販売開始日時
+          type: integer
+        status:
+          description: 販売状況
+          type: integer
+        storageMethodType:
+          description: 保存方法
+          type: integer
+        thumbnailUrl:
+          description: サムネイルURL
+          type: string
+        weight:
+          description: 重量(kg,少数第一位まで)
+          type: number
+      type: object
+    response.ProductMedia:
+      properties:
+        isThumbnail:
+          description: サムネイルとして使用
+          type: boolean
+        url:
+          description: メディアURL
+          type: string
+      type: object
+    response.ProductRate:
+      description: 商品評価
+      properties:
+        average:
+          description: 平均評価
+          type: number
+        count:
+          description: 合計評価数
+          type: integer
+        detail:
+          additionalProperties:
+            type: integer
+          description: 評価詳細
+          type: object
+      type: object
+    response.ProductResponse:
+      properties:
+        category:
+          $ref: '#/components/schemas/response.Category'
+        coordinator:
+          $ref: '#/components/schemas/response.Coordinator'
+        producer:
+          $ref: '#/components/schemas/response.Producer'
+        product:
+          $ref: '#/components/schemas/response.Product'
+        productTags:
+          description: 商品タグ一覧
+          items:
+            $ref: '#/components/schemas/response.ProductTag'
+          type: array
+          uniqueItems: false
+        productType:
+          $ref: '#/components/schemas/response.ProductType'
+      type: object
+    response.ProductTag:
+      properties:
+        id:
+          description: 商品タグID
+          type: string
+        name:
+          description: 商品タグ名
+          type: string
+      type: object
+    response.ProductType:
+      description: 品目情報
+      properties:
+        categoryId:
+          description: 商品種別ID
+          type: string
+        iconUrl:
+          description: アイコンURL
+          type: string
+        id:
+          description: 品目ID
+          type: string
+        name:
+          description: 品目名
+          type: string
+      type: object
+    response.ProductsResponse:
+      properties:
+        categories:
+          description: 商品種別一覧
+          items:
+            $ref: '#/components/schemas/response.Category'
+          type: array
+          uniqueItems: false
+        coordinators:
+          description: コーディネータ一覧
+          items:
+            $ref: '#/components/schemas/response.Coordinator'
+          type: array
+          uniqueItems: false
+        producers:
+          description: 生産者一覧
+          items:
+            $ref: '#/components/schemas/response.Producer'
+          type: array
+          uniqueItems: false
+        productTags:
+          description: 商品タグ一覧
+          items:
+            $ref: '#/components/schemas/response.ProductTag'
+          type: array
+          uniqueItems: false
+        productTypes:
+          description: 品目一覧
+          items:
+            $ref: '#/components/schemas/response.ProductType'
+          type: array
+          uniqueItems: false
+        products:
+          description: 商品一覧
+          items:
+            $ref: '#/components/schemas/response.Product'
+          type: array
+          uniqueItems: false
+        total:
+          description: 商品合計数
+          type: integer
+      type: object
+    response.Promotion:
+      description: プロモーション情報
+      properties:
+        code:
+          description: クーポンコード
+          type: string
+        description:
+          description: 詳細説明
+          type: string
+        discountRate:
+          description: 割引額(%/円)
+          type: integer
+        discountType:
+          description: 割引計算方法
+          type: integer
+        endAt:
+          description: クーポン使用可能日時(終了)
+          type: integer
+        id:
+          description: プロモーションID
+          type: string
+        startAt:
+          description: クーポン使用可能日時(開始)
+          type: integer
+        status:
+          description: ステータス
+          type: integer
+        title:
+          description: タイトル
+          type: string
+      type: object
     time.Weekday:
       type: integer
       x-enum-varnames:
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
       - Sunday
       - Monday
       - Tuesday
@@ -843,7 +850,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthResponse'
+                $ref: '#/components/schemas/response.AuthResponse'
           description: OK
         "400":
           content:
@@ -887,7 +894,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CartResponse'
+                $ref: '#/components/schemas/response.CartResponse'
           description: OK
         "401":
           content:
@@ -998,7 +1005,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CalcCartResponse'
+                $ref: '#/components/schemas/response.CalcCartResponse'
           description: OK
         "400":
           content:
@@ -1039,7 +1046,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckoutResponse'
+                $ref: '#/components/schemas/response.CheckoutResponse'
           description: OK
         "400":
           content:
@@ -1053,6 +1060,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/util.ErrorResponse'
           description: 認証エラー
+      security:
+      - bearerauth: []
       summary: 購入する
       tags:
       - Checkout
@@ -1077,7 +1086,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckoutStateResponse'
+                $ref: '#/components/schemas/response.CheckoutStateResponse'
           description: OK
         "400":
           content:
@@ -1137,7 +1146,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrdersResponse'
+                $ref: '#/components/schemas/response.OrdersResponse'
           description: OK
         "400":
           content:
@@ -1177,7 +1186,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderResponse'
+                $ref: '#/components/schemas/response.OrderResponse'
           description: OK
         "401":
           content:
@@ -1223,7 +1232,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductsResponse'
+                $ref: '#/components/schemas/response.ProductsResponse'
           description: OK
         "400":
           content:
@@ -1255,7 +1264,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductResponse'
+                $ref: '#/components/schemas/response.ProductResponse'
           description: OK
         "404":
           content:
@@ -1288,7 +1297,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthUserResponse'
+                $ref: '#/components/schemas/response.AuthUserResponse'
           description: OK
         "400":
           content:
@@ -1326,7 +1335,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthUserResponse'
+                $ref: '#/components/schemas/response.AuthUserResponse'
           description: OK
         "400":
           content:

--- a/docs/swagger/gen/user/v1/swagger.yaml
+++ b/docs/swagger/gen/user/v1/swagger.yaml
@@ -1410,9 +1410,6 @@ components:
                     $ref: '#/components/schemas/response.OrderRefund'
                 shippingAddress:
                     $ref: '#/components/schemas/response.Address'
-                shippingType:
-                    description: 配送方法
-                    type: integer
                 status:
                     description: 注文ステータス
                     type: integer
@@ -2446,6 +2443,13 @@ components:
         time.Weekday:
             type: integer
             x-enum-varnames:
+                - Sunday
+                - Monday
+                - Tuesday
+                - Wednesday
+                - Thursday
+                - Friday
+                - Saturday
                 - Sunday
                 - Monday
                 - Tuesday


### PR DESCRIPTION
## 概要
NotifyOrderCaptured 処理における newOrderProductCaptured 関数で、レポートの Overview に使用する顧客名の取得方法を修正しました。

## 変更内容
- **データ取得方法の修正**: `paymentAddress.Name()` から `customer.Name()` へ変更
- **API呼び出しの変更**: `MultiGetAddressesByRevision` から `GetUser` へ変更
- **テストの全面修正**: 新しいAPIに対応したモック設定とテストケースの更新
- **新しいエラーケースの追加**: `product failed to get user` テストケースを追加

## 背景・目的
注文確定通知のレポートで顧客名を正確に取得するため、住所情報ではなくユーザー情報から直接名前を取得する仕様に変更されました。

## テスト
- [x] API: go test -v ./internal/messenger/service -run TestNotifyOrderCaptured ✅
- [x] API: 全notify系テストの実行確認 ✅
- [x] モック設定の修正と新テストケースの追加 ✅

## 技術的な変更点
### notify.go
```go
// 変更前
paymentAddress *uentity.Address
addresses, err := s.multiGetAddressesByRevision(ectx, []int64{order.AddressRevisionID})
paymentAddress = addresses[0]
Overview: paymentAddress.Name(),

// 変更後  
customer *uentity.User
in := &user.GetUserInput{UserID: order.UserID}
customer, err = s.user.GetUser(ectx, in)
Overview: customer.Name(),
```

### notify_test.go
- 15個のテストケースを全て修正
- `GetUser` モック期待の追加
- `MultiGetAddressesByRevision` の呼び出し回数を2回→1回に修正
- 適切な User エンティティ構造の作成（Member フィールド含む）

## レビューポイント
- `newOrderProductCaptured` 関数の変更が適切か
- テストケースが全ての成功・失敗パターンをカバーしているか
- エラーハンドリングが適切に実装されているか

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - Checkout API の仕様に Bearer 認証を明記し、認証要件を明確化しました。
- バグ修正
  - 注文キャプチャ通知で、宛名/概要が住所ではなく顧客名に基づき正しく表示されるよう改善しました。
  - エラー処理を見直し、通知配信の一貫性と信頼性を向上しました。
- テスト
  - 通知機能のテストを拡充し、ユーザー情報を含むケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->