### PR TITLE
feat(api): APIリクエスト構造体にバリデーションタグを追加

### DIFF
--- a/api/internal/gateway/admin/v1/request/administrator.go
+++ b/api/internal/gateway/admin/v1/request/administrator.go
@@ -1,22 +1,22 @@
 package request
 
 type CreateAdministratorRequest struct {
-	Lastname      string `json:"lastname"`      // 姓
-	Firstname     string `json:"firstname"`     // 名
-	LastnameKana  string `json:"lastnameKana"`  // 姓(かな)
-	FirstnameKana string `json:"firstnameKana"` // 名(かな)
-	Email         string `json:"email"`         // メールアドレス
-	PhoneNumber   string `json:"phoneNumber"`   // 電話番号
+	Lastname      string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname     string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana  string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	Email         string `json:"email" binding:"required,email"`                   // メールアドレス
+	PhoneNumber   string `json:"phoneNumber" binding:"required,e164"`              // 電話番号
 }
 
 type UpdateAdministratorRequest struct {
-	Lastname      string `json:"lastname"`      // 姓
-	Firstname     string `json:"firstname"`     // 名
-	LastnameKana  string `json:"lastnameKana"`  // 姓(かな)
-	FirstnameKana string `json:"firstnameKana"` // 名(かな)
-	PhoneNumber   string `json:"phoneNumber"`   // 電話番号
+	Lastname      string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname     string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana  string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	PhoneNumber   string `json:"phoneNumber" binding:"required,e164"`              // 電話番号
 }
 
 type UpdateAdministratorEmailRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }

--- a/api/internal/gateway/admin/v1/request/auth.go
+++ b/api/internal/gateway/admin/v1/request/auth.go
@@ -1,50 +1,50 @@
 package request
 
 type SignInRequest struct {
-	Username string `json:"username"` // ユーザー名 (メールアドレス)
-	Password string `json:"password"` // パスワード
+	Username string `json:"username" binding:"required"` // ユーザー名 (メールアドレス)
+	Password string `json:"password" binding:"required"` // パスワード
 }
 
 type ConnectGoogleAccountRequest struct {
-	Code        string `json:"code"`        // 認証コード
-	Nonce       string `json:"nonce"`       // セキュア文字列（リプレイアタック対策）
-	RedirectURI string `json:"redirectUri"` // リダイレクトURI
+	Code        string `json:"code" binding:"required"`            // 認証コード
+	Nonce       string `json:"nonce" binding:"required"`           // セキュア文字列（リプレイアタック対策）
+	RedirectURI string `json:"redirectUri" binding:"required,url"` // リダイレクトURI
 }
 
 type ConnectLINEAccountRequest struct {
-	Code        string `json:"code"`        // 認証コード
-	Nonce       string `json:"nonce"`       // セキュア文字列（リプレイアタック対策）
-	RedirectURI string `json:"redirectUri"` // リダイレクトURI
+	Code        string `json:"code" binding:"required"`            // 認証コード
+	Nonce       string `json:"nonce" binding:"required"`           // セキュア文字列（リプレイアタック対策）
+	RedirectURI string `json:"redirectUri" binding:"required,url"` // リダイレクトURI
 }
 
 type RefreshAuthTokenRequest struct {
-	RefreshToken string `json:"refreshToken"` // 更新トークン
+	RefreshToken string `json:"refreshToken" binding:"required"` // 更新トークン
 }
 
 type RegisterAuthDeviceRequest struct {
-	Device string `json:"device"` // デバイスID
+	Device string `json:"device" binding:"required"` // デバイスID
 }
 
 type UpdateAuthEmailRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }
 
 type VerifyAuthEmailRequest struct {
-	VerifyCode string `json:"verifyCode"` // 検証コード
+	VerifyCode string `json:"verifyCode" binding:"required"` // 検証コード
 }
 
 type UpdateAuthPasswordRequest struct {
-	OldPassword          string `json:"oldPassword"`          // 現在のパスワード
-	NewPassword          string `json:"newPassword"`          // 新しいパスワード
-	PasswordConfirmation string `json:"passwordConfirmation"` // パスワード (確認用)
+	OldPassword          string `json:"oldPassword" binding:"required"`                              // 現在のパスワード
+	NewPassword          string `json:"newPassword" binding:"min=8,max=32"`                          // 新しいパスワード
+	PasswordConfirmation string `json:"passwordConfirmation" binding:"required,eqfield=NewPassword"` // パスワード (確認用)
 }
 type ForgotAuthPasswordRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }
 
 type ResetAuthPasswordRequest struct {
-	Email                string `json:"email"`                // メールアドレス
-	VerifyCode           string `json:"verifyCode"`           // 検証コード
-	Password             string `json:"password"`             // パスワード
-	PasswordConfirmation string `json:"passwordConfirmation"` // パスワード (確認用)
+	Email                string `json:"email" binding:"required,email"`                           // メールアドレス
+	VerifyCode           string `json:"verifyCode" binding:"required"`                            // 検証コード
+	Password             string `json:"password" binding:"min=8,max=32"`                          // パスワード
+	PasswordConfirmation string `json:"passwordConfirmation" binding:"required,eqfield=Password"` // パスワード (確認用)
 }

--- a/api/internal/gateway/admin/v1/request/broadcast.go
+++ b/api/internal/gateway/admin/v1/request/broadcast.go
@@ -1,24 +1,24 @@
 package request
 
 type UpdateBroadcastArchiveRequest struct {
-	ArchiveURL string `json:"archiveUrl"` // アーカイブ動画URL
+	ArchiveURL string `json:"archiveUrl" binding:"required,url"` // アーカイブ動画URL
 }
 
 type ActivateBroadcastMP4Request struct {
-	InputURL string `json:"inputUrl"` // 配信動画URL
+	InputURL string `json:"inputUrl" binding:"required,url"` // 配信動画URL
 }
 
 type AuthYoutubeBroadcastRequest struct {
-	YoutubeHandle string `json:"youtubeHandle"` // 連携先Youtubeアカウント
+	YoutubeHandle string `json:"youtubeHandle" binding:"required"` // 連携先Youtubeアカウント
 }
 
 type CallbackAuthYoutubeBroadcastRequest struct {
-	State    string `json:"state"`    // Google認証時に取得したstate
-	AuthCode string `json:"authCode"` // Google認証時に取得したcode
+	State    string `json:"state" binding:"required"`    // Google認証時に取得したstate
+	AuthCode string `json:"authCode" binding:"required"` // Google認証時に取得したcode
 }
 
 type CreateYoutubeBroadcastRequest struct {
-	Title       string `json:"title"`       // ライブ配信タイトル
-	Description string `json:"description"` // ライブ配信説明
-	Public      bool   `json:"public"`      // 公開設定
+	Title       string `json:"title" binding:"required,max=100"`         // ライブ配信タイトル
+	Description string `json:"description" binding:"omitempty,max=1000"` // ライブ配信説明
+	Public      bool   `json:"public" binding:""`                        // 公開設定
 }

--- a/api/internal/gateway/admin/v1/request/category.go
+++ b/api/internal/gateway/admin/v1/request/category.go
@@ -1,9 +1,9 @@
 package request
 
 type CreateCategoryRequest struct {
-	Name string `json:"name"` // 商品種別名
+	Name string `json:"name" binding:"required,max=32"` // 商品種別名
 }
 
 type UpdateCategoryRequest struct {
-	Name string `json:"name"` // 商品種別名
+	Name string `json:"name" binding:"required,max=32"` // 商品種別名
 }

--- a/api/internal/gateway/admin/v1/request/contact.go
+++ b/api/internal/gateway/admin/v1/request/contact.go
@@ -1,15 +1,15 @@
 package request
 
 type CreateContactRequest struct {
-	Title       string `json:"title"`       // お問い合わせ件名
-	CategoryID  string `json:"categoryId"`  // お問い合わせ種別ID
-	Content     string `json:"content"`     // お問い合わせ内容
-	Username    string `json:"username"`    // 氏名
-	UserID      string `json:"userId"`      // 問い合わせ作成者ID(null許容)
-	Email       string `json:"email"`       // メールアドレス
-	PhoneNumber string `json:"phoneNumber"` // 電話番号
-	ResponderID string `json:"responderId"` // 対応者ID(null許容)
-	Note        string `json:"note"`        // 対応者メモ
+	Title       string `json:"title" binding:"required,max=64"`     // お問い合わせ件名
+	CategoryID  string `json:"categoryId" binding:"required"`       // お問い合わせ種別ID
+	Content     string `json:"content" binding:"required,max=2000"` // お問い合わせ内容
+	Username    string `json:"username" binding:"required,max=32"`  // 氏名
+	UserID      string `json:"userId" binding:"omitempty"`          // 問い合わせ作成者ID(null許容)
+	Email       string `json:"email" binding:"required,email"`      // メールアドレス
+	PhoneNumber string `json:"phoneNumber" binding:"required,e164"` // 電話番号
+	ResponderID string `json:"responderId" binding:"omitempty"`     // 対応者ID(null許容)
+	Note        string `json:"note" binding:"omitempty,max=500"`    // 対応者メモ
 }
 
 // お問い合わせステータス(作成時は不明)
@@ -24,14 +24,14 @@ const (
 )
 
 type UpdateContactRequest struct {
-	Title       string        `json:"title"`       // お問い合わせ件名
-	CategoryID  string        `json:"categoryId"`  // お問い合わせ種別ID
-	Content     string        `json:"content"`     // お問い合わせ内容
-	Username    string        `json:"username"`    // 氏名
-	UserID      string        `json:"userId"`      // 問い合わせ作成者ID(null許容)
-	Email       string        `json:"email"`       // メールアドレス
-	PhoneNumber string        `json:"phoneNumber"` // 電話番号
-	ResponderID string        `json:"responderId"` // 対応者ID(null許容)
-	Note        string        `json:"note"`        // 対応者メモ
-	Status      ContactStatus `json:"status"`      // お問い合わせステータス
+	Title       string        `json:"title" binding:"required,max=64"`     // お問い合わせ件名
+	CategoryID  string        `json:"categoryId" binding:"required"`       // お問い合わせ種別ID
+	Content     string        `json:"content" binding:"required,max=2000"` // お問い合わせ内容
+	Username    string        `json:"username" binding:"required,max=32"`  // 氏名
+	UserID      string        `json:"userId" binding:"omitempty"`          // 問い合わせ作成者ID(null許容)
+	Email       string        `json:"email" binding:"required,email"`      // メールアドレス
+	PhoneNumber string        `json:"phoneNumber" binding:"required,e164"` // 電話番号
+	ResponderID string        `json:"responderId" binding:"omitempty"`     // 対応者ID(null許容)
+	Note        string        `json:"note" binding:"omitempty,max=500"`    // 対応者メモ
+	Status      ContactStatus `json:"status" binding:"min=0,max=4"`        // お問い合わせステータス
 }

--- a/api/internal/gateway/admin/v1/request/contact_read.go
+++ b/api/internal/gateway/admin/v1/request/contact_read.go
@@ -1,7 +1,7 @@
 package request
 
 type CreateContactReadRequest struct {
-	ContactID string `json:"contactId"` // お問い合わせID
-	UserID    string `json:"userId"`    // 送信者ID
-	UserType  int32  `json:"userType"`  // 送信者種別(不明:0, admin:1, uer:2, guest:3)
+	ContactID string `json:"contactId" binding:"required"`   // お問い合わせID
+	UserID    string `json:"userId" binding:"required"`      // 送信者ID
+	UserType  int32  `json:"userType" binding:"min=0,max=3"` // 送信者種別(不明:0, admin:1, uer:2, guest:3)
 }

--- a/api/internal/gateway/admin/v1/request/coordinator.go
+++ b/api/internal/gateway/admin/v1/request/coordinator.go
@@ -3,51 +3,51 @@ package request
 import "time"
 
 type CreateCoordinatorRequest struct {
-	Lastname          string         `json:"lastname"`          // 姓
-	Firstname         string         `json:"firstname"`         // 名
-	LastnameKana      string         `json:"lastnameKana"`      // 姓(かな)
-	FirstnameKana     string         `json:"firstnameKana"`     // 名(かな)
-	MarcheName        string         `json:"marcheName"`        // マルシェ名
-	Username          string         `json:"username"`          // 表示名
-	Profile           string         `json:"profile"`           // 紹介文
-	ProductTypeIDs    []string       `json:"productTypeIds"`    // 取り扱い品目一覧
-	ThumbnailURL      string         `json:"thumbnailUrl"`      // サムネイルURL
-	HeaderURL         string         `json:"headerUrl"`         // ヘッダー画像URL
-	PromotionVideoURL string         `json:"promotionVideoUrl"` // 紹介映像URL
-	BonusVideoURL     string         `json:"bonusVideoUrl"`     // 購入特典映像URL
-	InstagramID       string         `json:"instagramId"`       // Instagramアカウント
-	FacebookID        string         `json:"facebookId"`        // Facebookアカウント
-	Email             string         `json:"email"`             // メールアドレス
-	PhoneNumber       string         `json:"phoneNumber"`       // 電話番号
-	PostalCode        string         `json:"postalCode"`        // 郵便番号
-	PrefectureCode    int32          `json:"prefectureCode"`    // 都道府県
-	City              string         `json:"city"`              // 市区町村
-	AddressLine1      string         `json:"addressLine1"`      // 町名・番地
-	AddressLine2      string         `json:"addressLine2"`      // ビル名・号室など
-	BusinessDays      []time.Weekday `json:"businessDays"`      // 営業曜日(発送可能日)
+	Lastname          string         `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname         string         `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana      string         `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana     string         `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	MarcheName        string         `json:"marcheName" binding:"required,max=64"`             // マルシェ名
+	Username          string         `json:"username" binding:"required,max=32"`               // 表示名
+	Profile           string         `json:"profile" binding:"required,max=2000"`              // 紹介文
+	ProductTypeIDs    []string       `json:"productTypeIds" binding:"dive,required"`           // 取り扱い品目一覧
+	ThumbnailURL      string         `json:"thumbnailUrl" binding:"omitempty,url"`             // サムネイルURL
+	HeaderURL         string         `json:"headerUrl" binding:"omitempty,url"`                // ヘッダー画像URL
+	PromotionVideoURL string         `json:"promotionVideoUrl" binding:"omitempty,url"`        // 紹介映像URL
+	BonusVideoURL     string         `json:"bonusVideoUrl" binding:"omitempty,url"`            // 購入特典映像URL
+	InstagramID       string         `json:"instagramId" binding:"omitempty,max=30"`           // Instagramアカウント
+	FacebookID        string         `json:"facebookId" binding:"omitempty,max=50"`            // Facebookアカウント
+	Email             string         `json:"email" binding:"required,email"`                   // メールアドレス
+	PhoneNumber       string         `json:"phoneNumber" binding:"required,e164"`              // 電話番号
+	PostalCode        string         `json:"postalCode" binding:"numeric,max=16"`              // 郵便番号
+	PrefectureCode    int32          `json:"prefectureCode" binding:"required,min=1,max=47"`   // 都道府県
+	City              string         `json:"city" binding:"required,max=32"`                   // 市区町村
+	AddressLine1      string         `json:"addressLine1" binding:"required,max=64"`           // 町名・番地
+	AddressLine2      string         `json:"addressLine2" binding:"omitempty,max=64"`          // ビル名・号室など
+	BusinessDays      []time.Weekday `json:"businessDays" binding:"max=7,unique"`              // 営業曜日(発送可能日)
 }
 
 type UpdateCoordinatorRequest struct {
-	Lastname          string `json:"lastname"`          // 姓
-	Firstname         string `json:"firstname"`         // 名
-	LastnameKana      string `json:"lastnameKana"`      // 姓(かな)
-	FirstnameKana     string `json:"firstnameKana"`     // 名(かな)
-	Username          string `json:"username"`          // 表示名
-	Profile           string `json:"profile"`           // 紹介文
-	ThumbnailURL      string `json:"thumbnailUrl"`      // サムネイルURL
-	HeaderURL         string `json:"headerUrl"`         // ヘッダー画像URL
-	PromotionVideoURL string `json:"promotionVideoUrl"` // 紹介映像URL
-	BonusVideoURL     string `json:"bonusVideoUrl"`     // 購入特典映像URL
-	InstagramID       string `json:"instagramId"`       // Instagramアカウント
-	FacebookID        string `json:"facebookId"`        // Facebookアカウント
-	PhoneNumber       string `json:"phoneNumber"`       // 電話番号
-	PostalCode        string `json:"postalCode"`        // 郵便番号
-	PrefectureCode    int32  `json:"prefectureCode"`    // 都道府県
-	City              string `json:"city"`              // 市区町村
-	AddressLine1      string `json:"addressLine1"`      // 町名・番地
-	AddressLine2      string `json:"addressLine2"`      // ビル名・号室など
+	Lastname          string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname         string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana      string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana     string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	Username          string `json:"username" binding:"required,max=32"`               // 表示名
+	Profile           string `json:"profile" binding:"required,max=2000"`              // 紹介文
+	ThumbnailURL      string `json:"thumbnailUrl" binding:"omitempty,url"`             // サムネイルURL
+	HeaderURL         string `json:"headerUrl" binding:"omitempty,url"`                // ヘッダー画像URL
+	PromotionVideoURL string `json:"promotionVideoUrl" binding:"omitempty,url"`        // 紹介映像URL
+	BonusVideoURL     string `json:"bonusVideoUrl" binding:"omitempty,url"`            // 購入特典映像URL
+	InstagramID       string `json:"instagramId" binding:"omitempty,max=32"`           // Instagramアカウント
+	FacebookID        string `json:"facebookId" binding:"omitempty,max=50"`            // Facebookアカウント
+	PhoneNumber       string `json:"phoneNumber" binding:"required,e164"`              // 電話番号
+	PostalCode        string `json:"postalCode" binding:"numeric,max=16"`              // 郵便番号
+	PrefectureCode    int32  `json:"prefectureCode" binding:"required,min=1,max=47"`   // 都道府県
+	City              string `json:"city" binding:"required,max=32"`                   // 市区町村
+	AddressLine1      string `json:"addressLine1" binding:"required,max=64"`           // 町名・番地
+	AddressLine2      string `json:"addressLine2" binding:"omitempty,max=64"`          // ビル名・号室など
 }
 
 type UpdateCoordinatorEmailRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }

