### PR TITLE
feat(api): implement FacilityUser Delete method with transaction support

### DIFF
--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -238,6 +238,7 @@ type FacilityUser interface {
 	GetByExternalID(ctx context.Context, providerType entity.UserAuthProviderType, externalID, producerID string, fields ...string) (*entity.FacilityUser, error)
 	Create(ctx context.Context, user *entity.User) error
 	Update(ctx context.Context, userID string, params *UpdateFacilityUserParams) error
+	Delete(ctx context.Context, userID string) error
 }
 
 type UpdateFacilityUserParams struct {

--- a/api/internal/user/service/user.go
+++ b/api/internal/user/service/user.go
@@ -73,7 +73,8 @@ func (s *service) DeleteUser(ctx context.Context, in *user.DeleteUserInput) erro
 	if err != nil {
 		return internalError(err)
 	}
-	if u.Registered {
+	switch u.Type {
+	case entity.UserTypeMember:
 		auth := func(ctx context.Context) error {
 			err := s.userAuth.DeleteUser(ctx, u.CognitoID)
 			if errors.Is(err, cognito.ErrNotFound) {
@@ -82,8 +83,10 @@ func (s *service) DeleteUser(ctx context.Context, in *user.DeleteUserInput) erro
 			return err
 		}
 		err = s.db.Member.Delete(ctx, u.ID, auth)
-	} else {
+	case entity.UserTypeGuest:
 		err = s.db.Guest.Delete(ctx, u.ID)
+	case entity.UserTypeFacilityUser:
+		err = s.db.FacilityUser.Delete(ctx, u.ID)
 	}
 	return internalError(err)
 }

--- a/api/internal/user/service/user_test.go
+++ b/api/internal/user/service/user_test.go
@@ -368,6 +368,26 @@ func TestDeleteUser(t *testing.T) {
 			UpdatedAt: now,
 		},
 	}
+	f := &entity.User{
+		ID:         "user-id",
+		Status:     entity.UserStatusVerified,
+		Registered: false,
+		FacilityUser: entity.FacilityUser{
+			UserID:        "user-id",
+			ProducerID:    "producer-id",
+			ProviderType:  entity.UserAuthProviderTypeLINE,
+			ExternalID:    "external-id",
+			Email:         "test-user@and-period.jp",
+			Lastname:      "テスト",
+			Firstname:     "ユーザー",
+			LastnameKana:  "てすと",
+			FirstnameKana: "ゆーざー",
+			PhoneNumber:   "+810000000000",
+			LastCheckInAt: now,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		},
+	}
 
 	tests := []struct {
 		name      string
@@ -396,6 +416,17 @@ func TestDeleteUser(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(g, nil)
 				mocks.db.Guest.EXPECT().Delete(ctx, "user-id").Return(nil)
+			},
+			input: &user.DeleteUserInput{
+				UserID: "user-id",
+			},
+			expectErr: nil,
+		},
+		{
+			name: "success facility user",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(f, nil)
+				mocks.db.FacilityUser.EXPECT().Delete(ctx, "user-id").Return(nil)
 			},
 			input: &user.DeleteUserInput{
 				UserID: "user-id",
@@ -434,6 +465,17 @@ func TestDeleteUser(t *testing.T) {
 			setup: func(ctx context.Context, mocks *mocks) {
 				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(g, nil)
 				mocks.db.Guest.EXPECT().Delete(ctx, "user-id").Return(assert.AnError)
+			},
+			input: &user.DeleteUserInput{
+				UserID: "user-id",
+			},
+			expectErr: exception.ErrInternal,
+		},
+		{
+			name: "failed to delete facility user",
+			setup: func(ctx context.Context, mocks *mocks) {
+				mocks.db.User.EXPECT().Get(ctx, "user-id").Return(f, nil)
+				mocks.db.FacilityUser.EXPECT().Delete(ctx, "user-id").Return(assert.AnError)
 			},
 			input: &user.DeleteUserInput{
 				UserID: "user-id",


### PR DESCRIPTION
## Summary
- Add Delete method to FacilityUser interface and TiDB implementation with transaction support
- Update DeleteUser service to handle FacilityUser type routing  
- Add comprehensive test coverage for the Delete method

## Changes Made

### Database Layer
- **Added Delete method to FacilityUser interface** (`api/internal/user/database/database.go`)
  - Extends the interface with `Delete(ctx context.Context, userID string) error`

- **Implemented Delete method in TiDB** (`api/internal/user/database/tidb/facility_user.go`)
  - Uses database transaction to ensure atomicity
  - Nullifies `exists` field in `facility_users` table
  - Soft deletes user record by setting `deleted_at` timestamp
  - Proper error handling with `dbError` wrapper

### Service Layer  
- **Updated DeleteUser service** (`api/internal/user/service/user.go`)
  - Changed from simple registered/unregistered logic to user type-based routing
  - Added `entity.UserTypeFacilityUser` case to call `s.db.FacilityUser.Delete`

### Test Coverage
- **Added comprehensive Delete method tests** (`api/internal/user/database/tidb/facility_user_test.go`)
  - Success case with proper data verification
  - Edge case for non-existent user handling  
  - Validates soft delete behavior for both tables

- **Extended DeleteUser service tests** (`api/internal/user/service/user_test.go`)
  - Added facility user success case
  - Added facility user error case for comprehensive coverage

## Implementation Details

The Delete method implements a soft delete pattern:
1. **Transaction-based**: All operations occur within a single database transaction
2. **Dual-table update**: Updates both `facility_users` and `users` tables atomically
3. **Soft delete**: Sets `deleted_at` timestamp rather than hard deletion
4. **Exists field handling**: Nullifies the `exists` field in facility_users table

## Test Plan
- [x] Unit tests pass for new Delete method
- [x] Service layer tests updated and passing
- [x] Integration with existing DeleteUser service verified
- [ ] Run full test suite to ensure no regressions
- [ ] Manual verification of transaction behavior
- [ ] Verify soft delete behavior in database

🤖 Generated with [Claude Code](https://claude.ai/code)