### PR TITLE
Release for v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v6.0.1](https://github.com/and-period/furumaru/compare/v6.0.0...v6.0.1) - 2025-09-07
+- Claude Codeセッション管理システムの追加 by @taba2424 in https://github.com/and-period/furumaru/pull/3006
+
 ## [v6.0.0](https://github.com/and-period/furumaru/compare/v5.1.3...v6.0.0) - 2025-09-07
 - feat(api): キャンプ施設向け認証機能の実装 by @taba2424 in https://github.com/and-period/furumaru/pull/2963
 - OpenAPI tooling improvements and component name simplification by @taba2424 in https://github.com/and-period/furumaru/pull/2966


### PR DESCRIPTION
This pull request is for the next release as v6.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v6.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v6.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Claude Codeセッション管理システムの追加 by @taba2424 in https://github.com/and-period/furumaru/pull/3006


**Full Changelog**: https://github.com/and-period/furumaru/compare/v6.0.0...v6.0.1