--- a/api/internal/gateway/admin/v1/request/experience.go
+++ b/api/internal/gateway/admin/v1/request/experience.go
@@ -1,71 +1,71 @@
 package request
 
 type CreateExperienceRequest struct {
-	Title                 string                   `json:"title"`                 // 体験名
-	Description           string                   `json:"description"`           // 説明
-	Public                bool                     `json:"public"`                // 公開設定
-	SoldOut               bool                     `json:"soldOut"`               // 定員オーバーフラグ
-	CoordinatorID         string                   `json:"coordinatorId"`         // コーディネータID
-	ProducerID            string                   `json:"producerId"`            // 生産者ID
-	TypeID                string                   `json:"experienceTypeId"`      // 体験種別ID
-	Media                 []*CreateExperienceMedia `json:"media"`                 // メディア一覧
-	PriceAdult            int64                    `json:"priceAdult"`            // 大人料金
-	PriceJuniorHighSchool int64                    `json:"priceJuniorHighSchool"` // 中学生料金
-	PriceElementarySchool int64                    `json:"priceElementarySchool"` // 小学生料金
-	PricePreschool        int64                    `json:"pricePreschool"`        // 幼児料金
-	PriceSenior           int64                    `json:"priceSenior"`           // シニア料金
-	RecommendedPoint1     string                   `json:"recommendedPoint1"`     // おすすめポイント1
-	RecommendedPoint2     string                   `json:"recommendedPoint2"`     // おすすめポイント2
-	RecommendedPoint3     string                   `json:"recommendedPoint3"`     // おすすめポイント3
-	PromotionVideoURL     string                   `json:"promotionVideoUrl"`     // 紹介動画URL
-	Duration              int64                    `json:"duration"`              // 体験時間(分)
-	Direction             string                   `json:"direction"`             // アクセス方法
-	BusinessOpenTime      string                   `json:"businessOpenTime"`      // 営業開始時間
-	BusinessCloseTime     string                   `json:"businessCloseTime"`     // 営業終了時間
-	HostPostalCode        string                   `json:"hostPostalCode"`        // 開催場所(郵便番号)
-	HostPrefectureCode    int32                    `json:"hostPrefectureCode"`    // 開催場所(都道府県コード)
-	HostCity              string                   `json:"hostCity"`              // 開催場所(市区町村)
-	HostAddressLine1      string                   `json:"hostAddressLine1"`      // 開催場所(住所1)
-	HostAddressLine2      string                   `json:"hostAddressLine2"`      // 開催場所(住所2)
-	StartAt               int64                    `json:"startAt"`               // 募集開始日時
-	EndAt                 int64                    `json:"endAt"`                 // 募集終了日時
+	Title                 string                   `json:"title" binding:"required,max=128"`                      // 体験名
+	Description           string                   `json:"description" binding:"required,max=20000"`              // 説明
+	Public                bool                     `json:"public"`                                                // 公開設定
+	SoldOut               bool                     `json:"soldOut"`                                               // 定員オーバーフラグ
+	CoordinatorID         string                   `json:"coordinatorId" binding:"required"`                      // コーディネータID
+	ProducerID            string                   `json:"producerId" binding:"required"`                         // 生産者ID
+	TypeID                string                   `json:"experienceTypeId" binding:"required"`                   // 体験種別ID
+	Media                 []*CreateExperienceMedia `json:"media" binding:"required,dive"`                         // メディア一覧
+	PriceAdult            int64                    `json:"priceAdult" binding:"required,min=0,max=99"`            // 大人料金
+	PriceJuniorHighSchool int64                    `json:"priceJuniorHighSchool" binding:"required,min=0,max=99"` // 中学生料金
+	PriceElementarySchool int64                    `json:"priceElementarySchool" binding:"required,min=0,max=99"` // 小学生料金
+	PricePreschool        int64                    `json:"pricePreschool" binding:"required,min=0,max=99"`        // 幼児料金
+	PriceSenior           int64                    `json:"priceSenior" binding:"required,min=0,max=99"`           // シニア料金
+	RecommendedPoint1     string                   `json:"recommendedPoint1" binding:"omitempty,max=128"`         // おすすめポイント1
+	RecommendedPoint2     string                   `json:"recommendedPoint2" binding:"omitempty,max=128"`         // おすすめポイント2
+	RecommendedPoint3     string                   `json:"recommendedPoint3" binding:"omitempty,max=128"`         // おすすめポイント3
+	PromotionVideoURL     string                   `json:"promotionVideoUrl" binding:"omitempty,url"`             // 紹介動画URL
+	Duration              int64                    `json:"duration" binding:"min=0"`                              // 体験時間(分)
+	Direction             string                   `json:"direction" binding:"max=2000"`                          // アクセス方法
+	BusinessOpenTime      string                   `json:"businessOpenTime" binding:"time"`                       // 営業開始時間
+	BusinessCloseTime     string                   `json:"businessCloseTime" binding:"time"`                      // 営業終了時間
+	HostPostalCode        string                   `json:"hostPostalCode" binding:"required,numeric,max=16"`      // 開催場所(郵便番号)
+	HostPrefectureCode    int32                    `json:"hostPrefectureCode" binding:"required,min=1,max=47"`    // 開催場所(都道府県コード)
+	HostCity              string                   `json:"hostCity" binding:"required,max=32"`                    // 開催場所(市区町村)
+	HostAddressLine1      string                   `json:"hostAddressLine1" binding:"required,max=64"`            // 開催場所(住所1)
+	HostAddressLine2      string                   `json:"hostAddressLine2" binding:"omitempty,max=64"`           // 開催場所(住所2)
+	StartAt               int64                    `json:"startAt" binding:"required"`                            // 募集開始日時
+	EndAt                 int64                    `json:"endAt" binding:"required,gtfield=StartAt"`              // 募集終了日時
 }
 
 type CreateExperienceMedia struct {
-	URL         string `json:"url"`         // メディアURL
-	IsThumbnail bool   `json:"isThumbnail"` // サムネイルとして使用
+	URL         string `json:"url" binding:"required,url"` // メディアURL
+	IsThumbnail bool   `json:"isThumbnail"`                // サムネイルとして使用
 }
 
 type UpdateExperienceRequest struct {
-	Title                 string                   `json:"title"`                 // 体験名
-	Description           string                   `json:"description"`           // 説明
-	Public                bool                     `json:"public"`                // 公開設定
-	SoldOut               bool                     `json:"soldOut"`               // 定員オーバーフラグ
-	TypeID                string                   `json:"experienceTypeId"`      // 体験種別ID
-	Media                 []*UpdateExperienceMedia `json:"media"`                 // メディア一覧
-	PriceAdult            int64                    `json:"priceAdult"`            // 大人料金
-	PriceJuniorHighSchool int64                    `json:"priceJuniorHighSchool"` // 中学生料金
-	PriceElementarySchool int64                    `json:"priceElementarySchool"` // 小学生料金
-	PricePreschool        int64                    `json:"pricePreschool"`        // 幼児料金
-	PriceSenior           int64                    `json:"priceSenior"`           // シニア料金
-	RecommendedPoint1     string                   `json:"recommendedPoint1"`     // おすすめポイント1
-	RecommendedPoint2     string                   `json:"recommendedPoint2"`     // おすすめポイント2
-	RecommendedPoint3     string                   `json:"recommendedPoint3"`     // おすすめポイント3
-	PromotionVideoURL     string                   `json:"promotionVideoUrl"`     // 紹介動画URL
-	Duration              int64                    `json:"duration"`              // 体験時間(分)
-	Direction             string                   `json:"direction"`             // アクセス方法
-	BusinessOpenTime      string                   `json:"businessOpenTime"`      // 営業開始時間
-	BusinessCloseTime     string                   `json:"businessCloseTime"`     // 営業終了時間
-	HostPostalCode        string                   `json:"hostPostalCode"`        // 開催場所(郵便番号)
-	HostPrefectureCode    int32                    `json:"hostPrefectureCode"`    // 開催場所(都道府県コード)
-	HostCity              string                   `json:"hostCity"`              // 開催場所(市区町村)
-	HostAddressLine1      string                   `json:"hostAddressLine1"`      // 開催場所(住所1)
-	HostAddressLine2      string                   `json:"hostAddressLine2"`      // 開催場所(住所2)
-	StartAt               int64                    `json:"startAt"`               // 募集開始日時
-	EndAt                 int64                    `json:"endAt"`                 // 募集終了日時
+	Title                 string                   `json:"title" binding:"required,max=128"`                      // 体験名
+	Description           string                   `json:"description" binding:"required,max=20000"`              // 説明
+	Public                bool                     `json:"public"`                                                // 公開設定
+	SoldOut               bool                     `json:"soldOut"`                                               // 定員オーバーフラグ
+	TypeID                string                   `json:"experienceTypeId" binding:"required"`                   // 体験種別ID
+	Media                 []*UpdateExperienceMedia `json:"media" binding:"required,dive"`                         // メディア一覧
+	PriceAdult            int64                    `json:"priceAdult" binding:"required,min=0,max=99"`            // 大人料金
+	PriceJuniorHighSchool int64                    `json:"priceJuniorHighSchool" binding:"required,min=0,max=99"` // 中学生料金
+	PriceElementarySchool int64                    `json:"priceElementarySchool" binding:"required,min=0,max=99"` // 小学生料金
+	PricePreschool        int64                    `json:"pricePreschool" binding:"required,min=0,max=99"`        // 幼児料金
+	PriceSenior           int64                    `json:"priceSenior" binding:"required,min=0,max=99"`           // シニア料金
+	RecommendedPoint1     string                   `json:"recommendedPoint1" binding:"omitempty,max=128"`         // おすすめポイント1
+	RecommendedPoint2     string                   `json:"recommendedPoint2" binding:"omitempty,max=128"`         // おすすめポイント2
+	RecommendedPoint3     string                   `json:"recommendedPoint3" binding:"omitempty,max=128"`         // おすすめポイント3
+	PromotionVideoURL     string                   `json:"promotionVideoUrl" binding:"omitempty,url"`             // 紹介動画URL
+	Duration              int64                    `json:"duration" binding:"min=0"`                              // 体験時間(分)
+	Direction             string                   `json:"direction" binding:"max=2000"`                          // アクセス方法
+	BusinessOpenTime      string                   `json:"businessOpenTime" binding:"time"`                       // 営業開始時間
+	BusinessCloseTime     string                   `json:"businessCloseTime" binding:"time"`                      // 営業終了時間
+	HostPostalCode        string                   `json:"hostPostalCode" binding:"required,numeric,max=16"`      // 開催場所(郵便番号)
+	HostPrefectureCode    int32                    `json:"hostPrefectureCode" binding:"required,min=1,max=47"`    // 開催場所(都道府県コード)
+	HostCity              string                   `json:"hostCity" binding:"required,max=32"`                    // 開催場所(市区町村)
+	HostAddressLine1      string                   `json:"hostAddressLine1" binding:"required,max=64"`            // 開催場所(住所1)
+	HostAddressLine2      string                   `json:"hostAddressLine2" binding:"omitempty,max=64"`           // 開催場所(住所2)
+	StartAt               int64                    `json:"startAt" binding:"required"`                            // 募集開始日時
+	EndAt                 int64                    `json:"endAt" binding:"required,gtfield=StartAt"`              // 募集終了日時
 }
 
 type UpdateExperienceMedia struct {
-	URL         string `json:"url"`         // メディアURL
-	IsThumbnail bool   `json:"isThumbnail"` // サムネイルとして使用
+	URL         string `json:"url" binding:"required,url"` // メディアURL
+	IsThumbnail bool   `json:"isThumbnail"`                // サムネイルとして使用
 }

--- a/api/internal/gateway/admin/v1/request/experience_type.go
+++ b/api/internal/gateway/admin/v1/request/experience_type.go
@@ -1,9 +1,9 @@
 package request
 
 type CreateExperienceTypeRequest struct {
-	Name string `json:"name"` // 体験種別名
+	Name string `json:"name" binding:"required,max=32"` // 体験種別名
 }
 
 type UpdateExperienceTypeRequest struct {
-	Name string `json:"name"` // 体験種別名
+	Name string `json:"name" binding:"required,max=32"` // 体験種別名
 }

--- a/api/internal/gateway/admin/v1/request/live.go
+++ b/api/internal/gateway/admin/v1/request/live.go
@@ -1,16 +1,16 @@
 package request
 
 type CreateLiveRequest struct {
-	ProducerID string   `json:"producerId"` // 生産者ID
-	ProductIDs []string `json:"productIds"` // 商品ID一覧
-	Comment    string   `json:"comment"`    // コメント
-	StartAt    int64    `json:"startAt"`    // 配信開始日時
-	EndAt      int64    `json:"endAt"`      // 配信終了日時
+	ProducerID string   `json:"producerId" binding:"required"`               // 生産者ID
+	ProductIDs []string `json:"productIds" binding:"required,dive,required"` // 商品ID一覧
+	Comment    string   `json:"comment" binding:"required,max=2000"`         // コメント
+	StartAt    int64    `json:"startAt" binding:"required"`                  // 配信開始日時
+	EndAt      int64    `json:"endAt" binding:"required,gtfield=StartAt"`    // 配信終了日時
 }
 
 type UpdateLiveRequest struct {
-	ProductIDs []string `json:"productIds"` // 商品ID一覧
-	Comment    string   `json:"comment"`    // コメント
-	StartAt    int64    `json:"startAt"`    // 配信開始日時
-	EndAt      int64    `json:"endAt"`      // 配信終了日時
+	ProductIDs []string `json:"productIds" binding:"required,dive,required"` // 商品ID一覧
+	Comment    string   `json:"comment" binding:"required,max=2000"`         // コメント
+	StartAt    int64    `json:"startAt" binding:"required"`                  // 配信開始日時
+	EndAt      int64    `json:"endAt" binding:"required,gtfield=StartAt"`    // 配信終了日時
 }

--- a/api/internal/gateway/admin/v1/request/live_comment.go
+++ b/api/internal/gateway/admin/v1/request/live_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type UpdateLiveCommentRequest struct {
-	Disabled bool `json:"disabled"` // コメント無効フラグ
+	Disabled bool `json:"disabled" binding:""` // コメント無効フラグ
 }

--- a/api/internal/gateway/admin/v1/request/notification.go
+++ b/api/internal/gateway/admin/v1/request/notification.go
@@ -1,19 +1,19 @@
 package request
 
 type CreateNotificationRequest struct {
-	Type        int32   `json:"type"`        // お知らせ種別
-	Title       string  `json:"title"`       // タイトル
-	Body        string  `json:"body"`        // 本文
-	Note        string  `json:"note"`        // 備考
-	Targets     []int32 `json:"targets"`     // 掲載対象一覧
-	PublishedAt int64   `json:"publishedAt"` // 掲載開始日
-	PromotionID string  `json:"promotionId"` // プロモーションID
+	Type        int32   `json:"type" binding:"required"`                     // お知らせ種別
+	Title       string  `json:"title" binding:"required,max=128"`            // タイトル
+	Body        string  `json:"body" binding:"required,max=2000"`            // 本文
+	Note        string  `json:"note" binding:"omitempty,max=2000"`           // 備考
+	Targets     []int32 `json:"targets" binding:"min=1,max=4,dive,required"` // 掲載対象一覧
+	PublishedAt int64   `json:"publishedAt" binding:"required"`              // 掲載開始日
+	PromotionID string  `json:"promotionId" binding:"omitempty"`             // プロモーションID
 }
 
 type UpdateNotificationRequest struct {
-	Title       string  `json:"title"`       // タイトル
-	Body        string  `json:"body"`        // 本文
-	Note        string  `json:"note"`        // 備考
-	Targets     []int32 `json:"targets"`     // 掲載対象一覧
-	PublishedAt int64   `json:"publishedAt"` // 掲載開始日
+	Title       string  `json:"title" binding:"required,max=128"`            // タイトル
+	Body        string  `json:"body" binding:"required,max=2000"`            // 本文
+	Note        string  `json:"note" binding:"omitempty,max=2000"`           // 備考
+	Targets     []int32 `json:"targets" binding:"min=1,max=4,dive,required"` // 掲載対象一覧
+	PublishedAt int64   `json:"publishedAt" binding:"required"`              // 掲載開始日
 }

--- a/api/internal/gateway/admin/v1/request/order.go
+++ b/api/internal/gateway/admin/v1/request/order.go
@@ -1,23 +1,23 @@
 package request
 
 type DraftOrderRequest struct {
-	ShippingMessage string `json:"shippingMessage"` // 発送連絡時のメッセージ
+	ShippingMessage string `json:"shippingMessage" binding:"omitempty,max=2000"` // 発送連絡時のメッセージ
 }
 
 type CompleteOrderRequest struct {
-	ShippingMessage string `json:"shippingMessage"` // 発送連絡時のメッセージ
+	ShippingMessage string `json:"shippingMessage" binding:"omitempty,max=2000"` // 発送連絡時のメッセージ
 }
 
 type RefundOrderRequest struct {
-	Description string `json:"description"` // 返金理由
+	Description string `json:"description" binding:"required,max=2000"` // 返金理由
 }
 
 type UpdateOrderFulfillmentRequest struct {
-	ShippingCarrier int32  `json:"shippingCarrier"` // 配送会社
-	TrackingNumber  string `json:"trackingNumber"`  // 伝票番号
+	ShippingCarrier int32  `json:"shippingCarrier" binding:"required"` // 配送会社
+	TrackingNumber  string `json:"trackingNumber" binding:"required"`  // 伝票番号
 }
 
 type ExportOrdersRequest struct {
-	ShippingCarrier       int32 `json:"shippingCarrier"`       // 配送会社
-	CharacterEncodingType int32 `json:"characterEncodingType"` // 文字コード種別
+	ShippingCarrier       int32 `json:"shippingCarrier" binding:"required"` // 配送会社
+	CharacterEncodingType int32 `json:"characterEncodingType" binding:""`   // 文字コード種別
 }

--- a/api/internal/gateway/admin/v1/request/payment_system.go
+++ b/api/internal/gateway/admin/v1/request/payment_system.go
@@ -1,5 +1,5 @@
 package request
 
 type UpdatePaymentSystemRequest struct {
-	Status int32 `json:"status"` // 決済システム状態
+	Status int32 `json:"status" binding:"required"` // 決済システム状態
 }

--- a/api/internal/gateway/admin/v1/request/producer.go
+++ b/api/internal/gateway/admin/v1/request/producer.go
@@ -1,46 +1,46 @@
 package request
 
 type CreateProducerRequest struct {
-	CoordinatorID     string `json:"coordinatorId"`     // 担当コーディネータ名
-	Lastname          string `json:"lastname"`          // 姓
-	Firstname         string `json:"firstname"`         // 名
-	LastnameKana      string `json:"lastnameKana"`      // 姓(かな)
-	FirstnameKana     string `json:"firstnameKana"`     // 名(かな)
-	Username          string `json:"username"`          // 表示名
-	Profile           string `json:"profile"`           // 紹介文
-	ThumbnailURL      string `json:"thumbnailUrl"`      // サムネイルURL
-	HeaderURL         string `json:"headerUrl"`         // ヘッダー画像URL
-	PromotionVideoURL string `json:"promotionVideoUrl"` // 紹介映像URL
-	BonusVideoURL     string `json:"bonusVideoUrl"`     // 購入特典映像URL
-	InstagramID       string `json:"instagramId"`       // Instagramアカウント
-	FacebookID        string `json:"facebookId"`        // Facebookアカウント
-	Email             string `json:"email"`             // メールアドレス
-	PhoneNumber       string `json:"phoneNumber"`       // 電話番号
-	PostalCode        string `json:"postalCode"`        // 郵便番号
-	PrefectureCode    int32  `json:"prefectureCode"`    // 都道府県
-	City              string `json:"city"`              // 市区町村
-	AddressLine1      string `json:"addressLine1"`      // 町名・番地
-	AddressLine2      string `json:"addressLine2"`      // ビル名・号室など
+	CoordinatorID     string `json:"coordinatorId" binding:"required"`                 // 担当コーディネータ名
+	Lastname          string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname         string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana      string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana     string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	Username          string `json:"username" binding:"required,max=64"`               // 表示名
+	Profile           string `json:"profile" binding:"max=2000"`                       // 紹介文
+	ThumbnailURL      string `json:"thumbnailUrl" binding:"omitempty,url"`             // サムネイルURL
+	HeaderURL         string `json:"headerUrl" binding:"omitempty,url"`                // ヘッダー画像URL
+	PromotionVideoURL string `json:"promotionVideoUrl" binding:"omitempty,url"`        // 紹介映像URL
+	BonusVideoURL     string `json:"bonusVideoUrl" binding:"omitempty,url"`            // 購入特典映像URL
+	InstagramID       string `json:"instagramId" binding:"omitempty,max=30"`           // Instagramアカウント
+	FacebookID        string `json:"facebookId" binding:"omitempty,max=50"`            // Facebookアカウント
+	Email             string `json:"email" binding:"omitempty,email"`                  // メールアドレス
+	PhoneNumber       string `json:"phoneNumber" binding:"omitempty,e164"`             // 電話番号
+	PostalCode        string `json:"postalCode" binding:"omitempty,numeric,max=16"`    // 郵便番号
+	PrefectureCode    int32  `json:"prefectureCode" binding:"min=0,max=47"`            // 都道府県
+	City              string `json:"city" binding:"max=32"`                            // 市区町村
+	AddressLine1      string `json:"addressLine1" binding:"max=64"`                    // 町名・番地
+	AddressLine2      string `json:"addressLine2" binding:"max=64"`                    // ビル名・号室など
 }
 
 type UpdateProducerRequest struct {
-	Lastname          string `json:"lastname"`          // 姓
-	Firstname         string `json:"firstname"`         // 名
-	LastnameKana      string `json:"lastnameKana"`      // 姓(かな)
-	FirstnameKana     string `json:"firstnameKana"`     // 名(かな)
-	Username          string `json:"username"`          // 表示名
-	Profile           string `json:"profile"`           // 紹介文
-	ThumbnailURL      string `json:"thumbnailUrl"`      // サムネイルURL
-	HeaderURL         string `json:"headerUrl"`         // ヘッダー画像URL
-	PromotionVideoURL string `json:"promotionVideoUrl"` // 紹介映像URL
-	BonusVideoURL     string `json:"bonusVideoUrl"`     // 購入特典映像URL
-	InstagramID       string `json:"instagramId"`       // Instagramアカウント
-	FacebookID        string `json:"facebookId"`        // Facebookアカウント
-	Email             string `json:"email"`             // メールアドレス
-	PhoneNumber       string `json:"phoneNumber"`       // 電話番号
-	PostalCode        string `json:"postalCode"`        // 郵便番号
-	PrefectureCode    int32  `json:"prefectureCode"`    // 都道府県
-	City              string `json:"city"`              // 市区町村
-	AddressLine1      string `json:"addressLine1"`      // 町名・番地
-	AddressLine2      string `json:"addressLine2"`      // ビル名・号室など
+	Lastname          string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname         string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana      string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓(かな)
+	FirstnameKana     string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名(かな)
+	Username          string `json:"username" binding:"required,max=64"`               // 表示名
+	Profile           string `json:"profile" binding:"max=2000"`                       // 紹介文
+	ThumbnailURL      string `json:"thumbnailUrl" binding:"omitempty,url"`             // サムネイルURL
+	HeaderURL         string `json:"headerUrl" binding:"omitempty,url"`                // ヘッダー画像URL
+	PromotionVideoURL string `json:"promotionVideoUrl" binding:"omitempty,url"`        // 紹介映像URL
+	BonusVideoURL     string `json:"bonusVideoUrl" binding:"omitempty,url"`            // 購入特典映像URL
+	InstagramID       string `json:"instagramId" binding:"omitempty,max=30"`           // Instagramアカウント
+	FacebookID        string `json:"facebookId" binding:"omitempty,max=50"`            // Facebookアカウント
+	Email             string `json:"email" binding:"omitempty,email"`                  // メールアドレス
+	PhoneNumber       string `json:"phoneNumber" binding:"omitempty,e164"`             // 電話番号
+	PostalCode        string `json:"postalCode" binding:"omitempty,numeric,max=16"`    // 郵便番号
+	PrefectureCode    int32  `json:"prefectureCode" binding:"min=0,max=47"`            // 都道府県
+	City              string `json:"city" binding:"max=32"`                            // 市区町村
+	AddressLine1      string `json:"addressLine1" binding:"max=64"`                    // 町名・番地
+	AddressLine2      string `json:"addressLine2" binding:"max=64"`                    // ビル名・号室など
 }

