### PR TITLE
feat(web): add LIFF initialization to facility detail page

### DIFF
--- a/web/liff/src/pages/[facilityId]/index.vue
+++ b/web/liff/src/pages/[facilityId]/index.vue
@@ -4,14 +4,19 @@ import { NuxtLink } from '#components';
 import { storeToRefs } from 'pinia';
 import { useProductStore } from '~/stores/product';
 import { useShoppingCartStore } from '~/stores/shopping';
+import { useLiffInit } from '~/composables/useLiffInit';
 
 const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+
 const facilityId = computed<string>(() => String(route.params.facilityId || ''));
+const { init: initLiff } = useLiffInit();
 
 // 商品取得
 const productStore = useProductStore();
 const { products, isLoading, error } = storeToRefs(productStore);
-onMounted(() => {
+onMounted(async () => {
+  await initLiff(runtimeConfig.public.LIFF_ID);
   productStore.fetchProducts();
 });
 


### PR DESCRIPTION
## 概要
施設詳細ページにLIFF（LINE Front-end Framework）の初期化処理を追加しました。

## 変更内容
- `web/liff/src/pages/[facilityId]/index.vue`にLIFF初期化処理を追加
- `useLiffInit`コンポーザブルをインポート
- ページマウント時にLIFF IDを使用して初期化を実行

## 背景・目的
LIFFアプリケーションとして動作させるため、各ページでLIFF SDKの初期化が必要です。
施設詳細ページは顧客が最初にアクセスするエントリーポイントのため、適切な初期化処理を追加しました。

## テスト
- [ ] API: make test (Go)
- [ ] API: make lint-fix
- [ ] フロントエンド: yarn typecheck
- [ ] フロントエンド: yarn lint
- [ ] 手動テスト完了

## レビューポイント
- LIFF初期化のタイミング（onMounted）が適切か
- エラーハンドリングが必要か

## 関連情報
- LINE Front-end Framework（LIFF）の実装

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * カートに商品を追加する操作を追加。失敗時は適切にエラー処理を行い、ユーザー体験を向上。
* バグ修正
  * ページ表示時にLIFF初期化の完了を待ってから商品データを取得するように調整し、初回表示の安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->