--- a/api/internal/gateway/admin/v1/request/product.go
+++ b/api/internal/gateway/admin/v1/request/product.go
@@ -1,69 +1,69 @@
 package request
 
 type CreateProductRequest struct {
-	Name                 string                `json:"name"`                 // 商品名
-	Description          string                `json:"description"`          // 商品説明
-	Public               bool                  `json:"public"`               // 公開フラグ
-	CoordinatorID        string                `json:"coordinatorId"`        // コーディネータID
-	ProducerID           string                `json:"producerId"`           // 生産者ID
-	TypeID               string                `json:"productTypeId"`        // 品目ID
-	TagIDs               []string              `json:"productTagIds"`        // 商品タグID一覧
-	Inventory            int64                 `json:"inventory"`            // 在庫数
-	Weight               float64               `json:"weight"`               // 重量(kg,少数第一位まで)
-	ItemUnit             string                `json:"itemUnit"`             // 数量単位
-	ItemDescription      string                `json:"itemDescription"`      // 数量単位説明
-	Media                []*CreateProductMedia `json:"media"`                // メディア一覧
-	Price                int64                 `json:"price"`                // 販売価格(税込)
-	Cost                 int64                 `json:"cost"`                 // 原価(税込)
-	ExpirationDate       int64                 `json:"expirationDate"`       // 賞味期限(単位:日)
-	RecommendedPoint1    string                `json:"recommendedPoint1"`    // おすすめポイント1
-	RecommendedPoint2    string                `json:"recommendedPoint2"`    // おすすめポイント2
-	RecommendedPoint3    string                `json:"recommendedPoint3"`    // おすすめポイント3
-	StorageMethodType    int32                 `json:"storageMethodType"`    // 保存方法
-	DeliveryType         int32                 `json:"deliveryType"`         // 配送方法
-	Box60Rate            int64                 `json:"box60Rate"`            // 箱の占有率(サイズ:60)
-	Box80Rate            int64                 `json:"box80Rate"`            // 箱の占有率(サイズ:80)
-	Box100Rate           int64                 `json:"box100Rate"`           // 箱の占有率(サイズ:100)
-	OriginPrefectureCode int32                 `json:"originPrefectureCode"` // 原産地(都道府県)
-	OriginCity           string                `json:"originCity"`           // 原産地(市区町村)
-	StartAt              int64                 `json:"startAt"`              // 販売開始日時
-	EndAt                int64                 `json:"endAt"`                // 販売終了日時
+	Name                 string                `json:"name" binding:"required,max=64"`                       // 商品名
+	Description          string                `json:"description" binding:"required,max=2000"`              // 商品説明
+	Public               bool                  `json:"public"`                                               // 公開フラグ
+	CoordinatorID        string                `json:"coordinatorId" binding:"required"`                     // コーディネータID
+	ProducerID           string                `json:"producerId" binding:"required"`                        // 生産者ID
+	TypeID               string                `json:"productTypeId" binding:"required"`                     // 品目ID
+	TagIDs               []string              `json:"productTagIds" binding:"max=8,dive,required"`          // 商品タグID一覧
+	Inventory            int64                 `json:"inventory" binding:"min=0"`                            // 在庫数
+	Weight               float64               `json:"weight" binding:"min=0"`                               // 重量(kg,少数第一位まで)
+	ItemUnit             string                `json:"itemUnit" binding:"required,max=16"`                   // 数量単位
+	ItemDescription      string                `json:"itemDescription" binding:"required,max=64"`            // 数量単位説明
+	Media                []*CreateProductMedia `json:"media" binding:"max=8,dive"`                           // メディア一覧
+	Price                int64                 `json:"price" binding:"min=0"`                                // 販売価格(税込)
+	Cost                 int64                 `json:"cost" binding:"min=0"`                                 // 原価(税込)
+	ExpirationDate       int64                 `json:"expirationDate" binding:"min=0"`                       // 賞味期限(単位:日)
+	RecommendedPoint1    string                `json:"recommendedPoint1" binding:"omitempty,max=128"`        // おすすめポイント1
+	RecommendedPoint2    string                `json:"recommendedPoint2" binding:"omitempty,max=128"`        // おすすめポイント2
+	RecommendedPoint3    string                `json:"recommendedPoint3" binding:"omitempty,max=128"`        // おすすめポイント3
+	StorageMethodType    int32                 `json:"storageMethodType" binding:"required"`                 // 保存方法
+	DeliveryType         int32                 `json:"deliveryType" binding:"required"`                      // 配送方法
+	Box60Rate            int64                 `json:"box60Rate" binding:"min=0,max=600"`                    // 箱の占有率(サイズ:60)
+	Box80Rate            int64                 `json:"box80Rate" binding:"min=0,max=250"`                    // 箱の占有率(サイズ:80)
+	Box100Rate           int64                 `json:"box100Rate" binding:"min=0,max=100"`                   // 箱の占有率(サイズ:100)
+	OriginPrefectureCode int32                 `json:"originPrefectureCode" binding:"required,min=1,max=47"` // 原産地(都道府県)
+	OriginCity           string                `json:"originCity" binding:"max=32"`                          // 原産地(市区町村)
+	StartAt              int64                 `json:"startAt" binding:"required"`                           // 販売開始日時
+	EndAt                int64                 `json:"endAt" binding:"required,gtfield=StartAt"`             // 販売終了日時
 }
 
 type CreateProductMedia struct {
-	URL         string `json:"url"`         // メディアURL
-	IsThumbnail bool   `json:"isThumbnail"` // サムネイルとして使用
+	URL         string `json:"url" binding:"required,url"` // メディアURL
+	IsThumbnail bool   `json:"isThumbnail"`                // サムネイルとして使用
 }
 
 type UpdateProductRequest struct {
-	Name                 string                `json:"name"`                 // 商品名
-	Description          string                `json:"description"`          // 商品説明
-	Public               bool                  `json:"public"`               // 公開フラグ
-	TypeID               string                `json:"productTypeId"`        // 品目ID
-	TagIDs               []string              `json:"productTagIds"`        // 商品タグID一覧
-	Inventory            int64                 `json:"inventory"`            // 在庫数
-	Weight               float64               `json:"weight"`               // 重量(kg,少数第一位まで)
-	ItemUnit             string                `json:"itemUnit"`             // 数量単位
-	ItemDescription      string                `json:"itemDescription"`      // 数量単位説明
-	Media                []*UpdateProductMedia `json:"media"`                // メディア一覧
-	Price                int64                 `json:"price"`                // 販売価格(税込)
-	Cost                 int64                 `json:"cost"`                 // 原価(税込)
-	ExpirationDate       int64                 `json:"expirationDate"`       // 賞味期限(単位:日)
-	RecommendedPoint1    string                `json:"recommendedPoint1"`    // おすすめポイント1
-	RecommendedPoint2    string                `json:"recommendedPoint2"`    // おすすめポイント2
-	RecommendedPoint3    string                `json:"recommendedPoint3"`    // おすすめポイント3
-	StorageMethodType    int32                 `json:"storageMethodType"`    // 保存方法
-	DeliveryType         int32                 `json:"deliveryType"`         // 配送方法
-	Box60Rate            int64                 `json:"box60Rate"`            // 箱の占有率(サイズ:60)
-	Box80Rate            int64                 `json:"box80Rate"`            // 箱の占有率(サイズ:80)
-	Box100Rate           int64                 `json:"box100Rate"`           // 箱の占有率(サイズ:100)
-	OriginPrefectureCode int32                 `json:"originPrefectureCode"` // 原産地(都道府県)
-	OriginCity           string                `json:"originCity"`           // 原産地(市区町村)
-	StartAt              int64                 `json:"startAt"`              // 販売開始日時
-	EndAt                int64                 `json:"endAt"`                // 販売終了日時
+	Name                 string                `json:"name" binding:"required,max=64"`                       // 商品名
+	Description          string                `json:"description" binding:"required,max=2000"`              // 商品説明
+	Public               bool                  `json:"public"`                                               // 公開フラグ
+	TypeID               string                `json:"productTypeId" binding:"required"`                     // 品目ID
+	TagIDs               []string              `json:"productTagIds" binding:"max=8,dive,required"`          // 商品タグID一覧
+	Inventory            int64                 `json:"inventory" binding:"min=0"`                            // 在庫数
+	Weight               float64               `json:"weight" binding:"min=0"`                               // 重量(kg,少数第一位まで)
+	ItemUnit             string                `json:"itemUnit" binding:"required,max=16"`                   // 数量単位
+	ItemDescription      string                `json:"itemDescription" binding:"required,max=64"`            // 数量単位説明
+	Media                []*UpdateProductMedia `json:"media" binding:"max=8,dive"`                           // メディア一覧
+	Price                int64                 `json:"price" binding:"min=0"`                                // 販売価格(税込)
+	Cost                 int64                 `json:"cost" binding:"min=0"`                                 // 原価(税込)
+	ExpirationDate       int64                 `json:"expirationDate" binding:"min=0"`                       // 賞味期限(単位:日)
+	RecommendedPoint1    string                `json:"recommendedPoint1" binding:"omitempty,max=128"`        // おすすめポイント1
+	RecommendedPoint2    string                `json:"recommendedPoint2" binding:"omitempty,max=128"`        // おすすめポイント2
+	RecommendedPoint3    string                `json:"recommendedPoint3" binding:"omitempty,max=128"`        // おすすめポイント3
+	StorageMethodType    int32                 `json:"storageMethodType" binding:"required"`                 // 保存方法
+	DeliveryType         int32                 `json:"deliveryType" binding:"required"`                      // 配送方法
+	Box60Rate            int64                 `json:"box60Rate" binding:"min=0,max=600"`                    // 箱の占有率(サイズ:60)
+	Box80Rate            int64                 `json:"box80Rate" binding:"min=0,max=250"`                    // 箱の占有率(サイズ:80)
+	Box100Rate           int64                 `json:"box100Rate" binding:"min=0,max=100"`                   // 箱の占有率(サイズ:100)
+	OriginPrefectureCode int32                 `json:"originPrefectureCode" binding:"required,min=1,max=47"` // 原産地(都道府県)
+	OriginCity           string                `json:"originCity" binding:"max=32"`                          // 原産地(市区町村)
+	StartAt              int64                 `json:"startAt" binding:"required"`                           // 販売開始日時
+	EndAt                int64                 `json:"endAt" binding:"required,gtfield=StartAt"`             // 販売終了日時
 }
 
 type UpdateProductMedia struct {
-	URL         string `json:"url"`         // メディアURL
-	IsThumbnail bool   `json:"isThumbnail"` // サムネイルとして使用
+	URL         string `json:"url" binding:"required,url"` // メディアURL
+	IsThumbnail bool   `json:"isThumbnail"`                // サムネイルとして使用
 }

--- a/api/internal/gateway/admin/v1/request/product_tag.go
+++ b/api/internal/gateway/admin/v1/request/product_tag.go
@@ -1,9 +1,9 @@
 package request
 
 type CreateProductTagRequest struct {
-	Name string `json:"name"` // 商品タグ名
+	Name string `json:"name" binding:"required,max=32"` // 商品タグ名
 }
 
 type UpdateProductTagRequest struct {
-	Name string `json:"name"` // 商品タグ名
+	Name string `json:"name" binding:"required,max=32"` // 商品タグ名
 }

--- a/api/internal/gateway/admin/v1/request/product_type.go
+++ b/api/internal/gateway/admin/v1/request/product_type.go
@@ -1,11 +1,11 @@
 package request
 
 type CreateProductTypeRequest struct {
-	Name    string `json:"name"`    // 品目名
-	IconURL string `json:"iconUrl"` // アイコンURL
+	Name    string `json:"name" binding:"required,max=32"` // 品目名
+	IconURL string `json:"iconUrl" binding:"required,url"` // アイコンURL
 }
 
 type UpdateProductTypeRequest struct {
-	Name    string `json:"name"`    // 品目名
-	IconURL string `json:"iconUrl"` // アイコンURL
+	Name    string `json:"name" binding:"required,max=32"` // 品目名
+	IconURL string `json:"iconUrl" binding:"required,url"` // アイコンURL
 }

--- a/api/internal/gateway/admin/v1/request/promotion.go
+++ b/api/internal/gateway/admin/v1/request/promotion.go
@@ -1,23 +1,23 @@
 package request
 
 type CreatePromotionRequest struct {
-	Title        string `json:"title"`
-	Description  string `json:"description"`
-	Public       bool   `json:"public"`
-	DiscountType int32  `json:"discountType"`
-	DiscountRate int64  `json:"discountRate"`
-	Code         string `json:"code"`
-	StartAt      int64  `json:"startAt"`
-	EndAt        int64  `json:"endAt"`
+	Title        string `json:"title" binding:"required,max=64"`
+	Description  string `json:"description" binding:"required,max=2000"`
+	Public       bool   `json:"public" binding:""`
+	DiscountType int32  `json:"discountType" binding:"required"`
+	DiscountRate int64  `json:"discountRate" binding:"min=0"`
+	Code         string `json:"code" binding:"len=8"`
+	StartAt      int64  `json:"startAt" binding:"required"`
+	EndAt        int64  `json:"endAt" binding:"required,gtfield=StartAt"`
 }
 
 type UpdatePromotionRequest struct {
-	Title        string `json:"title"`
-	Description  string `json:"description"`
-	Public       bool   `json:"public"`
-	DiscountType int32  `json:"discountType"`
-	DiscountRate int64  `json:"discountRate"`
-	Code         string `json:"code"`
-	StartAt      int64  `json:"startAt"`
-	EndAt        int64  `json:"endAt"`
+	Title        string `json:"title" binding:"required,max=64"`
+	Description  string `json:"description" binding:"required,max=2000"`
+	Public       bool   `json:"public" binding:""`
+	DiscountType int32  `json:"discountType" binding:"required"`
+	DiscountRate int64  `json:"discountRate" binding:"min=0"`
+	Code         string `json:"code" binding:"len=8"`
+	StartAt      int64  `json:"startAt" binding:"required"`
+	EndAt        int64  `json:"endAt" binding:"required,gtfield=StartAt"`
 }

--- a/api/internal/gateway/admin/v1/request/schedule.go
+++ b/api/internal/gateway/admin/v1/request/schedule.go
@@ -1,31 +1,31 @@
 package request
 
 type CreateScheduleRequest struct {
-	CoordinatorID   string `json:"coordinatorId"`   // コーディネータID
-	Title           string `json:"title"`           // タイトル
-	Description     string `json:"description"`     // 説明
-	ThumbnailURL    string `json:"thumbnailUrl"`    // サムネイルURL
-	ImageURL        string `json:"imageUrl"`        // 蓋絵URL
-	OpeningVideoURL string `json:"openingVideoUrl"` // オープニング動画URL
-	Public          bool   `json:"public"`          // 公開フラグ
-	StartAt         int64  `json:"startAt"`         // 配信開始日時
-	EndAt           int64  `json:"endAt"`           // 配信終了日時
+	CoordinatorID   string `json:"coordinatorId" binding:"required"`         // コーディネータID
+	Title           string `json:"title" binding:"required,max=64"`          // タイトル
+	Description     string `json:"description" binding:"required,max=2000"`  // 説明
+	ThumbnailURL    string `json:"thumbnailUrl" binding:"omitempty,url"`     // サムネイルURL
+	ImageURL        string `json:"imageUrl" binding:"omitempty,url"`         // 蓋絵URL
+	OpeningVideoURL string `json:"openingVideoUrl" binding:"omitempty,url"`  // オープニング動画URL
+	Public          bool   `json:"public" binding:""`                        // 公開フラグ
+	StartAt         int64  `json:"startAt" binding:"required"`               // 配信開始日時
+	EndAt           int64  `json:"endAt" binding:"required,gtfield=StartAt"` // 配信終了日時
 }
 
 type UpdateScheduleRequest struct {
-	Title           string `json:"title"`           // タイトル
-	Description     string `json:"description"`     // 説明
-	ThumbnailURL    string `json:"thumbnailUrl"`    // サムネイルURL
-	ImageURL        string `json:"imageUrl"`        // 蓋絵URL
-	OpeningVideoURL string `json:"openingVideoUrl"` // オープニング動画URL
-	StartAt         int64  `json:"startAt"`         // 配信開始日時
-	EndAt           int64  `json:"endAt"`           // 配信終了日時
+	Title           string `json:"title" binding:"required,max=64"`          // タイトル
+	Description     string `json:"description" binding:"required,max=2000"`  // 説明
+	ThumbnailURL    string `json:"thumbnailUrl" binding:"omitempty,url"`     // サムネイルURL
+	ImageURL        string `json:"imageUrl" binding:"omitempty,url"`         // 蓋絵URL
+	OpeningVideoURL string `json:"openingVideoUrl" binding:"omitempty,url"`  // オープニング動画URL
+	StartAt         int64  `json:"startAt" binding:"required"`               // 配信開始日時
+	EndAt           int64  `json:"endAt" binding:"required,gtfield=StartAt"` // 配信終了日時
 }
 
 type ApproveScheduleRequest struct {
-	Approved bool `json:"approved"` // 承認フラグ
+	Approved bool `json:"approved" binding:""` // 承認フラグ
 }
 
 type PublishScheduleRequest struct {
-	Public bool `json:"public"` // 公開フラグ
+	Public bool `json:"public" binding:""` // 公開フラグ
 }

--- a/api/internal/gateway/admin/v1/request/shipping.go
+++ b/api/internal/gateway/admin/v1/request/shipping.go
@@ -1,71 +1,71 @@
 package request
 
 type CreateShippingRequest struct {
-	Name              string                `json:"name"`              // 配送設定名
-	Box60Rates        []*CreateShippingRate `json:"box60Rates"`        // 箱サイズ60の通常便配送料一覧
-	Box60Frozen       int64                 `json:"box60Frozen"`       // 箱サイズ60の冷凍便追加配送料(税込)
-	Box80Rates        []*CreateShippingRate `json:"box80Rates"`        // 箱サイズ80の通常便配送料一覧
-	Box80Frozen       int64                 `json:"box80Frozen"`       // 箱サイズ80の冷凍便追加配送料(税込)
-	Box100Rates       []*CreateShippingRate `json:"box100Rates"`       // 箱サイズ100の通常便配送料一覧
-	Box100Frozen      int64                 `json:"box100Frozen"`      // 箱サイズ100の冷凍便追加配送料(税込)
-	HasFreeShipping   bool                  `json:"hasFreeShipping"`   // 送料無料オプションの有無
-	FreeShippingRates int64                 `json:"freeShippingRates"` // 送料無料になる金額(税込)
+	Name              string                `json:"name" binding:"required,max=64"`                       // 配送設定名
+	Box60Rates        []*CreateShippingRate `json:"box60Rates" binding:"required,dive"`                   // 箱サイズ60の通常便配送料一覧
+	Box60Frozen       int64                 `json:"box60Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ60の冷凍便追加配送料(税込)
+	Box80Rates        []*CreateShippingRate `json:"box80Rates" binding:"required,dive"`                   // 箱サイズ80の通常便配送料一覧
+	Box80Frozen       int64                 `json:"box80Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ80の冷凍便追加配送料(税込)
+	Box100Rates       []*CreateShippingRate `json:"box100Rates" binding:"required,dive"`                  // 箱サイズ100の通常便配送料一覧
+	Box100Frozen      int64                 `json:"box100Frozen" binding:"required,min=0,lt=10000000000"` // 箱サイズ100の冷凍便追加配送料(税込)
+	HasFreeShipping   bool                  `json:"hasFreeShipping"`                                      // 送料無料オプションの有無
+	FreeShippingRates int64                 `json:"freeShippingRates" binding:"min=0,lt=10000000000"`     // 送料無料になる金額(税込)
 }
 
 type CreateShippingRate struct {
-	Name            string  `json:"name"`            // 配送料金設定名
-	Price           int64   `json:"price"`           // 配送料金(税込)
-	PrefectureCodes []int32 `json:"prefectureCodes"` // 対象都道府県一覧
+	Name            string  `json:"name" binding:"required,max=64"`                       // 配送料金設定名
+	Price           int64   `json:"price" binding:"required,min=0,lt=10000000000"`        // 配送料金(税込)
+	PrefectureCodes []int32 `json:"prefectureCodes" binding:"required,dive,min=1,max=47"` // 対象都道府県一覧
 }
 
 type UpdateShippingRequest struct {
-	Name              string                `json:"name"`              // 配送設定名
-	Box60Rates        []*UpdateShippingRate `json:"box60Rates"`        // 箱サイズ60の通常便配送料一覧
-	Box60Frozen       int64                 `json:"box60Frozen"`       // 箱サイズ60の冷凍便追加配送料(税込)
-	Box80Rates        []*UpdateShippingRate `json:"box80Rates"`        // 箱サイズ80の通常便配送料一覧
-	Box80Frozen       int64                 `json:"box80Frozen"`       // 箱サイズ80の冷凍便追加配送料(税込)
-	Box100Rates       []*UpdateShippingRate `json:"box100Rates"`       // 箱サイズ100の通常便配送料一覧
-	Box100Frozen      int64                 `json:"box100Frozen"`      // 箱サイズ100の冷凍便追加配送料(税込)
-	HasFreeShipping   bool                  `json:"hasFreeShipping"`   // 送料無料オプションの有無
-	FreeShippingRates int64                 `json:"freeShippingRates"` // 送料無料になる金額(税込)
+	Name              string                `json:"name" binding:"required,max=64"`                       // 配送設定名
+	Box60Rates        []*UpdateShippingRate `json:"box60Rates" binding:"required,dive"`                   // 箱サイズ60の通常便配送料一覧
+	Box60Frozen       int64                 `json:"box60Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ60の冷凍便追加配送料(税込)
+	Box80Rates        []*UpdateShippingRate `json:"box80Rates" binding:"required,dive"`                   // 箱サイズ80の通常便配送料一覧
+	Box80Frozen       int64                 `json:"box80Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ80の冷凍便追加配送料(税込)
+	Box100Rates       []*UpdateShippingRate `json:"box100Rates" binding:"required,dive"`                  // 箱サイズ100の通常便配送料一覧
+	Box100Frozen      int64                 `json:"box100Frozen" binding:"required,min=0,lt=10000000000"` // 箱サイズ100の冷凍便追加配送料(税込)
+	HasFreeShipping   bool                  `json:"hasFreeShipping"`                                      // 送料無料オプションの有無
+	FreeShippingRates int64                 `json:"freeShippingRates" binding:"min=0,lt=10000000000"`     // 送料無料になる金額(税込)
 }
 
 type UpdateShippingRate struct {
-	Name            string  `json:"name"`            // 配送料金設定名
-	Price           int64   `json:"price"`           // 配送料金(税込)
-	PrefectureCodes []int32 `json:"prefectureCodes"` // 対象都道府県一覧
+	Name            string  `json:"name" binding:"required,max=64"`                       // 配送料金設定名
+	Price           int64   `json:"price" binding:"required,min=0,lt=10000000000"`        // 配送料金(税込)
+	PrefectureCodes []int32 `json:"prefectureCodes" binding:"required,dive,min=1,max=47"` // 対象都道府県一覧
 }
 
 type UpsertShippingRequest struct {
-	Box60Rates        []*UpsertShippingRate `json:"box60Rates"`        // 箱サイズ60の通常便配送料一覧
-	Box60Frozen       int64                 `json:"box60Frozen"`       // 箱サイズ60の冷凍便追加配送料(税込)
-	Box80Rates        []*UpsertShippingRate `json:"box80Rates"`        // 箱サイズ80の通常便配送料一覧
-	Box80Frozen       int64                 `json:"box80Frozen"`       // 箱サイズ80の冷凍便追加配送料(税込)
-	Box100Rates       []*UpsertShippingRate `json:"box100Rates"`       // 箱サイズ100の通常便配送料一覧
-	Box100Frozen      int64                 `json:"box100Frozen"`      // 箱サイズ100の冷凍便追加配送料(税込)
-	HasFreeShipping   bool                  `json:"hasFreeShipping"`   // 送料無料オプションの有無
-	FreeShippingRates int64                 `json:"freeShippingRates"` // 送料無料になる金額(税込)
+	Box60Rates        []*UpsertShippingRate `json:"box60Rates" binding:"required,dive"`                   // 箱サイズ60の通常便配送料一覧
+	Box60Frozen       int64                 `json:"box60Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ60の冷凍便追加配送料(税込)
+	Box80Rates        []*UpsertShippingRate `json:"box80Rates" binding:"required,dive"`                   // 箱サイズ80の通常便配送料一覧
+	Box80Frozen       int64                 `json:"box80Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ80の冷凍便追加配送料(税込)
+	Box100Rates       []*UpsertShippingRate `json:"box100Rates" binding:"required,dive"`                  // 箱サイズ100の通常便配送料一覧
+	Box100Frozen      int64                 `json:"box100Frozen" binding:"required,min=0,lt=10000000000"` // 箱サイズ100の冷凍便追加配送料(税込)
+	HasFreeShipping   bool                  `json:"hasFreeShipping"`                                      // 送料無料オプションの有無
+	FreeShippingRates int64                 `json:"freeShippingRates" binding:"min=0,lt=10000000000"`     // 送料無料になる金額(税込)
 }
 
 type UpsertShippingRate struct {
-	Name            string  `json:"name"`            // 配送料金設定名
-	Price           int64   `json:"price"`           // 配送料金(税込)
-	PrefectureCodes []int32 `json:"prefectureCodes"` // 対象都道府県一覧
+	Name            string  `json:"name" binding:"required,max=64"`                       // 配送料金設定名
+	Price           int64   `json:"price" binding:"required,min=0,lt=10000000000"`        // 配送料金(税込)
+	PrefectureCodes []int32 `json:"prefectureCodes" binding:"required,dive,min=1,max=47"` // 対象都道府県一覧
 }
 
 type UpdateDefaultShippingRequest struct {
-	Box60Rates        []*UpdateDefaultShippingRate `json:"box60Rates"`        // 箱サイズ60の通常便配送料一覧
-	Box60Frozen       int64                        `json:"box60Frozen"`       // 箱サイズ60の冷凍便追加配送料(税込)
-	Box80Rates        []*UpdateDefaultShippingRate `json:"box80Rates"`        // 箱サイズ80の通常便配送料一覧
-	Box80Frozen       int64                        `json:"box80Frozen"`       // 箱サイズ80の冷凍便追加配送料(税込)
-	Box100Rates       []*UpdateDefaultShippingRate `json:"box100Rates"`       // 箱サイズ100の通常便配送料一覧
-	Box100Frozen      int64                        `json:"box100Frozen"`      // 箱サイズ100の冷凍便追加配送料(税込)
-	HasFreeShipping   bool                         `json:"hasFreeShipping"`   // 送料無料オプションの有無
-	FreeShippingRates int64                        `json:"freeShippingRates"` // 送料無料になる金額(税込)
+	Box60Rates        []*UpdateDefaultShippingRate `json:"box60Rates" binding:"required,dive"`                   // 箱サイズ60の通常便配送料一覧
+	Box60Frozen       int64                        `json:"box60Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ60の冷凍便追加配送料(税込)
+	Box80Rates        []*UpdateDefaultShippingRate `json:"box80Rates" binding:"required,dive"`                   // 箱サイズ80の通常便配送料一覧
+	Box80Frozen       int64                        `json:"box80Frozen" binding:"required,min=0,lt=10000000000"`  // 箱サイズ80の冷凍便追加配送料(税込)
+	Box100Rates       []*UpdateDefaultShippingRate `json:"box100Rates" binding:"required,dive"`                  // 箱サイズ100の通常便配送料一覧
+	Box100Frozen      int64                        `json:"box100Frozen" binding:"required,min=0,lt=10000000000"` // 箱サイズ100の冷凍便追加配送料(税込)
+	HasFreeShipping   bool                         `json:"hasFreeShipping"`                                      // 送料無料オプションの有無
+	FreeShippingRates int64                        `json:"freeShippingRates" binding:"min=0,lt=10000000000"`     // 送料無料になる金額(税込)
 }
 
 type UpdateDefaultShippingRate struct {
-	Name            string  `json:"name"`            // 配送料金設定名
-	Price           int64   `json:"price"`           // 配送料金(税込)
-	PrefectureCodes []int32 `json:"prefectureCodes"` // 対象都道府県一覧
+	Name            string  `json:"name" binding:"required,max=64"`                       // 配送料金設定名
+	Price           int64   `json:"price" binding:"required,min=0,lt=10000000000"`        // 配送料金(税込)
+	PrefectureCodes []int32 `json:"prefectureCodes" binding:"required,dive,min=1,max=47"` // 対象都道府県一覧
 }

--- a/api/internal/gateway/admin/v1/request/shop.go
+++ b/api/internal/gateway/admin/v1/request/shop.go
@@ -3,7 +3,7 @@ package request
 import "time"
 
 type UpdateShopRequest struct {
-	Name           string         `json:"name"`           // 店舗名
-	ProductTypeIDs []string       `json:"productTypeIds"` // 取り扱い品目一覧
-	BusinessDays   []time.Weekday `json:"businessDays"`   // 営業曜日(発送可能日)
+	Name           string         `json:"name" binding:"required,max=64"`                  // 店舗名
+	ProductTypeIDs []string       `json:"productTypeIds" binding:"required,dive,required"` // 取り扱い品目一覧
+	BusinessDays   []time.Weekday `json:"businessDays" binding:"max=7,unique"`             // 営業曜日(発送可能日)
 }

--- a/api/internal/gateway/admin/v1/request/spot.go
+++ b/api/internal/gateway/admin/v1/request/spot.go
@@ -1,23 +1,23 @@
 package request
 
 type CreateSpotRequest struct {
-	TypeID       string  `json:"spotTypeId"`   // スポット種別ID
-	Name         string  `json:"name"`         // スポット名
-	Description  string  `json:"description"`  // 説明
-	ThumbnailURL string  `json:"thumbnailUrl"` // サムネイルURL
-	Latitude     float64 `json:"latitude"`     // 緯度
-	Longitude    float64 `json:"longitude"`    // 経度
+	TypeID       string  `json:"spotTypeId" binding:"required"`                 // スポット種別ID
+	Name         string  `json:"name" binding:"required,max=64"`                // スポット名
+	Description  string  `json:"description" binding:"omitempty,max=2000"`      // 説明
+	ThumbnailURL string  `json:"thumbnailUrl" binding:"omitempty,url"`          // サムネイルURL
+	Latitude     float64 `json:"latitude" binding:"required,min=-90,max=90"`    // 緯度
+	Longitude    float64 `json:"longitude" binding:"required,min=-180,max=180"` // 経度
 }
 
 type UpdateSpotRequest struct {
-	TypeID       string  `json:"spotTypeId"`   // スポット種別ID
-	Name         string  `json:"name"`         // スポット名
-	Description  string  `json:"description"`  // 説明
-	ThumbnailURL string  `json:"thumbnailUrl"` // サムネイルURL
-	Latitude     float64 `json:"latitude"`     // 緯度
-	Longitude    float64 `json:"longitude"`    // 経度
+	TypeID       string  `json:"spotTypeId" binding:"required"`                 // スポット種別ID
+	Name         string  `json:"name" binding:"required,max=64"`                // スポット名
+	Description  string  `json:"description" binding:"omitempty,max=2000"`      // 説明
+	ThumbnailURL string  `json:"thumbnailUrl" binding:"omitempty,url"`          // サムネイルURL
+	Latitude     float64 `json:"latitude" binding:"required,min=-90,max=90"`    // 緯度
+	Longitude    float64 `json:"longitude" binding:"required,min=-180,max=180"` // 経度
 }
 
 type ApproveSpotRequest struct {
-	Approved bool `json:"approved"` // 承認フラグ
+	Approved bool `json:"approved" binding:""` // 承認フラグ
 }

--- a/api/internal/gateway/admin/v1/request/spot_type.go
+++ b/api/internal/gateway/admin/v1/request/spot_type.go
@@ -1,9 +1,9 @@
 package request
 
 type CreateSpotTypeRequest struct {
-	Name string `json:"name"` // スポット種別名
+	Name string `json:"name" binding:"required,max=32"` // スポット種別名
 }
 
 type UpdateSpotTypeRequest struct {
-	Name string `json:"name"` // スポット種別名
+	Name string `json:"name" binding:"required,max=32"` // スポット種別名
 }

--- a/api/internal/gateway/admin/v1/request/thread.go
+++ b/api/internal/gateway/admin/v1/request/thread.go
@@ -1,15 +1,15 @@
 package request
 
 type CreateThreadRequest struct {
-	ContactID string `json:"contactId"` // お問い合わせID
-	UserID    string `json:"userId"`    // 送信者ID
-	Content   string `json:"content"`   // 内容
-	UserType  int32  `json:"userType"`  // 送信者種別(不明:0, admin:1, uer:2, guest:3)
+	ContactID string `json:"contactId" binding:"required"`        // お問い合わせID
+	UserID    string `json:"userId" binding:"required"`           // 送信者ID
+	Content   string `json:"content" binding:"required,max=1000"` // 内容
+	UserType  int32  `json:"userType" binding:"min=0,max=3"`      // 送信者種別(不明:0, admin:1, uer:2, guest:3)
 }
 
 type UpdateThreadRequest struct {
-	ThreadID string `json:"threadId"` // お問い合わせID
-	UserID   string `json:"userId"`   // 送信者ID
-	Content  string `json:"content"`  // 内容
-	UserType int32  `json:"userType"` // 送信者種別(不明:0, admin:1, uer:2, guest:3)
+	ThreadID string `json:"threadId" binding:"required"`         // お問い合わせID
+	UserID   string `json:"userId" binding:"required"`           // 送信者ID
+	Content  string `json:"content" binding:"required,max=1000"` // 内容
+	UserType int32  `json:"userType" binding:"min=0,max=3"`      // 送信者種別(不明:0, admin:1, uer:2, guest:3)
 }

--- a/api/internal/gateway/admin/v1/request/uploader.go
+++ b/api/internal/gateway/admin/v1/request/uploader.go
@@ -1,5 +1,5 @@
 package request
 
 type GetUploadURLRequest struct {
-	FileType string `json:"fileType"` // ファイル種別
+	FileType string `json:"fileType" binding:"required"` // ファイル種別
 }

--- a/api/internal/gateway/admin/v1/request/video.go
+++ b/api/internal/gateway/admin/v1/request/video.go
@@ -1,31 +1,31 @@
 package request
 
 type CreateVideoRequest struct {
-	Title             string   `json:"title"`             // タイトル
-	Description       string   `json:"description"`       // 説明
-	CoordinatorID     string   `json:"coordinatorId"`     // コーディネータID
-	ProductIDs        []string `json:"productIds"`        // 商品ID一覧
-	ExperienceIDs     []string `json:"experienceIds"`     // 体験ID一覧
-	ThumbnailURL      string   `json:"thumbnailUrl"`      // サムネイルURL
-	VideoURL          string   `json:"videoUrl"`          // 動画URL
-	Public            bool     `json:"public"`            // 公開設定
-	Limited           bool     `json:"limited"`           // 限定公開設定
-	DisplayProduct    bool     `json:"displayProduct"`    // 商品への表示設定
-	DisplayExperience bool     `json:"displayExperience"` // 体験への表示設定
-	PublishedAt       int64    `json:"publishedAt"`       // 公開日時
+	Title             string   `json:"title" binding:"required,max=128"`        // タイトル
+	Description       string   `json:"description" binding:"required,max=2000"` // 説明
+	CoordinatorID     string   `json:"coordinatorId" binding:"required"`        // コーディネータID
+	ProductIDs        []string `json:"productIds" binding:"dive,required"`      // 商品ID一覧
+	ExperienceIDs     []string `json:"experienceIds" binding:"dive,required"`   // 体験ID一覧
+	ThumbnailURL      string   `json:"thumbnailUrl" binding:"required,url"`     // サムネイルURL
+	VideoURL          string   `json:"videoUrl" binding:"required,url"`         // 動画URL
+	Public            bool     `json:"public" binding:""`                       // 公開設定
+	Limited           bool     `json:"limited" binding:""`                      // 限定公開設定
+	DisplayProduct    bool     `json:"displayProduct" binding:""`               // 商品への表示設定
+	DisplayExperience bool     `json:"displayExperience" binding:""`            // 体験への表示設定
+	PublishedAt       int64    `json:"publishedAt" binding:"required"`          // 公開日時
 }
 
 type UpdateVideoRequest struct {
-	Title             string   `json:"title"`             // タイトル
-	Description       string   `json:"description"`       // 説明
-	CategoryIDs       []string `json:"categoryIds"`       // カテゴリID一覧
-	ProductIDs        []string `json:"productIds"`        // 商品ID一覧
-	ExperienceIDs     []string `json:"experienceIds"`     // 体験ID一覧
-	ThumbnailURL      string   `json:"thumbnailUrl"`      // サムネイルURL
-	VideoURL          string   `json:"videoUrl"`          // 動画URL
-	Public            bool     `json:"public"`            // 公開設定
-	Limited           bool     `json:"limited"`           // 限定公開設定
-	DisplayProduct    bool     `json:"displayProduct"`    // 商品への表示設定
-	DisplayExperience bool     `json:"displayExperience"` // 体験への表示設定
-	PublishedAt       int64    `json:"publishedAt"`       // 公開日時
+	Title             string   `json:"title" binding:"required,max=128"`        // タイトル
+	Description       string   `json:"description" binding:"required,max=2000"` // 説明
+	CoordinatorID     string   `json:"coordinatorId" binding:"required"`        // コーディネータID
+	ProductIDs        []string `json:"productIds" binding:"dive,required"`      // 商品ID一覧
+	ExperienceIDs     []string `json:"experienceIds" binding:"dive,required"`   // 体験ID一覧
+	ThumbnailURL      string   `json:"thumbnailUrl" binding:"required,url"`     // サムネイルURL
+	VideoURL          string   `json:"videoUrl" binding:"required,url"`         // 動画URL
+	Public            bool     `json:"public" binding:""`                       // 公開設定
+	Limited           bool     `json:"limited" binding:""`                      // 限定公開設定
+	DisplayProduct    bool     `json:"displayProduct" binding:""`               // 商品への表示設定
+	DisplayExperience bool     `json:"displayExperience" binding:""`            // 体験への表示設定
+	PublishedAt       int64    `json:"publishedAt" binding:"required"`          // 公開日時
 }

--- a/api/internal/gateway/admin/v1/request/video_comment.go
+++ b/api/internal/gateway/admin/v1/request/video_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type UpdateVideoCommentRequest struct {
-	Disabled bool `json:"disabled"` // コメント無効フラグ
+	Disabled bool `json:"disabled" binding:""` // コメント無効フラグ
 }

--- a/api/internal/gateway/user/facility/auth/jwt.go
+++ b/api/internal/gateway/user/facility/auth/jwt.go
@@ -138,7 +138,7 @@ func (g *jwtGenerator) DeleteRefreshToken(ctx context.Context, userID string) er
 		"user_id": userID,
 	}
 	tokens := RefreshTokens{}
-	if err := g.cache.Scan(ctx, tokens, filter); err != nil {
+	if err := g.cache.Scan(ctx, &tokens, filter); err != nil {
 		return fmt.Errorf("auth: failed to scan refresh tokens: %w", err)
 	}
 	if len(tokens) == 0 {

--- a/api/internal/gateway/user/facility/request/checkout.go
+++ b/api/internal/gateway/user/facility/request/checkout.go
@@ -1,20 +1,20 @@
 package request
 
 type CheckoutRequest struct {
-	RequestID     string              `json:"requestId"`     // 支払いキー(重複判定用)
-	CoordinatorID string              `json:"coordinatorId"` // コーディネータID
-	BoxNumber     int64               `json:"boxNumber"`     // 箱の通番（箱単位で購入する場合）
-	PromotionCode string              `json:"promotionCode"` // プロモーションコード
-	PaymentMethod int32               `json:"paymentMethod"` // 支払い方法
-	CreditCard    *CheckoutCreditCard `json:"creditCard"`    // クレジットカード決済情報
-	CallbackURL   string              `json:"callbackUrl"`   // 決済完了後のリダイレクト先URL
-	Total         int64               `json:"total"`         // 支払い合計金額（誤り検出用）
+	RequestID     string              `json:"requestId" binding:"required"`            // 支払いキー(重複判定用)
+	CoordinatorID string              `json:"coordinatorId" binding:"required"`        // コーディネータID
+	BoxNumber     int64               `json:"boxNumber" binding:"min=0"`               // 箱の通番（箱単位で購入する場合）
+	PromotionCode string              `json:"promotionCode" binding:"omitempty,len=8"` // プロモーションコード
+	PaymentMethod int32               `json:"paymentMethod" binding:"required"`        // 支払い方法
+	CreditCard    *CheckoutCreditCard `json:"creditCard" binding:"omitempty,dive"`     // クレジットカード決済情報
+	CallbackURL   string              `json:"callbackUrl" binding:"required,http_url"` // 決済完了後のリダイレクト先URL
+	Total         int64               `json:"total" binding:"min=0"`                   // 支払い合計金額（誤り検出用）
 }
 
 type CheckoutCreditCard struct {
-	Name              string `json:"name"`              // カード名義
-	Number            string `json:"number"`            // カード番号
-	Month             int64  `json:"month"`             // 有効期限（月）
-	Year              int64  `json:"year"`              // 有効期限（年）
-	VerificationValue string `json:"verificationValue"` // セキュリティコード
+	Name              string `json:"name" binding:"required"`                         // カード名義
+	Number            string `json:"number" binding:"required,credit_card"`           // カード番号
+	Month             int64  `json:"month" binding:"min=1,max=12"`                    // 有効期限（月）
+	Year              int64  `json:"year" binding:"min=2000,max=2100"`                // 有効期限（年）
+	VerificationValue string `json:"verificationValue" binding:"min=3,max=4,numeric"` // セキュリティコード
 }

--- a/api/internal/gateway/user/v1/request/address.go
+++ b/api/internal/gateway/user/v1/request/address.go
@@ -1,29 +1,29 @@
 package request
 
 type CreateAddressRequest struct {
-	Lastname       string `json:"lastname"`       // 姓
-	Firstname      string `json:"firstname"`      // 名
-	LastnameKana   string `json:"lastnameKana"`   // 姓（かな）
-	FirstnameKana  string `json:"firstnameKana"`  // 名（かな）
-	PostalCode     string `json:"postalCode"`     // 郵便番号
-	PrefectureCode int32  `json:"prefectureCode"` // 都道府県
-	City           string `json:"city"`           // 市区町村
-	AddressLine1   string `json:"addressLine1"`   // 町名・番地
-	AddressLine2   string `json:"addressLine2"`   // ビル名・号室など
-	PhoneNumber    string `json:"phoneNumber"`    // 電話番号
-	IsDefault      bool   `json:"isDefault"`      // デフォルト設定フラグ
+	Lastname       string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname      string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana   string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓（かな）
+	FirstnameKana  string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名（かな）
+	PostalCode     string `json:"postalCode" binding:"required,max=16,numeric"`     // 郵便番号
+	PrefectureCode int32  `json:"prefectureCode" binding:"required,min=1,max=47"`   // 都道府県
+	City           string `json:"city" binding:"required,max=32"`                   // 市区町村
+	AddressLine1   string `json:"addressLine1" binding:"required,max=64"`           // 町名・番地
+	AddressLine2   string `json:"addressLine2" binding:"omitempty,max=64"`          // ビル名・号室など
+	PhoneNumber    string `json:"phoneNumber" binding:"required,phone_number"`      // 電話番号
+	IsDefault      bool   `json:"isDefault"`                                        // デフォルト設定フラグ
 }
 
 type UpdateAddressRequest struct {
-	Lastname       string `json:"lastname"`       // 姓
-	Firstname      string `json:"firstname"`      // 名
-	LastnameKana   string `json:"lastnameKana"`   // 姓（かな）
-	FirstnameKana  string `json:"firstnameKana"`  // 名（かな）
-	PostalCode     string `json:"postalCode"`     // 郵便番号
-	PrefectureCode int32  `json:"prefectureCode"` // 都道府県
-	City           string `json:"city"`           // 市区町村
-	AddressLine1   string `json:"addressLine1"`   // 町名・番地
-	AddressLine2   string `json:"addressLine2"`   // ビル名・号室など
-	PhoneNumber    string `json:"phoneNumber"`    // 電話番号
-	IsDefault      bool   `json:"isDefault"`      // デフォルト設定フラグ
+	Lastname       string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname      string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana   string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓（かな）
+	FirstnameKana  string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名（かな）
+	PostalCode     string `json:"postalCode" binding:"required,max=16,numeric"`     // 郵便番号
+	PrefectureCode int32  `json:"prefectureCode" binding:"required,min=1,max=47"`   // 都道府県
+	City           string `json:"city" binding:"required,max=32"`                   // 市区町村
+	AddressLine1   string `json:"addressLine1" binding:"required,max=64"`           // 町名・番地
+	AddressLine2   string `json:"addressLine2" binding:"omitempty,max=64"`          // ビル名・号室など
+	PhoneNumber    string `json:"phoneNumber" binding:"required,phone_number"`      // 電話番号
+	IsDefault      bool   `json:"isDefault"`                                        // デフォルト設定フラグ
 }

--- a/api/internal/gateway/user/v1/request/auth.go
+++ b/api/internal/gateway/user/v1/request/auth.go
@@ -1,27 +1,27 @@
 package request
 
 type SignInRequest struct {
-	Username string `json:"username"` // ユーザー名 (メールアドレス,電話番号)
-	Password string `json:"password"` // パスワード
+	Username string `json:"username" binding:"required"` // ユーザー名 (メールアドレス,電話番号)
+	Password string `json:"password" binding:"required"` // パスワード
 }
 
 type RefreshAuthTokenRequest struct {
-	RefreshToken string `json:"refreshToken"` // 更新トークン
+	RefreshToken string `json:"refreshToken" binding:"required"` // 更新トークン
 }
 
 type UpdateAuthPasswordRequest struct {
-	OldPassword          string `json:"oldPassword"`          // 現在のパスワード
-	NewPassword          string `json:"newPassword"`          // 新しいパスワード
-	PasswordConfirmation string `json:"passwordConfirmation"` // パスワード (確認用)
+	OldPassword          string `json:"oldPassword" binding:"required"`                              // 現在のパスワード
+	NewPassword          string `json:"newPassword" binding:"min=8,max=32"`                          // 新しいパスワード
+	PasswordConfirmation string `json:"passwordConfirmation" binding:"required,eqfield=NewPassword"` // パスワード (確認用)
 }
 
 type ForgotAuthPasswordRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }
 
 type ResetAuthPasswordRequest struct {
-	Email                string `json:"email"`                // メールアドレス
-	VerifyCode           string `json:"verifyCode"`           // 検証コード
-	Password             string `json:"password"`             // パスワード
-	PasswordConfirmation string `json:"passwordConfirmation"` // パスワード (確認用)
+	Email                string `json:"email" binding:"required,email"`                           // メールアドレス
+	VerifyCode           string `json:"verifyCode" binding:"required"`                            // 検証コード
+	Password             string `json:"password" binding:"min=8,max=32"`                          // パスワード
+	PasswordConfirmation string `json:"passwordConfirmation" binding:"required,eqfield=Password"` // パスワード (確認用)
 }

--- a/api/internal/gateway/user/v1/request/auth_user.go
+++ b/api/internal/gateway/user/v1/request/auth_user.go
@@ -1,69 +1,69 @@
 package request
 
 type CreateAuthUserRequest struct {
-	Username             string `json:"username"`             // ユーザー名(表示名)
-	AccountID            string `json:"accountId"`            // ユーザーID(検索名)
-	Lastname             string `json:"lastname"`             // 姓
-	Firstname            string `json:"firstname"`            // 名
-	LastnameKana         string `json:"lastnameKana"`         // 姓（かな）
-	FirstnameKana        string `json:"firstnameKana"`        // 名（かな）
-	Email                string `json:"email"`                // メールアドレス
-	PhoneNumber          string `json:"phoneNumber"`          // 電話番号
-	Password             string `json:"password"`             // パスワード
-	PasswordConfirmation string `json:"passwordConfirmation"` // パスワード (確認用)
+	Username             string `json:"username" binding:"required,max=32"`                       // ユーザー名(表示名)
+	AccountID            string `json:"accountId" binding:"required,max=32,account_id"`           // ユーザーID(検索名)
+	Lastname             string `json:"lastname" binding:"required,max=16"`                       // 姓
+	Firstname            string `json:"firstname" binding:"required,max=16"`                      // 名
+	LastnameKana         string `json:"lastnameKana" binding:"required,max=32,hiragana"`          // 姓（かな）
+	FirstnameKana        string `json:"firstnameKana" binding:"required,max=32,hiragana"`         // 名（かな）
+	Email                string `json:"email" binding:"required,email"`                           // メールアドレス
+	PhoneNumber          string `json:"phoneNumber" binding:"required,e164"`                      // 電話番号
+	Password             string `json:"password" binding:"min=8,max=32"`                          // パスワード
+	PasswordConfirmation string `json:"passwordConfirmation" binding:"required,eqfield=Password"` // パスワード (確認用)
 }
 
 type VerifyAuthUserRequest struct {
-	ID         string `json:"id"`         // ユーザーID
-	VerifyCode string `json:"verifyCode"` // 検証コード
+	ID         string `json:"id" binding:"required"`         // ユーザーID
+	VerifyCode string `json:"verifyCode" binding:"required"` // 検証コード
 }
 
 type CreateAuthUserWithGoogleRequest struct {
-	Code          string `json:"code"`          // 認証コード
-	Nonce         string `json:"nonce"`         // セキュア文字列（リプレイアタック対策）
-	RedirectURI   string `json:"redirectUri"`   // リダイレクトURI
-	Username      string `json:"username"`      // ユーザー名(表示名)
-	AccountID     string `json:"accountId"`     // ユーザーID(検索名)
-	Lastname      string `json:"lastname"`      // 姓
-	Firstname     string `json:"firstname"`     // 名
-	LastnameKana  string `json:"lastnameKana"`  // 姓（かな）
-	FirstnameKana string `json:"firstnameKana"` // 名（かな）
-	PhoneNumber   string `json:"phoneNumber"`   // 電話番号
+	Code          string `json:"code" binding:"required"`                                // 認証コード
+	Nonce         string `json:"nonce" binding:"required"`                               // セキュア文字列（リプレイアタック対策）
+	RedirectURI   string `json:"redirectUri" binding:"required,url"`                     // リダイレクトURI
+	Username      string `json:"username" binding:"required,max=32"`                     // ユーザー名(表示名)
+	AccountID     string `json:"accountId" binding:"required,min=4,max=32,alphanumeric"` // ユーザーID(検索名)
+	Lastname      string `json:"lastname" binding:"required,max=16"`                     // 姓
+	Firstname     string `json:"firstname" binding:"required,max=16"`                    // 名
+	LastnameKana  string `json:"lastnameKana" binding:"required,max=32,hiragana"`        // 姓（かな）
+	FirstnameKana string `json:"firstnameKana" binding:"required,max=32,hiragana"`       // 名（かな）
+	PhoneNumber   string `json:"phoneNumber" binding:"required,e164"`                    // 電話番号
 }
 
 type CreateAuthUserWithLINERequest struct {
-	Code          string `json:"code"`          // 認証コード
-	Nonce         string `json:"nonce"`         // セキュア文字列（リプレイアタック対策）
-	RedirectURI   string `json:"redirectUri"`   // リダイレクトURI
-	Username      string `json:"username"`      // ユーザー名(表示名)
-	AccountID     string `json:"accountId"`     // ユーザーID(検索名)
-	Lastname      string `json:"lastname"`      // 姓
-	Firstname     string `json:"firstname"`     // 名
-	LastnameKana  string `json:"lastnameKana"`  // 姓（かな）
-	FirstnameKana string `json:"firstnameKana"` // 名（かな）
-	PhoneNumber   string `json:"phoneNumber"`   // 電話番号
+	Code          string `json:"code" binding:"required"`                                // 認証コード
+	Nonce         string `json:"nonce" binding:"required"`                               // セキュア文字列（リプレイアタック対策）
+	RedirectURI   string `json:"redirectUri" binding:"required,url"`                     // リダイレクトURI
+	Username      string `json:"username" binding:"required,max=32"`                     // ユーザー名(表示名)
+	AccountID     string `json:"accountId" binding:"required,min=4,max=32,alphanumeric"` // ユーザーID(検索名)
+	Lastname      string `json:"lastname" binding:"required,max=16"`                     // 姓
+	Firstname     string `json:"firstname" binding:"required,max=16"`                    // 名
+	LastnameKana  string `json:"lastnameKana" binding:"required,max=32,hiragana"`        // 姓（かな）
+	FirstnameKana string `json:"firstnameKana" binding:"required,max=32,hiragana"`       // 名（かな）
+	PhoneNumber   string `json:"phoneNumber" binding:"required,e164"`                    // 電話番号
 }
 
 type UpdateAuthUserEmailRequest struct {
-	Email string `json:"email"` // メールアドレス
+	Email string `json:"email" binding:"required,email"` // メールアドレス
 }
 
 type VerifyAuthUserEmailRequest struct {
-	VerifyCode string `json:"verifyCode"` // 検証コード
+	VerifyCode string `json:"verifyCode" binding:"required"` // 検証コード
 }
 
 type UpdateAuthUserUsernameRequest struct {
-	Username string `json:"username"` // ユーザー名(表示名)
+	Username string `json:"username" binding:"required,max=32"` // ユーザー名(表示名)
 }
 
 type UpdateAuthUserAccountIDRequest struct {
-	AccountID string `json:"accountId"` // ユーザーID(検索名)
+	AccountID string `json:"accountId" binding:"required,max=32,account_id"` // ユーザーID(検索名)
 }
 
 type UpdateAuthUserNotificationRequest struct {
-	Enabled bool `json:"enabled"` // 通知の有効化設定
+	Enabled bool `json:"enabled" binding:""` // 通知の有効化設定
 }
 
 type UpdateAuthUserThumbnailRequest struct {
-	ThumbnailURL string `json:"thumbnailUrl"` // サムネイルURL
+	ThumbnailURL string `json:"thumbnailUrl" binding:"omitempty,url"` // サムネイルURL
 }

--- a/api/internal/gateway/user/v1/request/cart.go
+++ b/api/internal/gateway/user/v1/request/cart.go
@@ -1,6 +1,6 @@
 package request
 
 type AddCartItemRequest struct {
-	ProductID string `json:"productId"` // 商品ID
-	Quantity  int64  `json:"quantity"`  // 数量
+	ProductID string `json:"productId" binding:"required"` // 商品ID
+	Quantity  int64  `json:"quantity" binding:"min=1"`     // 数量
 }

--- a/api/internal/gateway/user/v1/request/checkout.go
+++ b/api/internal/gateway/user/v1/request/checkout.go
@@ -1,40 +1,40 @@
 package request
 
 type CheckoutProductRequest struct {
-	RequestID         string              `json:"requestId"`         // 支払いキー(重複判定用)
-	CoordinatorID     string              `json:"coordinatorId"`     // コーディネータID
-	BoxNumber         int64               `json:"boxNumber"`         // 箱の通番（箱単位で購入する場合）
-	BillingAddressID  string              `json:"billingAddressId"`  // 請求先住所ID
-	ShippingAddressID string              `json:"shippingAddressId"` // 配送先住所ID
-	PromotionCode     string              `json:"promotionCode"`     // プロモーションコード
-	PaymentMethod     int32               `json:"paymentMethod"`     // 支払い方法
-	CreditCard        *CheckoutCreditCard `json:"creditCard"`        // クレジットカード決済情報
-	CallbackURL       string              `json:"callbackUrl"`       // 決済完了後のリダイレクト先URL
-	Total             int64               `json:"total"`             // 支払い合計金額（誤り検出用）
+	RequestID         string              `json:"requestId" binding:"required"`            // 支払いキー(重複判定用)
+	CoordinatorID     string              `json:"coordinatorId" binding:"required"`        // コーディネータID
+	BoxNumber         int64               `json:"boxNumber" binding:"min=0"`               // 箱の通番（箱単位で購入する場合）
+	BillingAddressID  string              `json:"billingAddressId" binding:"required"`     // 請求先住所ID
+	ShippingAddressID string              `json:"shippingAddressId" binding:"required"`    // 配送先住所ID
+	PromotionCode     string              `json:"promotionCode" binding:"omitempty,len=8"` // プロモーションコード
+	PaymentMethod     int32               `json:"paymentMethod" binding:"required"`        // 支払い方法
+	CreditCard        *CheckoutCreditCard `json:"creditCard" binding:"omitempty,dive"`     // クレジットカード決済情報
+	CallbackURL       string              `json:"callbackUrl" binding:"required,http_url"` // 決済完了後のリダイレクト先URL
+	Total             int64               `json:"total" binding:"min=0"`                   // 支払い合計金額（誤り検出用）
 }
 
 type CheckoutExperienceRequest struct {
-	RequestID             string              `json:"requestId"`             // 支払いキー(重複判定用)
-	BillingAddressID      string              `json:"billingAddressId"`      // 請求先住所ID
-	PromotionCode         string              `json:"promotionCode"`         // プロモーションコード
-	AdultCount            int64               `json:"adultCount"`            // 大人人数
-	JuniorHighSchoolCount int64               `json:"juniorHighSchoolCount"` // 中学生人数
-	ElementarySchoolCount int64               `json:"elementarySchoolCount"` // 小学生人数
-	PreschoolCount        int64               `json:"preschoolCount"`        // 幼児人数
-	SeniorCount           int64               `json:"seniorCount"`           // シニア人数
-	Transportation        string              `json:"transportation"`        // 交通手段
-	RequestedDate         string              `json:"requestedDate"`         // 体験希望日
-	RequestedTime         string              `json:"requestedTime"`         // 体験希望時間
-	PaymentMethod         int32               `json:"paymentMethod"`         // 支払い方法
-	CreditCard            *CheckoutCreditCard `json:"creditCard"`            // クレジットカード決済情報
-	CallbackURL           string              `json:"callbackUrl"`           // 決済完了後のリダイレクト先URL
-	Total                 int64               `json:"total"`                 // 支払い合計金額（誤り検出用）
+	RequestID             string              `json:"requestId" binding:"required"`                 // 支払いキー(重複判定用)
+	BillingAddressID      string              `json:"billingAddressId" binding:"required"`          // 請求先住所ID
+	PromotionCode         string              `json:"promotionCode" binding:"omitempty,len=8"`      // プロモーションコード
+	AdultCount            int64               `json:"adultCount" binding:"min=0,max=99"`            // 大人人数
+	JuniorHighSchoolCount int64               `json:"juniorHighSchoolCount" binding:"min=0,max=99"` // 中学生人数
+	ElementarySchoolCount int64               `json:"elementarySchoolCount" binding:"min=0,max=99"` // 小学生人数
+	PreschoolCount        int64               `json:"preschoolCount" binding:"min=0,max=99"`        // 幼児人数
+	SeniorCount           int64               `json:"seniorCount" binding:"min=0,max=99"`           // シニア人数
+	Transportation        string              `json:"transportation" binding:"omitempty,max=256"`   // 交通手段
+	RequestedDate         string              `json:"requestedDate" binding:"omitempty,date"`       // 体験希望日
+	RequestedTime         string              `json:"requestedTime" binding:"omitempty,time"`       // 体験希望時間
+	PaymentMethod         int32               `json:"paymentMethod" binding:"required"`             // 支払い方法
+	CreditCard            *CheckoutCreditCard `json:"creditCard" binding:"omitempty,dive"`          // クレジットカード決済情報
+	CallbackURL           string              `json:"callbackUrl" binding:"required,http_url"`      // 決済完了後のリダイレクト先URL
+	Total                 int64               `json:"total" binding:"min=0"`                        // 支払い合計金額（誤り検出用）
 }
 
 type CheckoutCreditCard struct {
-	Name              string `json:"name"`              // カード名義
-	Number            string `json:"number"`            // カード番号
-	Month             int64  `json:"month"`             // 有効期限（月）
-	Year              int64  `json:"year"`              // 有効期限（年）
-	VerificationValue string `json:"verificationValue"` // セキュリティコード
+	Name              string `json:"name" binding:"required"`                         // カード名義
+	Number            string `json:"number" binding:"required,credit_card"`           // カード番号
+	Month             int64  `json:"month" binding:"min=1,max=12"`                    // 有効期限（月）
+	Year              int64  `json:"year" binding:"min=2000,max=2100"`                // 有効期限（年）
+	VerificationValue string `json:"verificationValue" binding:"min=3,max=4,numeric"` // セキュリティコード
 }

--- a/api/internal/gateway/user/v1/request/experience_review.go
+++ b/api/internal/gateway/user/v1/request/experience_review.go
@@ -1,17 +1,17 @@
 package request
 
 type CreateExperienceReviewRequest struct {
-	Rate    int64  `json:"rate"`    // 評価
-	Title   string `json:"title"`   // タイトル
-	Comment string `json:"comment"` // コメント
+	Rate    int64  `json:"rate" binding:"min=1,max=5"`          // 評価
+	Title   string `json:"title" binding:"required,max=64"`     // タイトル
+	Comment string `json:"comment" binding:"required,max=2000"` // コメント
 }
 
 type UpdateExperienceReviewRequest struct {
-	Rate    int64  `json:"rate"`    // 評価
-	Title   string `json:"title"`   // タイトル
-	Comment string `json:"comment"` // コメント
+	Rate    int64  `json:"rate" binding:"min=1,max=5"`          // 評価
+	Title   string `json:"title" binding:"required,max=64"`     // タイトル
+	Comment string `json:"comment" binding:"required,max=2000"` // コメント
 }
 
 type UpsertExperienceReviewReactionRequest struct {
-	ReactionType int32 `json:"reactionType"` // リアクション種別
+	ReactionType int32 `json:"reactionType" binding:"required"` // リアクション種別
 }

--- a/api/internal/gateway/user/v1/request/guest_checkout.go
+++ b/api/internal/gateway/user/v1/request/guest_checkout.go
@@ -1,48 +1,48 @@
 package request
 
 type GuestCheckoutProductRequest struct {
-	RequestID       string                `json:"requestId"`       // 支払いキー(重複判定用)
-	CoordinatorID   string                `json:"coordinatorId"`   // コーディネータID
-	BoxNumber       int64                 `json:"boxNumber"`       // 箱の通番（箱単位で購入する場合）
-	PromotionCode   string                `json:"promotionCode"`   // プロモーションコード
-	PaymentMethod   int32                 `json:"paymentMethod"`   // 支払い方法
-	CreditCard      *CheckoutCreditCard   `json:"creditCard"`      // クレジットカード決済情報
-	CallbackURL     string                `json:"callbackUrl"`     // 決済完了後のリダイレクト先URL
-	Total           int64                 `json:"total"`           // 支払い合計金額（誤り検出用）
-	Email           string                `json:"email"`           // メールアドレス
-	IsSameAddress   bool                  `json:"isSameAddress"`   // 配送先住所を請求先住所と同一にする
-	BillingAddress  *GuestCheckoutAddress `json:"billingAddress"`  // 請求先住所
-	ShippingAddress *GuestCheckoutAddress `json:"shippingAddress"` // 配送先住所
+	RequestID       string                `json:"requestId" binding:"required"`                                            // 支払いキー(重複判定用)
+	CoordinatorID   string                `json:"coordinatorId" binding:"required"`                                        // コーディネータID
+	BoxNumber       int64                 `json:"boxNumber" binding:"min=0"`                                               // 箱の通番（箱単位で購入する場合）
+	PromotionCode   string                `json:"promotionCode" binding:"omitempty,len=8"`                                 // プロモーションコード
+	PaymentMethod   int32                 `json:"paymentMethod" binding:"required"`                                        // 支払い方法
+	CreditCard      *CheckoutCreditCard   `json:"creditCard" binding:"omitempty,dive"`                                     // クレジットカード決済情報
+	CallbackURL     string                `json:"callbackUrl" binding:"required,http_url"`                                 // 決済完了後のリダイレクト先URL
+	Total           int64                 `json:"total" binding:"min=0"`                                                   // 支払い合計金額（誤り検出用）
+	Email           string                `json:"email" binding:"required,email"`                                          // メールアドレス
+	IsSameAddress   bool                  `json:"isSameAddress"`                                                           // 配送先住所を請求先住所と同一にする
+	BillingAddress  *GuestCheckoutAddress `json:"billingAddress" binding:"required,dive"`                                  // 請求先住所
+	ShippingAddress *GuestCheckoutAddress `json:"shippingAddress" binding:"required_without=IsSameAddress,omitempty,dive"` // 配送先住所
 }
 
 type GuestCheckoutExperienceRequest struct {
-	RequestID             string                `json:"requestId"`             // 支払いキー(重複判定用)
-	PromotionCode         string                `json:"promotionCode"`         // プロモーションコード
-	AdultCount            int64                 `json:"adultCount"`            // 大人人数
-	JuniorHighSchoolCount int64                 `json:"juniorHighSchoolCount"` // 中学生人数
-	ElementarySchoolCount int64                 `json:"elementarySchoolCount"` // 小学生人数
-	PreschoolCount        int64                 `json:"preschoolCount"`        // 幼児人数
-	SeniorCount           int64                 `json:"seniorCount"`           // シニア人数
-	Transportation        string                `json:"transportation"`        // 交通手段
-	RequestedDate         string                `json:"requestedDate"`         // 体験希望日
-	RequestedTime         string                `json:"requestedTime"`         // 体験希望時間
-	PaymentMethod         int32                 `json:"paymentMethod"`         // 支払い方法
-	CreditCard            *CheckoutCreditCard   `json:"creditCard"`            // クレジットカード決済情報
-	CallbackURL           string                `json:"callbackUrl"`           // 決済完了後のリダイレクト先URL
-	Total                 int64                 `json:"total"`                 // 支払い合計金額（誤り検出用）
-	Email                 string                `json:"email"`                 // メールアドレス
-	BillingAddress        *GuestCheckoutAddress `json:"billingAddress"`        // 請求先住所
+	RequestID             string                `json:"requestId" binding:"required"`                 // 支払いキー(重複判定用)
+	PromotionCode         string                `json:"promotionCode" binding:"omitempty,len=8"`      // プロモーションコード
+	AdultCount            int64                 `json:"adultCount" binding:"min=0,max=99"`            // 大人人数
+	JuniorHighSchoolCount int64                 `json:"juniorHighSchoolCount" binding:"min=0,max=99"` // 中学生人数
+	ElementarySchoolCount int64                 `json:"elementarySchoolCount" binding:"min=0,max=99"` // 小学生人数
+	PreschoolCount        int64                 `json:"preschoolCount" binding:"min=0,max=99"`        // 幼児人数
+	SeniorCount           int64                 `json:"seniorCount" binding:"min=0,max=99"`           // シニア人数
+	Transportation        string                `json:"transportation" binding:"omitempty,max=256"`   // 交通手段
+	RequestedDate         string                `json:"requestedDate" binding:"omitempty,date"`       // 体験希望日
+	RequestedTime         string                `json:"requestedTime" binding:"omitempty,time"`       // 体験希望時間
+	PaymentMethod         int32                 `json:"paymentMethod" binding:"required"`             // 支払い方法
+	CreditCard            *CheckoutCreditCard   `json:"creditCard" binding:"omitempty,dive"`          // クレジットカード決済情報
+	CallbackURL           string                `json:"callbackUrl" binding:"required,http_url"`      // 決済完了後のリダイレクト先URL
+	Total                 int64                 `json:"total" binding:"min=0"`                        // 支払い合計金額（誤り検出用）
+	Email                 string                `json:"email" binding:"required,email"`               // メールアドレス
+	BillingAddress        *GuestCheckoutAddress `json:"billingAddress" binding:"required,dive"`       // 請求先住所
 }
 
 type GuestCheckoutAddress struct {
-	Lastname       string `json:"lastname"`       // 姓
-	Firstname      string `json:"firstname"`      // 名
-	LastnameKana   string `json:"lastnameKana"`   // 姓（かな）
-	FirstnameKana  string `json:"firstnameKana"`  // 名（かな）
-	PostalCode     string `json:"postalCode"`     // 郵便番号
-	PrefectureCode int32  `json:"prefectureCode"` // 都道府県
-	City           string `json:"city"`           // 市区町村
-	AddressLine1   string `json:"addressLine1"`   // 町名・番地
-	AddressLine2   string `json:"addressLine2"`   // ビル名・号室など
-	PhoneNumber    string `json:"phoneNumber"`    // 電話番号
+	Lastname       string `json:"lastname" binding:"required,max=16"`               // 姓
+	Firstname      string `json:"firstname" binding:"required,max=16"`              // 名
+	LastnameKana   string `json:"lastnameKana" binding:"required,max=32,hiragana"`  // 姓（かな）
+	FirstnameKana  string `json:"firstnameKana" binding:"required,max=32,hiragana"` // 名（かな）
+	PostalCode     string `json:"postalCode" binding:"required,max=16,numeric"`     // 郵便番号
+	PrefectureCode int32  `json:"prefectureCode" binding:"required,min=1,max=47"`   // 都道府県
+	City           string `json:"city" binding:"required,max=32"`                   // 市区町村
+	AddressLine1   string `json:"addressLine1" binding:"required,max=64"`           // 町名・番地
+	AddressLine2   string `json:"addressLine2" binding:"omitempty,max=64"`          // ビル名・号室など
+	PhoneNumber    string `json:"phoneNumber" binding:"required,phone_number"`      // 電話番号
 }

--- a/api/internal/gateway/user/v1/request/guest_live_comment.go
+++ b/api/internal/gateway/user/v1/request/guest_live_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type CreateGuestLiveCommentRequest struct {
-	Comment string `json:"comment"` // コメント
+	Comment string `json:"comment" binding:"required,max=200"` // コメント
 }

--- a/api/internal/gateway/user/v1/request/guest_video_comment.go
+++ b/api/internal/gateway/user/v1/request/guest_video_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type CreateGuestVideoCommentRequest struct {
-	Comment string `json:"comment"` // コメント
+	Comment string `json:"comment" binding:"required,max=200"` // コメント
 }

--- a/api/internal/gateway/user/v1/request/live_comment.go
+++ b/api/internal/gateway/user/v1/request/live_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type CreateLiveCommentRequest struct {
-	Comment string `json:"comment"` // コメント
+	Comment string `json:"comment" binding:"required,max=200"` // コメント
 }

--- a/api/internal/gateway/user/v1/request/product_review.go
+++ b/api/internal/gateway/user/v1/request/product_review.go
@@ -1,17 +1,17 @@
 package request
 
 type CreateProductReviewRequest struct {
-	Rate    int64  `json:"rate"`    // 評価
-	Title   string `json:"title"`   // タイトル
-	Comment string `json:"comment"` // コメント
+	Rate    int64  `json:"rate" binding:"min=1,max=5"`          // 評価
+	Title   string `json:"title" binding:"required,max=64"`     // タイトル
+	Comment string `json:"comment" binding:"required,max=2000"` // コメント
 }
 
 type UpdateProductReviewRequest struct {
-	Rate    int64  `json:"rate"`    // 評価
-	Title   string `json:"title"`   // タイトル
-	Comment string `json:"comment"` // コメント
+	Rate    int64  `json:"rate" binding:"min=1,max=5"`          // 評価
+	Title   string `json:"title" binding:"required,max=64"`     // タイトル
+	Comment string `json:"comment" binding:"required,max=2000"` // コメント
 }
 
 type UpsertProductReviewReactionRequest struct {
-	ReactionType int32 `json:"reactionType"` // リアクション種別
+	ReactionType int32 `json:"reactionType" binding:"required"` // リアクション種別
 }

--- a/api/internal/gateway/user/v1/request/spot.go
+++ b/api/internal/gateway/user/v1/request/spot.go
@@ -1,19 +1,19 @@
 package request
 
 type CreateSpotRequest struct {
-	TypeID       string  `json:"spotTypeId"`   // スポット種別ID
-	Name         string  `json:"name"`         // スポット名
-	Description  string  `json:"description"`  // 説明
-	ThumbnailURL string  `json:"thumbnailUrl"` // サムネイルURL
-	Latitude     float64 `json:"latitude"`     // 緯度
-	Longitude    float64 `json:"longitude"`    // 経度
+	TypeID       string  `json:"spotTypeId" binding:"required"`                 // スポット種別ID
+	Name         string  `json:"name" binding:"required,max=64"`                // スポット名
+	Description  string  `json:"description" binding:"omitempty,max=2000"`      // 説明
+	ThumbnailURL string  `json:"thumbnailUrl" binding:"omitempty,url"`          // サムネイルURL
+	Latitude     float64 `json:"latitude" binding:"required,min=-90,max=90"`    // 緯度
+	Longitude    float64 `json:"longitude" binding:"required,min=-180,max=180"` // 経度
 }
 
 type UpdateSpotRequest struct {
-	TypeID       string  `json:"spotTypeId"`   // スポット種別ID
-	Name         string  `json:"name"`         // スポット名
-	Description  string  `json:"description"`  // 説明
-	ThumbnailURL string  `json:"thumbnailUrl"` // サムネイルURL
-	Latitude     float64 `json:"latitude"`     // 緯度
-	Longitude    float64 `json:"longitude"`    // 経度
+	TypeID       string  `json:"spotTypeId" binding:"required"`                 // スポット種別ID
+	Name         string  `json:"name" binding:"required,max=64"`                // スポット名
+	Description  string  `json:"description" binding:"omitempty,max=2000"`      // 説明
+	ThumbnailURL string  `json:"thumbnailUrl" binding:"omitempty,url"`          // サムネイルURL
+	Latitude     float64 `json:"latitude" binding:"required,min=-90,max=90"`    // 緯度
+	Longitude    float64 `json:"longitude" binding:"required,min=-180,max=180"` // 経度
 }

--- a/api/internal/gateway/user/v1/request/uploader.go
+++ b/api/internal/gateway/user/v1/request/uploader.go
@@ -1,5 +1,5 @@
 package request
 
 type GetUploadURLRequest struct {
-	FileType string `json:"fileType"` // ファイル種別
+	FileType string `json:"fileType" binding:"required"` // ファイル種別
 }

--- a/api/internal/gateway/user/v1/request/video_comment.go
+++ b/api/internal/gateway/user/v1/request/video_comment.go
@@ -1,5 +1,5 @@
 package request
 
 type CreateVideoCommentRequest struct {
-	Comment string `json:"comment"` // コメント
+	Comment string `json:"comment" binding:"required,max=200"` // コメント
 }

--- a/api/internal/store/input.go
+++ b/api/internal/store/input.go
@@ -161,11 +161,11 @@ type CheckoutProductDetail struct {
 
 type CheckoutExperienceDetail struct {
 	ExperienceID          string `validate:"required"`
-	AdultCount            int64  `validate:"min=0"`
-	JuniorHighSchoolCount int64  `validate:"min=0"`
-	ElementarySchoolCount int64  `validate:"min=0"`
-	PreschoolCount        int64  `validate:"min=0"`
-	SeniorCount           int64  `validate:"min=0"`
+	AdultCount            int64  `validate:"min=0,max=99"`
+	JuniorHighSchoolCount int64  `validate:"min=0,max=99"`
+	ElementarySchoolCount int64  `validate:"min=0,max=99"`
+	PreschoolCount        int64  `validate:"min=0,max=99"`
+	SeniorCount           int64  `validate:"min=0,max=99"`
 	Transportation        string `validate:"max=256"`
 	RequestedDate         string `validate:"omitempty,date"`
 	RequestedTime         string `validate:"omitempty,time"`

--- a/docs/swagger/gen/admin/v1/swagger.yaml
+++ b/docs/swagger/gen/admin/v1/swagger.yaml
@@ -5,6 +5,8 @@ components:
                 inputUrl:
                     description: 配信動画URL
                     type: string
+            required:
+                - inputUrl
             type: object
         request.ApproveScheduleRequest:
             properties:
@@ -23,6 +25,8 @@ components:
                 youtubeHandle:
                     description: 連携先Youtubeアカウント
                     type: string
+            required:
+                - youtubeHandle
             type: object
         request.CallbackAuthYoutubeBroadcastRequest:
             properties:
@@ -32,11 +36,15 @@ components:
                 state:
                     description: Google認証時に取得したstate
                     type: string
+            required:
+                - authCode
+                - state
             type: object
         request.CompleteOrderRequest:
             properties:
                 shippingMessage:
                     description: 発送連絡時のメッセージ
+                    maxLength: 2000
                     type: string
             type: object
         request.ConnectGoogleAccountRequest:
@@ -50,6 +58,10 @@ components:
                 redirectUri:
                     description: リダイレクトURI
                     type: string
+            required:
+                - code
+                - nonce
+                - redirectUri
             type: object
         request.ConnectLINEAccountRequest:
             properties:
@@ -62,9 +74,15 @@ components:
                 redirectUri:
                     description: リダイレクトURI
                     type: string
+            required:
+                - code
+                - nonce
+                - redirectUri
             type: object
         request.ContactStatus:
             description: お問い合わせステータス
+            maximum: 4
+            minimum: 0
             type: integer
             x-enum-comments:
                 ContactStatusDiscard: 対応不要
@@ -85,25 +103,39 @@ components:
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名(かな)
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓(かな)
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
+            required:
+                - email
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
             type: object
         request.CreateCategoryRequest:
             properties:
                 name:
                     description: 商品種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.CreateContactReadRequest:
             properties:
@@ -115,7 +147,12 @@ components:
                     type: string
                 userType:
                     description: 送信者種別(不明:0, admin:1, uer:2, guest:3)
+                    maximum: 3
+                    minimum: 0
                     type: integer
+            required:
+                - contactId
+                - userId
             type: object
         request.CreateContactRequest:
             properties:
@@ -124,12 +161,14 @@ components:
                     type: string
                 content:
                     description: お問い合わせ内容
+                    maxLength: 2000
                     type: string
                 email:
                     description: メールアドレス
                     type: string
                 note:
                     description: 対応者メモ
+                    maxLength: 500
                     type: string
                 phoneNumber:
                     description: 電話番号
@@ -139,13 +178,22 @@ components:
                     type: string
                 title:
                     description: お問い合わせ件名
+                    maxLength: 64
                     type: string
                 userId:
                     description: 問い合わせ作成者ID(null許容)
                     type: string
                 username:
                     description: 氏名
+                    maxLength: 32
                     type: string
+            required:
+                - categoryId
+                - content
+                - email
+                - phoneNumber
+                - title
+                - username
             type: object
         request.CreateExperienceMedia:
             properties:
@@ -155,6 +203,8 @@ components:
                 url:
                     description: メディアURL
                     type: string
+            required:
+                - url
             type: object
         request.CreateExperienceRequest:
             properties:
@@ -169,12 +219,15 @@ components:
                     type: string
                 description:
                     description: 説明
+                    maxLength: 20000
                     type: string
                 direction:
                     description: アクセス方法
+                    maxLength: 2000
                     type: string
                 duration:
                     description: 体験時間(分)
+                    minimum: 0
                     type: integer
                 endAt:
                     description: 募集終了日時
@@ -184,18 +237,24 @@ components:
                     type: string
                 hostAddressLine1:
                     description: 開催場所(住所1)
+                    maxLength: 64
                     type: string
                 hostAddressLine2:
                     description: 開催場所(住所2)
+                    maxLength: 64
                     type: string
                 hostCity:
                     description: 開催場所(市区町村)
+                    maxLength: 32
                     type: string
                 hostPostalCode:
                     description: 開催場所(郵便番号)
+                    maxLength: 16
                     type: string
                 hostPrefectureCode:
                     description: 開催場所(都道府県コード)
+                    maximum: 47
+                    minimum: 1
                     type: integer
                 media:
                     description: メディア一覧
@@ -205,18 +264,28 @@ components:
                     uniqueItems: false
                 priceAdult:
                     description: 大人料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceElementarySchool:
                     description: 小学生料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceJuniorHighSchool:
                     description: 中学生料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 pricePreschool:
                     description: 幼児料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceSenior:
                     description: シニア料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 producerId:
                     description: 生産者ID
@@ -229,12 +298,15 @@ components:
                     type: boolean
                 recommendedPoint1:
                     description: おすすめポイント1
+                    maxLength: 128
                     type: string
                 recommendedPoint2:
                     description: おすすめポイント2
+                    maxLength: 128
                     type: string
                 recommendedPoint3:
                     description: おすすめポイント3
+                    maxLength: 128
                     type: string
                 soldOut:
                     description: 定員オーバーフラグ
@@ -244,18 +316,41 @@ components:
                     type: integer
                 title:
                     description: 体験名
+                    maxLength: 128
                     type: string
+            required:
+                - coordinatorId
+                - description
+                - endAt
+                - experienceTypeId
+                - hostAddressLine1
+                - hostCity
+                - hostPostalCode
+                - hostPrefectureCode
+                - media
+                - priceAdult
+                - priceElementarySchool
+                - priceJuniorHighSchool
+                - pricePreschool
+                - priceSenior
+                - producerId
+                - startAt
+                - title
             type: object
         request.CreateExperienceTypeRequest:
             properties:
                 name:
                     description: 体験種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.CreateLiveRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 endAt:
                     description: 配信終了日時
@@ -272,14 +367,22 @@ components:
                 startAt:
                     description: 配信開始日時
                     type: integer
+            required:
+                - comment
+                - endAt
+                - producerId
+                - productIds
+                - startAt
             type: object
         request.CreateNotificationRequest:
             properties:
                 body:
                     description: 本文
+                    maxLength: 2000
                     type: string
                 note:
                     description: 備考
+                    maxLength: 2000
                     type: string
                 promotionId:
                     description: プロモーションID
@@ -291,28 +394,40 @@ components:
                     description: 掲載対象一覧
                     items:
                         type: integer
+                    maxItems: 4
+                    minItems: 1
                     type: array
                     uniqueItems: false
                 title:
                     description: タイトル
+                    maxLength: 128
                     type: string
                 type:
                     description: お知らせ種別
                     type: integer
+            required:
+                - body
+                - publishedAt
+                - targets
+                - title
+                - type
             type: object
         request.CreateProducerRequest:
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 bonusVideoUrl:
                     description: 購入特典映像URL
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 coordinatorId:
                     description: 担当コーディネータ名
@@ -322,36 +437,46 @@ components:
                     type: string
                 facebookId:
                     description: Facebookアカウント
+                    maxLength: 50
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名(かな)
+                    maxLength: 32
                     type: string
                 headerUrl:
                     description: ヘッダー画像URL
                     type: string
                 instagramId:
                     description: Instagramアカウント
+                    maxLength: 30
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓(かな)
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 0
                     type: integer
                 profile:
                     description: 紹介文
+                    maxLength: 2000
                     type: string
                 promotionVideoUrl:
                     description: 紹介映像URL
@@ -361,7 +486,15 @@ components:
                     type: string
                 username:
                     description: 表示名
+                    maxLength: 64
                     type: string
+            required:
+                - coordinatorId
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - username
             type: object
         request.CreateProductMedia:
             properties:
@@ -371,62 +504,82 @@ components:
                 url:
                     description: メディアURL
                     type: string
+            required:
+                - url
             type: object
         request.CreateProductRequest:
             properties:
                 box60Rate:
                     description: 箱の占有率(サイズ:60)
+                    maximum: 600
+                    minimum: 0
                     type: integer
                 box80Rate:
                     description: 箱の占有率(サイズ:80)
+                    maximum: 250
+                    minimum: 0
                     type: integer
                 box100Rate:
                     description: 箱の占有率(サイズ:100)
+                    maximum: 100
+                    minimum: 0
                     type: integer
                 coordinatorId:
                     description: コーディネータID
                     type: string
                 cost:
                     description: 原価(税込)
+                    minimum: 0
                     type: integer
                 deliveryType:
                     description: 配送方法
                     type: integer
                 description:
                     description: 商品説明
+                    maxLength: 2000
                     type: string
                 endAt:
                     description: 販売終了日時
                     type: integer
                 expirationDate:
                     description: 賞味期限(単位:日)
+                    minimum: 0
                     type: integer
                 inventory:
                     description: 在庫数
+                    minimum: 0
                     type: integer
                 itemDescription:
                     description: 数量単位説明
+                    maxLength: 64
                     type: string
                 itemUnit:
                     description: 数量単位
+                    maxLength: 16
                     type: string
                 media:
                     description: メディア一覧
                     items:
                         $ref: '#/components/schemas/request.CreateProductMedia'
+                    maxItems: 8
                     type: array
                     uniqueItems: false
                 name:
                     description: 商品名
+                    maxLength: 64
                     type: string
                 originCity:
                     description: 原産地(市区町村)
+                    maxLength: 32
                     type: string
                 originPrefectureCode:
                     description: 原産地(都道府県)
+                    maximum: 47
+                    minimum: 1
                     type: integer
                 price:
                     description: 販売価格(税込)
+                    minimum: 0
                     type: integer
                 producerId:
                     description: 生産者ID
@@ -435,6 +588,7 @@ components:
                     description: 商品タグID一覧
                     items:
                         type: string
+                    maxItems: 8
                     type: array
                     uniqueItems: false
                 productTypeId:
@@ -445,12 +599,15 @@ components:
                     type: boolean
                 recommendedPoint1:
                     description: おすすめポイント1
+                    maxLength: 128
                     type: string
                 recommendedPoint2:
                     description: おすすめポイント2
+                    maxLength: 128
                     type: string
                 recommendedPoint3:
                     description: おすすめポイント3
+                    maxLength: 128
                     type: string
                 startAt:
                     description: 販売開始日時
@@ -460,13 +617,31 @@ components:
                     type: integer
                 weight:
                     description: 重量(kg,少数第一位まで)
+                    minimum: 0
                     type: number
+            required:
+                - coordinatorId
+                - deliveryType
+                - description
+                - endAt
+                - itemDescription
+                - itemUnit
+                - name
+                - originPrefectureCode
+                - producerId
+                - productTagIds
+                - productTypeId
+                - startAt
+                - storageMethodType
             type: object
         request.CreateProductTagRequest:
             properties:
                 name:
                     description: 商品タグ名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.CreateProductTypeRequest:
             properties:
@@ -475,15 +650,21 @@ components:
                     type: string
                 name:
                     description: 品目名
+                    maxLength: 32
                     type: string
+            required:
+                - iconUrl
+                - name
             type: object
         request.CreatePromotionRequest:
             properties:
                 code:
                     type: string
                 description:
+                    maxLength: 2000
                     type: string
                 discountRate:
+                    minimum: 0
                     type: integer
                 discountType:
                     type: integer
@@ -494,7 +675,14 @@ components:
                 startAt:
                     type: integer
                 title:
+                    maxLength: 64
                     type: string
+            required:
+                - description
+                - discountType
+                - endAt
+                - startAt
+                - title
             type: object
         request.CreateScheduleRequest:
             properties:
@@ -503,6 +691,7 @@ components:
                     type: string
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 endAt:
                     description: 配信終了日時
@@ -524,12 +713,20 @@ components:
                     type: string
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - coordinatorId
+                - description
+                - endAt
+                - startAt
+                - title
             type: object
         request.CreateShippingRate:
             properties:
                 name:
                     description: 配送料金設定名
+                    maxLength: 64
                     type: string
                 prefectureCodes:
                     description: 対象都道府県一覧
@@ -539,12 +736,18 @@ components:
                     uniqueItems: false
                 price:
                     description: 配送料金(税込)
+                    minimum: 0
                     type: integer
+            required:
+                - name
+                - prefectureCodes
+                - price
             type: object
         request.CreateShippingRequest:
             properties:
                 box60Frozen:
                     description: 箱サイズ60の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box60Rates:
                     description: 箱サイズ60の通常便配送料一覧
@@ -554,6 +757,7 @@ components:
                     uniqueItems: false
                 box80Frozen:
                     description: 箱サイズ80の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box80Rates:
                     description: 箱サイズ80の通常便配送料一覧
@@ -563,6 +767,7 @@ components:
                     uniqueItems: false
                 box100Frozen:
                     description: 箱サイズ100の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box100Rates:
                     description: 箱サイズ100の通常便配送料一覧
@@ -572,27 +777,43 @@ components:
                     uniqueItems: false
                 freeShippingRates:
                     description: 送料無料になる金額(税込)
+                    minimum: 0
                     type: integer
                 hasFreeShipping:
                     description: 送料無料オプションの有無
                     type: boolean
                 name:
                     description: 配送設定名
+                    maxLength: 64
                     type: string
+            required:
+                - box100Frozen
+                - box100Rates
+                - box60Frozen
+                - box60Rates
+                - box80Frozen
+                - box80Rates
+                - name
             type: object
         request.CreateSpotRequest:
             properties:
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 latitude:
                     description: 緯度
+                    maximum: 90
+                    minimum: -90
                     type: number
                 longitude:
                     description: 経度
+                    maximum: 180
+                    minimum: -180
                     type: number
                 name:
                     description: スポット名
+                    maxLength: 64
                     type: string
                 spotTypeId:
                     description: スポット種別ID
@@ -600,12 +821,20 @@ components:
                 thumbnailUrl:
                     description: サムネイルURL
                     type: string
+            required:
+                - latitude
+                - longitude
+                - name
+                - spotTypeId
             type: object
         request.CreateSpotTypeRequest:
             properties:
                 name:
                     description: スポット種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.CreateThreadRequest:
             properties:
@@ -614,13 +843,20 @@ components:
                     type: string
                 content:
                     description: 内容
+                    maxLength: 1000
                     type: string
                 userId:
                     description: 送信者ID
                     type: string
                 userType:
                     description: 送信者種別(不明:0, admin:1, uer:2, guest:3)
+                    maximum: 3
+                    minimum: 0
                     type: integer
+            required:
+                - contactId
+                - content
+                - userId
             type: object
         request.CreateVideoRequest:
             properties:
@@ -629,6 +865,7 @@ components:
                     type: string
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 displayExperience:
                     description: 体験への表示設定
@@ -662,27 +899,42 @@ components:
                     type: string
                 title:
                     description: タイトル
+                    maxLength: 128
                     type: string
                 videoUrl:
                     description: 動画URL
                     type: string
+            required:
+                - coordinatorId
+                - description
+                - experienceIds
+                - productIds
+                - publishedAt
+                - thumbnailUrl
+                - title
+                - videoUrl
             type: object
         request.CreateYoutubeBroadcastRequest:
             properties:
                 description:
                     description: ライブ配信説明
+                    maxLength: 1000
                     type: string
                 public:
                     description: 公開設定
                     type: boolean
                 title:
                     description: ライブ配信タイトル
+                    maxLength: 100
                     type: string
+            required:
+                - title
             type: object
         request.DraftOrderRequest:
             properties:
                 shippingMessage:
                     description: 発送連絡時のメッセージ
+                    maxLength: 2000
                     type: string
             type: object
         request.ExportOrdersRequest:
@@ -693,18 +945,24 @@ components:
                 shippingCarrier:
                     description: 配送会社
                     type: integer
+            required:
+                - shippingCarrier
             type: object
         request.ForgotAuthPasswordRequest:
             properties:
                 email:
                     description: メールアドレス
                     type: string
+            required:
+                - email
             type: object
         request.GetUploadURLRequest:
             properties:
                 fileType:
                     description: ファイル種別
                     type: string
+            required:
+                - fileType
             type: object
         request.PublishScheduleRequest:
             properties:
@@ -717,18 +975,25 @@ components:
                 refreshToken:
                     description: 更新トークン
                     type: string
+            required:
+                - refreshToken
             type: object
         request.RefundOrderRequest:
             properties:
                 description:
                     description: 返金理由
+                    maxLength: 2000
                     type: string
+            required:
+                - description
             type: object
         request.RegisterAuthDeviceRequest:
             properties:
                 device:
                     description: デバイスID
                     type: string
+            required:
+                - device
             type: object
         request.ResetAuthPasswordRequest:
             properties:
@@ -737,6 +1002,8 @@ components:
                     type: string
                 password:
                     description: パスワード
+                    maxLength: 32
+                    minLength: 8
                     type: string
                 passwordConfirmation:
                     description: パスワード (確認用)
@@ -744,6 +1011,10 @@ components:
                 verifyCode:
                     description: 検証コード
                     type: string
+            required:
+                - email
+                - passwordConfirmation
+                - verifyCode
             type: object
         request.SignInRequest:
             properties:
@@ -753,41 +1024,60 @@ components:
                 username:
                     description: ユーザー名 (メールアドレス)
                     type: string
+            required:
+                - password
+                - username
             type: object
         request.UpdateAdministratorEmailRequest:
             properties:
                 email:
                     description: メールアドレス
                     type: string
+            required:
+                - email
             type: object
         request.UpdateAdministratorRequest:
             properties:
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名(かな)
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓(かな)
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
+            required:
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
             type: object
         request.UpdateAuthEmailRequest:
             properties:
                 email:
                     description: メールアドレス
                     type: string
+            required:
+                - email
             type: object
         request.UpdateAuthPasswordRequest:
             properties:
                 newPassword:
                     description: 新しいパスワード
+                    maxLength: 32
+                    minLength: 8
                     type: string
                 oldPassword:
                     description: 現在のパスワード
@@ -795,18 +1085,26 @@ components:
                 passwordConfirmation:
                     description: パスワード (確認用)
                     type: string
+            required:
+                - oldPassword
+                - passwordConfirmation
             type: object
         request.UpdateBroadcastArchiveRequest:
             properties:
                 archiveUrl:
                     description: アーカイブ動画URL
                     type: string
+            required:
+                - archiveUrl
             type: object
         request.UpdateCategoryRequest:
             properties:
                 name:
                     description: 商品種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.UpdateContactRequest:
             properties:
@@ -815,12 +1113,14 @@ components:
                     type: string
                 content:
                     description: お問い合わせ内容
+                    maxLength: 2000
                     type: string
                 email:
                     description: メールアドレス
                     type: string
                 note:
                     description: 対応者メモ
+                    maxLength: 500
                     type: string
                 phoneNumber:
                     description: 電話番号
@@ -832,60 +1132,82 @@ components:
                     $ref: '#/components/schemas/request.ContactStatus'
                 title:
                     description: お問い合わせ件名
+                    maxLength: 64
                     type: string
                 userId:
                     description: 問い合わせ作成者ID(null許容)
                     type: string
                 username:
                     description: 氏名
+                    maxLength: 32
                     type: string
+            required:
+                - categoryId
+                - content
+                - email
+                - phoneNumber
+                - title
+                - username
             type: object
         request.UpdateCoordinatorRequest:
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 bonusVideoUrl:
                     description: 購入特典映像URL
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 facebookId:
                     description: Facebookアカウント
+                    maxLength: 50
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名(かな)
+                    maxLength: 32
                     type: string
                 headerUrl:
                     description: ヘッダー画像URL
                     type: string
                 instagramId:
                     description: Instagramアカウント
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓(かな)
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 1
                     type: integer
                 profile:
                     description: 紹介文
+                    maxLength: 2000
                     type: string
                 promotionVideoUrl:
                     description: 紹介映像URL
@@ -895,12 +1217,25 @@ components:
                     type: string
                 username:
                     description: 表示名
+                    maxLength: 32
                     type: string
+            required:
+                - addressLine1
+                - city
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
+                - prefectureCode
+                - profile
+                - username
             type: object
         request.UpdateDefaultShippingRate:
             properties:
                 name:
                     description: 配送料金設定名
+                    maxLength: 64
                     type: string
                 prefectureCodes:
                     description: 対象都道府県一覧
@@ -910,12 +1245,18 @@ components:
                     uniqueItems: false
                 price:
                     description: 配送料金(税込)
+                    minimum: 0
                     type: integer
+            required:
+                - name
+                - prefectureCodes
+                - price
             type: object
         request.UpdateDefaultShippingRequest:
             properties:
                 box60Frozen:
                     description: 箱サイズ60の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box60Rates:
                     description: 箱サイズ60の通常便配送料一覧
@@ -925,6 +1266,7 @@ components:
                     uniqueItems: false
                 box80Frozen:
                     description: 箱サイズ80の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box80Rates:
                     description: 箱サイズ80の通常便配送料一覧
@@ -934,6 +1276,7 @@ components:
                     uniqueItems: false
                 box100Frozen:
                     description: 箱サイズ100の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box100Rates:
                     description: 箱サイズ100の通常便配送料一覧
@@ -943,10 +1286,18 @@ components:
                     uniqueItems: false
                 freeShippingRates:
                     description: 送料無料になる金額(税込)
+                    minimum: 0
                     type: integer
                 hasFreeShipping:
                     description: 送料無料オプションの有無
                     type: boolean
+            required:
+                - box100Frozen
+                - box100Rates
+                - box60Frozen
+                - box60Rates
+                - box80Frozen
+                - box80Rates
             type: object
         request.UpdateExperienceMedia:
             properties:
@@ -956,6 +1307,8 @@ components:
                 url:
                     description: メディアURL
                     type: string
+            required:
+                - url
             type: object
         request.UpdateExperienceRequest:
             properties:
@@ -967,12 +1320,15 @@ components:
                     type: string
                 description:
                     description: 説明
+                    maxLength: 20000
                     type: string
                 direction:
                     description: アクセス方法
+                    maxLength: 2000
                     type: string
                 duration:
                     description: 体験時間(分)
+                    minimum: 0
                     type: integer
                 endAt:
                     description: 募集終了日時
@@ -982,18 +1338,24 @@ components:
                     type: string
                 hostAddressLine1:
                     description: 開催場所(住所1)
+                    maxLength: 64
                     type: string
                 hostAddressLine2:
                     description: 開催場所(住所2)
+                    maxLength: 64
                     type: string
                 hostCity:
                     description: 開催場所(市区町村)
+                    maxLength: 32
                     type: string
                 hostPostalCode:
                     description: 開催場所(郵便番号)
+                    maxLength: 16
                     type: string
                 hostPrefectureCode:
                     description: 開催場所(都道府県コード)
+                    maximum: 47
+                    minimum: 1
                     type: integer
                 media:
                     description: メディア一覧
@@ -1003,18 +1365,28 @@ components:
                     uniqueItems: false
                 priceAdult:
                     description: 大人料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceElementarySchool:
                     description: 小学生料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceJuniorHighSchool:
                     description: 中学生料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 pricePreschool:
                     description: 幼児料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 priceSenior:
                     description: シニア料金
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 promotionVideoUrl:
                     description: 紹介動画URL
@@ -1024,12 +1396,15 @@ components:
                     type: boolean
                 recommendedPoint1:
                     description: おすすめポイント1
+                    maxLength: 128
                     type: string
                 recommendedPoint2:
                     description: おすすめポイント2
+                    maxLength: 128
                     type: string
                 recommendedPoint3:
                     description: おすすめポイント3
+                    maxLength: 128
                     type: string
                 soldOut:
                     description: 定員オーバーフラグ
@@ -1039,13 +1414,33 @@ components:
                     type: integer
                 title:
                     description: 体験名
+                    maxLength: 128
                     type: string
+            required:
+                - description
+                - endAt
+                - experienceTypeId
+                - hostAddressLine1
+                - hostCity
+                - hostPostalCode
+                - hostPrefectureCode
+                - media
+                - priceAdult
+                - priceElementarySchool
+                - priceJuniorHighSchool
+                - pricePreschool
+                - priceSenior
+                - startAt
+                - title
             type: object
         request.UpdateExperienceTypeRequest:
             properties:
                 name:
                     description: 体験種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.UpdateLiveCommentRequest:
             properties:
@@ -1057,6 +1452,7 @@ components:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 endAt:
                     description: 配信終了日時
@@ -1070,14 +1466,21 @@ components:
                 startAt:
                     description: 配信開始日時
                     type: integer
+            required:
+                - comment
+                - endAt
+                - productIds
+                - startAt
             type: object
         request.UpdateNotificationRequest:
             properties:
                 body:
                     description: 本文
+                    maxLength: 2000
                     type: string
                 note:
                     description: 備考
+                    maxLength: 2000
                     type: string
                 publishedAt:
                     description: 掲載開始日
@@ -1086,67 +1489,90 @@ components:
                     description: 掲載対象一覧
                     items:
                         type: integer
+                    maxItems: 4
+                    minItems: 1
                     type: array
                     uniqueItems: false
                 title:
                     description: タイトル
+                    maxLength: 128
                     type: string
+            required:
+                - body
+                - publishedAt
+                - targets
+                - title
             type: object
         request.UpdatePaymentSystemRequest:
             properties:
                 status:
                     description: 決済システム状態
                     type: integer
+            required:
+                - status
             type: object
         request.UpdateProducerRequest:
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 bonusVideoUrl:
                     description: 購入特典映像URL
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 email:
                     description: メールアドレス
                     type: string
                 facebookId:
                     description: Facebookアカウント
+                    maxLength: 50
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名(かな)
+                    maxLength: 32
                     type: string
                 headerUrl:
                     description: ヘッダー画像URL
                     type: string
                 instagramId:
                     description: Instagramアカウント
+                    maxLength: 30
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓(かな)
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 0
                     type: integer
                 profile:
                     description: 紹介文
+                    maxLength: 2000
                     type: string
                 promotionVideoUrl:
                     description: 紹介映像URL
@@ -1156,13 +1582,23 @@ components:
                     type: string
                 username:
                     description: 表示名
+                    maxLength: 64
                     type: string
+            required:
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - username
             type: object
         request.UpdateProductTagRequest:
             properties:
                 name:
                     description: 商品タグ名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.UpdateProductTypeRequest:
             properties:
@@ -1171,15 +1607,21 @@ components:
                     type: string
                 name:
                     description: 品目名
+                    maxLength: 32
                     type: string
+            required:
+                - iconUrl
+                - name
             type: object
         request.UpdatePromotionRequest:
             properties:
                 code:
                     type: string
                 description:
+                    maxLength: 2000
                     type: string
                 discountRate:
+                    minimum: 0
                     type: integer
                 discountType:
                     type: integer
@@ -1190,12 +1632,20 @@ components:
                 startAt:
                     type: integer
                 title:
+                    maxLength: 64
                     type: string
+            required:
+                - description
+                - discountType
+                - endAt
+                - startAt
+                - title
             type: object
         request.UpdateScheduleRequest:
             properties:
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 endAt:
                     description: 配信終了日時
@@ -1214,12 +1664,19 @@ components:
                     type: string
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - description
+                - endAt
+                - startAt
+                - title
             type: object
         request.UpdateShippingRate:
             properties:
                 name:
                     description: 配送料金設定名
+                    maxLength: 64
                     type: string
                 prefectureCodes:
                     description: 対象都道府県一覧
@@ -1229,12 +1686,18 @@ components:
                     uniqueItems: false
                 price:
                     description: 配送料金(税込)
+                    minimum: 0
                     type: integer
+            required:
+                - name
+                - prefectureCodes
+                - price
             type: object
         request.UpdateShippingRequest:
             properties:
                 box60Frozen:
                     description: 箱サイズ60の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box60Rates:
                     description: 箱サイズ60の通常便配送料一覧
@@ -1244,6 +1707,7 @@ components:
                     uniqueItems: false
                 box80Frozen:
                     description: 箱サイズ80の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box80Rates:
                     description: 箱サイズ80の通常便配送料一覧
@@ -1253,6 +1717,7 @@ components:
                     uniqueItems: false
                 box100Frozen:
                     description: 箱サイズ100の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box100Rates:
                     description: 箱サイズ100の通常便配送料一覧
@@ -1262,13 +1727,23 @@ components:
                     uniqueItems: false
                 freeShippingRates:
                     description: 送料無料になる金額(税込)
+                    minimum: 0
                     type: integer
                 hasFreeShipping:
                     description: 送料無料オプションの有無
                     type: boolean
                 name:
                     description: 配送設定名
+                    maxLength: 64
                     type: string
+            required:
+                - box100Frozen
+                - box100Rates
+                - box60Frozen
+                - box60Rates
+                - box80Frozen
+                - box80Rates
+                - name
             type: object
         request.UpdateShopRequest:
             properties:
@@ -1284,10 +1759,12 @@ components:
                             - Thursday
                             - Friday
                             - Saturday
+                    maxItems: 7
                     type: array
-                    uniqueItems: false
+                    uniqueItems: true
                 name:
                     description: 店舗名
+                    maxLength: 64
                     type: string
                 productTypeIds:
                     description: 取り扱い品目一覧
@@ -1295,20 +1772,29 @@ components:
                         type: string
                     type: array
                     uniqueItems: false
+            required:
+                - name
+                - productTypeIds
             type: object
         request.UpdateSpotRequest:
             properties:
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 latitude:
                     description: 緯度
+                    maximum: 90
+                    minimum: -90
                     type: number
                 longitude:
                     description: 経度
+                    maximum: 180
+                    minimum: -180
                     type: number
                 name:
                     description: スポット名
+                    maxLength: 64
                     type: string
                 spotTypeId:
                     description: スポット種別ID
@@ -1316,17 +1802,26 @@ components:
                 thumbnailUrl:
                     description: サムネイルURL
                     type: string
+            required:
+                - latitude
+                - longitude
+                - name
+                - spotTypeId
             type: object
         request.UpdateSpotTypeRequest:
             properties:
                 name:
                     description: スポット種別名
+                    maxLength: 32
                     type: string
+            required:
+                - name
             type: object
         request.UpdateThreadRequest:
             properties:
                 content:
                     description: 内容
+                    maxLength: 1000
                     type: string
                 threadId:
                     description: お問い合わせID
@@ -1336,7 +1831,13 @@ components:
                     type: string
                 userType:
                     description: 送信者種別(不明:0, admin:1, uer:2, guest:3)
+                    maximum: 3
+                    minimum: 0
                     type: integer
+            required:
+                - content
+                - threadId
+                - userId
             type: object
         request.UpdateVideoCommentRequest:
             properties:
@@ -1346,14 +1847,12 @@ components:
             type: object
         request.UpdateVideoRequest:
             properties:
-                categoryIds:
-                    description: カテゴリID一覧
-                    items:
-                        type: string
-                    type: array
-                    uniqueItems: false
+                coordinatorId:
+                    description: コーディネータID
+                    type: string
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 displayExperience:
                     description: 体験への表示設定
@@ -1387,15 +1886,26 @@ components:
                     type: string
                 title:
                     description: タイトル
+                    maxLength: 128
                     type: string
                 videoUrl:
                     description: 動画URL
                     type: string
+            required:
+                - coordinatorId
+                - description
+                - experienceIds
+                - productIds
+                - publishedAt
+                - thumbnailUrl
+                - title
+                - videoUrl
             type: object
         request.UpsertShippingRate:
             properties:
                 name:
                     description: 配送料金設定名
+                    maxLength: 64
                     type: string
                 prefectureCodes:
                     description: 対象都道府県一覧
@@ -1405,12 +1915,18 @@ components:
                     uniqueItems: false
                 price:
                     description: 配送料金(税込)
+                    minimum: 0
                     type: integer
+            required:
+                - name
+                - prefectureCodes
+                - price
             type: object
         request.UpsertShippingRequest:
             properties:
                 box60Frozen:
                     description: 箱サイズ60の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box60Rates:
                     description: 箱サイズ60の通常便配送料一覧
@@ -1420,6 +1936,7 @@ components:
                     uniqueItems: false
                 box80Frozen:
                     description: 箱サイズ80の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box80Rates:
                     description: 箱サイズ80の通常便配送料一覧
@@ -1429,6 +1946,7 @@ components:
                     uniqueItems: false
                 box100Frozen:
                     description: 箱サイズ100の冷凍便追加配送料(税込)
+                    minimum: 0
                     type: integer
                 box100Rates:
                     description: 箱サイズ100の通常便配送料一覧
@@ -1438,16 +1956,26 @@ components:
                     uniqueItems: false
                 freeShippingRates:
                     description: 送料無料になる金額(税込)
+                    minimum: 0
                     type: integer
                 hasFreeShipping:
                     description: 送料無料オプションの有無
                     type: boolean
+            required:
+                - box100Frozen
+                - box100Rates
+                - box60Frozen
+                - box60Rates
+                - box80Frozen
+                - box80Rates
             type: object
         request.VerifyAuthEmailRequest:
             properties:
                 verifyCode:
                     description: 検証コード
                     type: string
+            required:
+                - verifyCode
             type: object
         response.Address:
             description: デフォルト設定の住所情報

--- a/docs/swagger/gen/user/facility/swagger.yaml
+++ b/docs/swagger/gen/user/facility/swagger.yaml
@@ -17,6 +17,8 @@ components:
       properties:
         month:
           description: 有効期限（月）
+          maximum: 12
+          minimum: 1
           type: integer
         name:
           description: カード名義
@@ -26,15 +28,23 @@ components:
           type: string
         verificationValue:
           description: セキュリティコード
+          maxLength: 4
+          minLength: 3
           type: string
         year:
           description: 有効期限（年）
+          maximum: 2100
+          minimum: 2000
           type: integer
+      required:
+      - name
+      - number
       type: object
     request.CheckoutRequest:
       properties:
         boxNumber:
           description: 箱の通番（箱単位で購入する場合）
+          minimum: 0
           type: integer
         callbackUrl:
           description: 決済完了後のリダイレクト先URL
@@ -55,7 +65,13 @@ components:
           type: string
         total:
           description: 支払い合計金額（誤り検出用）
+          minimum: 0
           type: integer
+      required:
+      - callbackUrl
+      - coordinatorId
+      - paymentMethod
+      - requestId
       type: object
     request.CreateAuthUserRequest:
       properties:
@@ -779,6 +795,20 @@ components:
     time.Weekday:
       type: integer
       x-enum-varnames:
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
       - Sunday
       - Monday
       - Tuesday

--- a/docs/swagger/gen/user/v1/swagger.yaml
+++ b/docs/swagger/gen/user/v1/swagger.yaml
@@ -7,13 +7,18 @@ components:
                     type: string
                 quantity:
                     description: 数量
+                    minimum: 1
                     type: integer
+            required:
+                - productId
             type: object
         request.CheckoutCreditCard:
             description: クレジットカード決済情報
             properties:
                 month:
                     description: 有効期限（月）
+                    maximum: 12
+                    minimum: 1
                     type: integer
                 name:
                     description: カード名義
@@ -23,15 +28,24 @@ components:
                     type: string
                 verificationValue:
                     description: セキュリティコード
+                    maxLength: 4
+                    minLength: 3
                     type: string
                 year:
                     description: 有効期限（年）
+                    maximum: 2100
+                    minimum: 2000
                     type: integer
+            required:
+                - name
+                - number
             type: object
         request.CheckoutExperienceRequest:
             properties:
                 adultCount:
                     description: 大人人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 billingAddressId:
                     description: 請求先住所ID
@@ -43,15 +57,21 @@ components:
                     $ref: '#/components/schemas/request.CheckoutCreditCard'
                 elementarySchoolCount:
                     description: 小学生人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 juniorHighSchoolCount:
                     description: 中学生人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 paymentMethod:
                     description: 支払い方法
                     type: integer
                 preschoolCount:
                     description: 幼児人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 promotionCode:
                     description: プロモーションコード
@@ -67,13 +87,22 @@ components:
                     type: string
                 seniorCount:
                     description: シニア人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 total:
                     description: 支払い合計金額（誤り検出用）
+                    minimum: 0
                     type: integer
                 transportation:
                     description: 交通手段
+                    maxLength: 256
                     type: string
+            required:
+                - billingAddressId
+                - callbackUrl
+                - paymentMethod
+                - requestId
             type: object
         request.CheckoutProductRequest:
             properties:
@@ -82,6 +111,7 @@ components:
                     type: string
                 boxNumber:
                     description: 箱の通番（箱単位で購入する場合）
+                    minimum: 0
                     type: integer
                 callbackUrl:
                     description: 決済完了後のリダイレクト先URL
@@ -105,66 +135,101 @@ components:
                     type: string
                 total:
                     description: 支払い合計金額（誤り検出用）
+                    minimum: 0
                     type: integer
+            required:
+                - billingAddressId
+                - callbackUrl
+                - coordinatorId
+                - paymentMethod
+                - requestId
+                - shippingAddressId
             type: object
         request.CreateAddressRequest:
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 isDefault:
                     description: デフォルト設定フラグ
                     type: boolean
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 1
                     type: integer
+            required:
+                - addressLine1
+                - city
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
+                - postalCode
+                - prefectureCode
             type: object
         request.CreateAuthUserRequest:
             properties:
                 accountId:
                     description: ユーザーID(検索名)
+                    maxLength: 32
                     type: string
                 email:
                     description: メールアドレス
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 password:
                     description: パスワード
+                    maxLength: 32
+                    minLength: 8
                     type: string
                 passwordConfirmation:
                     description: パスワード (確認用)
@@ -174,27 +239,44 @@ components:
                     type: string
                 username:
                     description: ユーザー名(表示名)
+                    maxLength: 32
                     type: string
+            required:
+                - accountId
+                - email
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - passwordConfirmation
+                - phoneNumber
+                - username
             type: object
         request.CreateAuthUserWithGoogleRequest:
             properties:
                 accountId:
                     description: ユーザーID(検索名)
+                    maxLength: 32
+                    minLength: 4
                     type: string
                 code:
                     description: 認証コード
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 nonce:
                     description: セキュア文字列（リプレイアタック対策）
@@ -207,27 +289,45 @@ components:
                     type: string
                 username:
                     description: ユーザー名(表示名)
+                    maxLength: 32
                     type: string
+            required:
+                - accountId
+                - code
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - nonce
+                - phoneNumber
+                - redirectUri
+                - username
             type: object
         request.CreateAuthUserWithLINERequest:
             properties:
                 accountId:
                     description: ユーザーID(検索名)
+                    maxLength: 32
+                    minLength: 4
                     type: string
                 code:
                     description: 認証コード
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 nonce:
                     description: セキュア文字列（リプレイアタック対策）
@@ -240,63 +340,104 @@ components:
                     type: string
                 username:
                     description: ユーザー名(表示名)
+                    maxLength: 32
                     type: string
+            required:
+                - accountId
+                - code
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - nonce
+                - phoneNumber
+                - redirectUri
+                - username
             type: object
         request.CreateExperienceReviewRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 rate:
                     description: 評価
+                    maximum: 5
+                    minimum: 1
                     type: integer
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - comment
+                - title
             type: object
         request.CreateGuestLiveCommentRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 200
                     type: string
+            required:
+                - comment
             type: object
         request.CreateGuestVideoCommentRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 200
                     type: string
+            required:
+                - comment
             type: object
         request.CreateLiveCommentRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 200
                     type: string
+            required:
+                - comment
             type: object
         request.CreateProductReviewRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 rate:
                     description: 評価
+                    maximum: 5
+                    minimum: 1
                     type: integer
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - comment
+                - title
             type: object
         request.CreateSpotRequest:
             properties:
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 latitude:
                     description: 緯度
+                    maximum: 90
+                    minimum: -90
                     type: number
                 longitude:
                     description: 経度
+                    maximum: 180
+                    minimum: -180
                     type: number
                 name:
                     description: スポット名
+                    maxLength: 64
                     type: string
                 spotTypeId:
                     description: スポット種別ID
@@ -304,63 +445,97 @@ components:
                 thumbnailUrl:
                     description: サムネイルURL
                     type: string
+            required:
+                - latitude
+                - longitude
+                - name
+                - spotTypeId
             type: object
         request.CreateVideoCommentRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 200
                     type: string
+            required:
+                - comment
             type: object
         request.ForgotAuthPasswordRequest:
             properties:
                 email:
                     description: メールアドレス
                     type: string
+            required:
+                - email
             type: object
         request.GetUploadURLRequest:
             properties:
                 fileType:
                     description: ファイル種別
                     type: string
+            required:
+                - fileType
             type: object
         request.GuestCheckoutAddress:
             description: 請求先住所
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 1
                     type: integer
+            required:
+                - addressLine1
+                - city
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
+                - postalCode
+                - prefectureCode
             type: object
         request.GuestCheckoutExperienceRequest:
             properties:
                 adultCount:
                     description: 大人人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 billingAddress:
                     $ref: '#/components/schemas/request.GuestCheckoutAddress'
@@ -371,18 +546,24 @@ components:
                     $ref: '#/components/schemas/request.CheckoutCreditCard'
                 elementarySchoolCount:
                     description: 小学生人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 email:
                     description: メールアドレス
                     type: string
                 juniorHighSchoolCount:
                     description: 中学生人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 paymentMethod:
                     description: 支払い方法
                     type: integer
                 preschoolCount:
                     description: 幼児人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 promotionCode:
                     description: プロモーションコード
@@ -398,13 +579,23 @@ components:
                     type: string
                 seniorCount:
                     description: シニア人数
+                    maximum: 99
+                    minimum: 0
                     type: integer
                 total:
                     description: 支払い合計金額（誤り検出用）
+                    minimum: 0
                     type: integer
                 transportation:
                     description: 交通手段
+                    maxLength: 256
                     type: string
+            required:
+                - billingAddress
+                - callbackUrl
+                - email
+                - paymentMethod
+                - requestId
             type: object
         request.GuestCheckoutProductRequest:
             properties:
@@ -412,6 +603,7 @@ components:
                     $ref: '#/components/schemas/request.GuestCheckoutAddress'
                 boxNumber:
                     description: 箱の通番（箱単位で購入する場合）
+                    minimum: 0
                     type: integer
                 callbackUrl:
                     description: 決済完了後のリダイレクト先URL
@@ -440,13 +632,23 @@ components:
                     $ref: '#/components/schemas/request.GuestCheckoutAddress'
                 total:
                     description: 支払い合計金額（誤り検出用）
+                    minimum: 0
                     type: integer
+            required:
+                - billingAddress
+                - callbackUrl
+                - coordinatorId
+                - email
+                - paymentMethod
+                - requestId
             type: object
         request.RefreshAuthTokenRequest:
             properties:
                 refreshToken:
                     description: 更新トークン
                     type: string
+            required:
+                - refreshToken
             type: object
         request.ResetAuthPasswordRequest:
             properties:
@@ -455,6 +657,8 @@ components:
                     type: string
                 password:
                     description: パスワード
+                    maxLength: 32
+                    minLength: 8
                     type: string
                 passwordConfirmation:
                     description: パスワード (確認用)
@@ -462,6 +666,10 @@ components:
                 verifyCode:
                     description: 検証コード
                     type: string
+            required:
+                - email
+                - passwordConfirmation
+                - verifyCode
             type: object
         request.SignInRequest:
             properties:
@@ -471,47 +679,72 @@ components:
                 username:
                     description: ユーザー名 (メールアドレス,電話番号)
                     type: string
+            required:
+                - password
+                - username
             type: object
         request.UpdateAddressRequest:
             properties:
                 addressLine1:
                     description: 町名・番地
+                    maxLength: 64
                     type: string
                 addressLine2:
                     description: ビル名・号室など
+                    maxLength: 64
                     type: string
                 city:
                     description: 市区町村
+                    maxLength: 32
                     type: string
                 firstname:
                     description: 名
+                    maxLength: 16
                     type: string
                 firstnameKana:
                     description: 名（かな）
+                    maxLength: 32
                     type: string
                 isDefault:
                     description: デフォルト設定フラグ
                     type: boolean
                 lastname:
                     description: 姓
+                    maxLength: 16
                     type: string
                 lastnameKana:
                     description: 姓（かな）
+                    maxLength: 32
                     type: string
                 phoneNumber:
                     description: 電話番号
                     type: string
                 postalCode:
                     description: 郵便番号
+                    maxLength: 16
                     type: string
                 prefectureCode:
                     description: 都道府県
+                    maximum: 47
+                    minimum: 1
                     type: integer
+            required:
+                - addressLine1
+                - city
+                - firstname
+                - firstnameKana
+                - lastname
+                - lastnameKana
+                - phoneNumber
+                - postalCode
+                - prefectureCode
             type: object
         request.UpdateAuthPasswordRequest:
             properties:
                 newPassword:
                     description: 新しいパスワード
+                    maxLength: 32
+                    minLength: 8
                     type: string
                 oldPassword:
                     description: 現在のパスワード
@@ -519,18 +752,26 @@ components:
                 passwordConfirmation:
                     description: パスワード (確認用)
                     type: string
+            required:
+                - oldPassword
+                - passwordConfirmation
             type: object
         request.UpdateAuthUserAccountIDRequest:
             properties:
                 accountId:
                     description: ユーザーID(検索名)
+                    maxLength: 32
                     type: string
+            required:
+                - accountId
             type: object
         request.UpdateAuthUserEmailRequest:
             properties:
                 email:
                     description: メールアドレス
                     type: string
+            required:
+                - email
             type: object
         request.UpdateAuthUserNotificationRequest:
             properties:
@@ -548,45 +789,68 @@ components:
             properties:
                 username:
                     description: ユーザー名(表示名)
+                    maxLength: 32
                     type: string
+            required:
+                - username
             type: object
         request.UpdateExperienceReviewRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 rate:
                     description: 評価
+                    maximum: 5
+                    minimum: 1
                     type: integer
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - comment
+                - title
             type: object
         request.UpdateProductReviewRequest:
             properties:
                 comment:
                     description: コメント
+                    maxLength: 2000
                     type: string
                 rate:
                     description: 評価
+                    maximum: 5
+                    minimum: 1
                     type: integer
                 title:
                     description: タイトル
+                    maxLength: 64
                     type: string
+            required:
+                - comment
+                - title
             type: object
         request.UpdateSpotRequest:
             properties:
                 description:
                     description: 説明
+                    maxLength: 2000
                     type: string
                 latitude:
                     description: 緯度
+                    maximum: 90
+                    minimum: -90
                     type: number
                 longitude:
                     description: 経度
+                    maximum: 180
+                    minimum: -180
                     type: number
                 name:
                     description: スポット名
+                    maxLength: 64
                     type: string
                 spotTypeId:
                     description: スポット種別ID
@@ -594,24 +858,35 @@ components:
                 thumbnailUrl:
                     description: サムネイルURL
                     type: string
+            required:
+                - latitude
+                - longitude
+                - name
+                - spotTypeId
             type: object
         request.UpsertExperienceReviewReactionRequest:
             properties:
                 reactionType:
                     description: リアクション種別
                     type: integer
+            required:
+                - reactionType
             type: object
         request.UpsertProductReviewReactionRequest:
             properties:
                 reactionType:
                     description: リアクション種別
                     type: integer
+            required:
+                - reactionType
             type: object
         request.VerifyAuthUserEmailRequest:
             properties:
                 verifyCode:
                     description: 検証コード
                     type: string
+            required:
+                - verifyCode
             type: object
         request.VerifyAuthUserRequest:
             properties:
@@ -621,6 +896,9 @@ components:
                 verifyCode:
                     description: 検証コード
                     type: string
+            required:
+                - id
+                - verifyCode
             type: object
         response.Address:
             description: アドレス情報
@@ -2443,13 +2721,6 @@ components:
         time.Weekday:
             type: integer
             x-enum-varnames:
-                - Sunday
-                - Monday
-                - Tuesday
-                - Wednesday
-                - Thursday
-                - Friday
-                - Saturday
                 - Sunday
                 - Monday
                 - Tuesday


### PR DESCRIPTION
## 概要
admin/user gateway のリクエスト構造体にバリデーションタグを統一的に追加し、APIリクエストの検証機能を強化しました。

## 変更内容
- **admin gateway**: 28個のリクエストファイルにバリデーションタグを追加
- **user gateway**: 15個のリクエストファイルにバリデーションタグを追加
- facility/requestの既存パターンに合わせた統一的なバリデーション規則を適用
- gofmtによるコードフォーマット修正を実施

## 背景・目的
既存のfacility/requestディレクトリでは適切なバリデーションタグが設定されていましたが、admin/user gatewayのリクエスト構造体にはバリデーションタグが不足していました。APIの堅牢性向上とデータ整合性確保のため、統一的なバリデーション規則を適用する必要がありました。

## 主な追加バリデーション
- **文字列長制限**: `max=16`, `max=32`, `max=64`, `max=2000`など適切な長さ制限
- **必須フィールド**: `required`タグによる必須入力チェック
- **数値範囲**: `min=0`, `max=47`（都道府県コードなど）、`min=1`など適切な範囲制限
- **フォーマット検証**: `email`, `phone_number`, `http_url`, `hiragana`, `numeric`など
- **配列検証**: `dive`タグによるネストした構造体の検証
- **フィールド比較**: `gtfield=StartAt`など関連フィールド間の制約

## テスト
- [x] gofmtによるフォーマット修正完了
- [ ] API: make test (Go)
- [ ] API: make lint-fix
- [ ] 手動での各エンドポイントバリデーション確認

## レビューポイント
- バリデーションルールの妥当性（特に数値範囲と文字列長制限）
- 既存のfacility/requestパターンとの一貫性
- 必須/任意フィールドの分類が適切か
- ネストした構造体でのdiveタグの使用が適切か

## 関連ファイル
- `api/internal/gateway/admin/v1/request/*.go` (28ファイル)
- `api/internal/gateway/user/v1/request/*.go` (15ファイル)
- Swagger定義ファイルの自動更新

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 管理・ユーザー向け各種APIの入力バリデーションを大幅強化（必須化、最大文字数、メール/URL/電話番号形式、配列要素チェック、数値範囲、日時相関、ひらがな検証など）。不正入力時のエラーがより明確に。

- リファクタ
  - 動画更新リクエストでCategoryIDsを廃止し、CoordinatorIDを必須化。
  - 体験/商品/ライブ等で開始・終了時刻の必須化と整合性チェックを導入。人数/数量は0～99に制約。
  - 住所/連絡先/配送/通知/チェックアウト関連にも同様の制約を適用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->