### PR TITLE
feat(web): 体験管理ページのUI/UX改善

### DIFF
--- a/web/admin/src/components/templates/ExperienceList.vue
+++ b/web/admin/src/components/templates/ExperienceList.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { mdiDelete, mdiPlus, mdiContentCopy } from '@mdi/js'
+import { mdiDelete, mdiPlus, mdiContentCopy, mdiCalendarCheck } from '@mdi/js'
 import type { VDataTable } from 'vuetify/lib/components/index.mjs'
 import { prefecturesList } from '~/constants'
 import { getResizedImages } from '~/lib/helpers'
@@ -45,10 +45,6 @@ const props = defineProps({
     type: Array<Producer>,
     defaut: () => [],
   },
-  experiencesResponse: {
-    type: Array<ExperiencesResponse>,
-    default: () => [],
-  },
   experiences: {
     type: Array<Experience>,
     default: () => [],
@@ -72,7 +68,7 @@ const emit = defineEmits<{
   (e: 'click:update-items-per-page', page: number): void
   (e: 'click:show', productId: string): void
   (e: 'click:new'): void
-  (e: 'click:copyItem'): void
+  (e: 'click:copy-item'): void
   (e: 'click:delete', productId: string): void
   (e: 'update:delete-dialog', v: boolean): void
   (e: 'update:selectedItemId', v: string): void
@@ -125,7 +121,6 @@ const handleUpdateSelectItemId = (itemIds: string[]): void => {
     emit('update:selectedItemId', itemIds[0])
   }
 }
-console.log(props.experiencesResponse)
 
 const selectedItem = ref<Experience>()
 
@@ -188,6 +183,10 @@ const onClickShow = (productId: string): void => {
 
 const onClickNew = (): void => {
   emit('click:new')
+}
+
+const onClickCopyItem = (): void => {
+  emit('click:copy-item')
 }
 
 const onClickDelete = (): void => {
@@ -253,13 +252,21 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
     width="500"
   >
     <v-card>
-      <v-card-text class="text-h7">
-        {{ selectedItem?.title }}を本当に削除しますか？
+      <v-card-title class="text-h6 py-4">
+        体験削除の確認
+      </v-card-title>
+      <v-card-text class="pb-4">
+        <div class="text-body-1">
+          「{{ selectedItem?.title }}」を削除しますか？
+        </div>
+        <div class="text-body-2 text-medium-emphasis mt-2">
+          この操作は取り消せません。
+        </div>
       </v-card-text>
-      <v-card-actions>
+      <v-card-actions class="px-6 pb-4">
         <v-spacer />
         <v-btn
-          color="error"
+          color="medium-emphasis"
           variant="text"
           @click="toggleDeleteDialog"
         >
@@ -267,8 +274,8 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
         </v-btn>
         <v-btn
           :loading="loading"
-          color="primary"
-          variant="outlined"
+          color="error"
+          variant="elevated"
           @click="onClickDelete"
         >
           削除
@@ -278,34 +285,69 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
   </v-dialog>
 
   <v-card
-    class="mt-4"
-    flat
+    class="mt-6"
+    elevation="0"
+    rounded="lg"
   >
-    <v-card-title class="d-flex flex-row">
-      体験管理
-    </v-card-title>
-
-    <div class="d-flex w-100 px-6 ga-2">
-      <v-spacer />
-      <v-btn
-        v-show="isRegisterable()"
-        variant="outlined"
-        color="primary"
-        @click="onClickNew"
-      >
+    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
+      <div class="d-flex align-center">
         <v-icon
-          start
-          :icon="mdiPlus"
+          :icon="mdiCalendarCheck"
+          size="28"
+          class="mr-3 text-primary"
         />
-        体験登録
-      </v-btn>
-    </div>
+        <div>
+          <h1 class="text-h5 font-weight-bold text-primary">
+            体験管理
+          </h1>
+          <p class="text-body-2 text-medium-emphasis ma-0">
+            体験の登録・編集・削除を行います
+          </p>
+        </div>
+      </div>
+      <div class="d-flex ga-3">
+        <v-btn
+          v-show="isRegisterable()"
+          variant="outlined"
+          color="secondary"
+          size="large"
+          :disabled="selectedItemId === ''"
+          @click="onClickCopyItem"
+        >
+          <v-icon
+            start
+            :icon="mdiContentCopy"
+          />
+          体験複製
+          <v-tooltip
+            v-if="selectedItemId === ''"
+            activator="parent"
+            location="bottom"
+          >
+            コピー元の体験をチェックする必要があります。
+          </v-tooltip>
+        </v-btn>
+        <v-btn
+          v-show="isRegisterable()"
+          variant="elevated"
+          color="primary"
+          size="large"
+          @click="onClickNew"
+        >
+          <v-icon
+            start
+            :icon="mdiPlus"
+          />
+          体験登録
+        </v-btn>
+      </div>
+    </v-card-title>
 
     <v-card-text>
       <v-data-table-server
         :headers="headers"
         :loading="loading"
-        :items="props.experiencesResponse.experiences"
+        :items="props.experiences"
         :items-per-page="props.tableItemsPerPage"
         :items-length="props.tableItemsTotal"
         hover
@@ -344,7 +386,7 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
           <v-btn
             v-show="isDeletable()"
             variant="outlined"
-            color="primary"
+            color="error"
             size="small"
             @click.stop="toggleDeleteDialog(item)"
           >

--- a/web/admin/src/components/templates/ExperienceNew.vue
+++ b/web/admin/src/components/templates/ExperienceNew.vue
@@ -1,5 +1,17 @@
 <script lang="ts" setup>
-import { mdiClose, mdiPlus } from '@mdi/js'
+import {
+  mdiClose,
+  mdiPlus,
+  mdiCalendarCheck,
+  mdiImageMultiple,
+  mdiStar,
+  mdiCurrencyJpy,
+  mdiMapMarker,
+  mdiClock,
+  mdiVideo,
+  mdiArrowLeft,
+  mdiTagMultiple,
+} from '@mdi/js'
 import useVuelidate from '@vuelidate/core'
 
 import dayjs, { unix } from 'dayjs'
@@ -29,6 +41,7 @@ interface Props {
   searchErrorMessage: string
   searchLoading: boolean
   videoUploading: boolean
+  producerSearchKeyword?: string
 }
 
 const props = defineProps<Props>()
@@ -42,6 +55,7 @@ const emit = defineEmits<{
   ): void
   (e: 'click:search-address'): void
   (e: 'submit'): void
+  (e: 'update:producer-search-keyword', v: string): void
 }>()
 
 const thumbnailIndex = computed<number>({
@@ -123,7 +137,6 @@ const onChangeVideo = (files?: FileList): void => {
   if (!files) {
     return
   }
-  // 動画ファイルのemits
   emit('update:video', files)
 }
 
@@ -155,6 +168,11 @@ const endTimeDataValue = computed({
     const endAt = dayjs(`${timeData.date} ${timeData.time}`)
     formDataValue.value.endAt = endAt.unix()
   },
+})
+
+const producerSearchKeywordValue = computed({
+  get: (): string => props.producerSearchKeyword || '',
+  set: (v: string): void => emit('update:producer-search-keyword', v),
 })
 
 const formDataValidate = useVuelidate(
@@ -194,147 +212,198 @@ const onSubmit = async (): Promise<void> => {
 </script>
 
 <template>
-  <v-alert
-    v-show="props.isAlert"
-    :type="props.alertType"
-    class="mb-2"
-    v-text="props.alertText"
-  />
+  <v-container class="pa-6">
+    <v-alert
+      v-show="props.isAlert"
+      :type="props.alertType"
+      class="mb-6"
+      v-text="props.alertText"
+    />
 
-  <v-card-title>体験登録</v-card-title>
+    <div class="mb-6">
+      <v-btn
+        variant="text"
+        :prepend-icon="mdiArrowLeft"
+        @click="$router.back()"
+      >
+        戻る
+      </v-btn>
+      <h1 class="text-h4 font-weight-bold mt-2 mb-2">
+        体験登録
+      </h1>
+      <p class="text-body-1 text-grey-darken-1">
+        新しい体験の情報を登録します。各セクションを順番に入力してください。
+      </p>
+    </div>
 
-  <v-row>
-    <v-col
-      sm="12"
-      md="12"
-      lg="8"
-    >
-      <div class="mb-4">
+    <v-row>
+      <v-col
+        cols="12"
+        lg="8"
+      >
+        <!-- 基本情報セクション -->
         <v-card
-          elevation="0"
-          class="mb-4"
-          :loading="loading"
+          class="form-section-card mb-6"
+          elevation="2"
         >
-          <v-card-title>基本情報</v-card-title>
-          <v-card-text>
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiCalendarCheck"
+              size="24"
+              class="mr-3 text-primary"
+            />
+            <span class="text-h6 font-weight-medium">基本情報</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
             <v-autocomplete
               v-model="formDataValidate.producerId.$model"
-              label="生産者名"
+              v-model:search="producerSearchKeywordValue"
+              label="生産者名 *"
               :items="producers"
               item-title="username"
               item-value="id"
+              variant="outlined"
+              density="comfortable"
+              :error-messages="getErrorMessage(formDataValidate.producerId.$errors)"
+              class="mb-4"
             />
             <v-text-field
               v-model="formDataValidate.title.$model"
-              label="体験名"
-              outlined
+              label="体験名 *"
+              variant="outlined"
+              density="comfortable"
+              :error-messages="getErrorMessage(formDataValidate.title.$errors)"
+              class="mb-4"
             />
             <v-textarea
               v-model="formDataValidate.description.$model"
-              label="体験説明"
+              label="体験説明 *"
               maxlength="2000"
-            />
-            <v-number-input
-              v-model="formDataValidate.duration.$model"
-              :max="24"
-              :min="0"
-              :reverse="false"
-              control-variant="default"
-              label="所要時間"
-              :hide-input="false"
-              :inset="true"
-            />
-            <p class="text-subtitle-2 text-grey py-2">
-              営業時間
-            </p>
-            <div class="d-flex flex-column flex-md-row justify-center">
-              <v-text-field
-                v-model="formDataValidate.businessOpenTime.$model"
-                type="time"
-                variant="outlined"
-                density="compact"
-              />
-              <div class="pa-3">
-                〜
-              </div>
-              <v-text-field
-                v-model="formDataValidate.businessCloseTime.$model"
-                type="time"
-                variant="outlined"
-                density="compact"
-              />
-            </div>
-            <v-textarea
-              v-model="formDataValidate.direction.$model"
-              label="アクセス方法"
-              maxlength="2000"
+              variant="outlined"
+              density="comfortable"
+              rows="4"
+              counter
+              :error-messages="getErrorMessage(formDataValidate.description.$errors)"
             />
           </v-card-text>
-          <v-card-subtitle>商品画像登録</v-card-subtitle>
-          <v-card-text>
+        </v-card>
+
+        <!-- 体験画像管理セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiImageMultiple"
+              size="24"
+              class="mr-3 text-primary"
+            />
+            <span class="text-h6 font-weight-medium">体験画像管理</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <div class="mb-4">
+              <atoms-file-upload-filed
+                text="体験画像をアップロード"
+                @update:files="onClickImageUpload"
+              />
+            </div>
+
             <v-radio-group
+              v-if="formDataValue.media.length > 0"
               v-model="thumbnailIndex"
               :error-messages="getErrorMessage(formDataValidate.media.$errors)"
+              class="image-gallery"
             >
+              <div class="mb-3">
+                <v-chip
+                  color="primary"
+                  variant="outlined"
+                  size="small"
+                >
+                  サムネイルを選択してください
+                </v-chip>
+              </div>
               <v-row>
                 <v-col
                   v-for="(img, i) in formDataValue.media"
                   :key="i"
-                  cols="4"
-                  class="d-flex flex-row align-center"
+                  cols="6"
+                  sm="4"
+                  md="3"
                 >
                   <v-card
-                    rounded
-                    variant="outlined"
-                    width="100%"
-                    :class="{ 'thumbnail-border': img.isThumbnail }"
+                    class="image-card"
+                    :class="{ 'thumbnail-selected': img.isThumbnail }"
                     @click="onClickThumbnail(i)"
                   >
                     <v-img
                       :src="img.url"
                       aspect-ratio="1"
+                      class="image-preview"
                     >
-                      <div class="d-flex col">
+                      <div class="image-overlay">
                         <v-radio
                           :value="i"
                           color="primary"
+                          class="thumbnail-radio"
                         />
                         <v-btn
                           :icon="mdiClose"
                           color="error"
                           variant="text"
                           size="small"
-                          @click="onDeleteThumbnail(i)"
+                          class="delete-btn"
+                          @click.stop="onDeleteThumbnail(i)"
                         />
                       </div>
                     </v-img>
+                    <v-card-text class="pa-2 text-center">
+                      <v-chip
+                        v-if="img.isThumbnail"
+                        color="primary"
+                        size="x-small"
+                        variant="elevated"
+                      >
+                        サムネイル
+                      </v-chip>
+                      <span
+                        v-else
+                        class="text-caption text-grey"
+                      >
+                        画像 {{ i + 1 }}
+                      </span>
+                    </v-card-text>
                   </v-card>
                 </v-col>
               </v-row>
             </v-radio-group>
-            <p
-              v-show="formDataValue.media.length > 0"
-              class="mt-2"
-            >
-              ※ check された商品画像がサムネイルになります
-            </p>
-            <div class="mb-2">
-              <atoms-file-upload-filed
-                text="商品画像"
-                @update:files="onClickImageUpload"
-              />
-            </div>
           </v-card-text>
-          <div class="mx-4">
+        </v-card>
+
+        <!-- 紹介動画セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiVideo"
+              size="24"
+              class="mr-3 text-primary"
+            />
+            <span class="text-h6 font-weight-medium">紹介動画</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
             <molecules-video-select-form
-              label="紹介動画"
+              label="紹介動画をアップロード"
               :loading="videoUploading"
               @update:file="onChangeVideo"
             />
             <template v-if="formDataValue.promotionVideoUrl">
               <v-responsive
                 :aspect-ratio="16 / 9"
-                class="border pa-4"
+                class="mt-4 border rounded"
               >
                 <video
                   class="w-100"
@@ -343,29 +412,136 @@ const onSubmit = async (): Promise<void> => {
                 />
               </v-responsive>
             </template>
-          </div>
-          <v-card-text>
-            <v-text-field
-              v-model="formDataValidate.recommendedPoint1.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.recommendedPoint1.$errors)
-              "
-              label="おすすめポイント1"
+          </v-card-text>
+        </v-card>
+
+        <!-- おすすめポイント・詳細セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiStar"
+              size="24"
+              class="mr-3 text-primary"
             />
-            <v-text-field
-              v-model="formDataValidate.recommendedPoint2.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.recommendedPoint2.$errors)
-              "
-              label="おすすめポイント2"
+            <span class="text-h6 font-weight-medium">おすすめポイント・詳細</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <div class="mb-4">
+              <p class="text-subtitle-2 mb-3 text-grey-darken-1">
+                おすすめポイント
+              </p>
+              <v-text-field
+                v-model="formDataValidate.recommendedPoint1.$model"
+                :error-messages="
+                  getErrorMessage(formDataValidate.recommendedPoint1.$errors)
+                "
+                label="ポイント 1"
+                variant="outlined"
+                density="comfortable"
+                class="mb-3"
+              />
+              <v-text-field
+                v-model="formDataValidate.recommendedPoint2.$model"
+                :error-messages="
+                  getErrorMessage(formDataValidate.recommendedPoint2.$errors)
+                "
+                label="ポイント 2"
+                variant="outlined"
+                density="comfortable"
+                class="mb-3"
+              />
+              <v-text-field
+                v-model="formDataValidate.recommendedPoint3.$model"
+                :error-messages="
+                  getErrorMessage(formDataValidate.recommendedPoint3.$errors)
+                "
+                label="ポイント 3"
+                variant="outlined"
+                density="comfortable"
+              />
+            </div>
+
+            <v-row>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.duration.$model"
+                  label="所要時間"
+                  type="number"
+                  :min="0"
+                  :max="24"
+                  variant="outlined"
+                  density="comfortable"
+                  suffix="時間"
+                  :error-messages="getErrorMessage(formDataValidate.duration.$errors)"
+                />
+              </v-col>
+            </v-row>
+
+            <v-textarea
+              v-model="formDataValidate.direction.$model"
+              label="アクセス方法"
+              maxlength="2000"
+              variant="outlined"
+              density="comfortable"
+              rows="3"
+              counter
+              :error-messages="getErrorMessage(formDataValidate.direction.$errors)"
             />
-            <v-text-field
-              v-model="formDataValidate.recommendedPoint3.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.recommendedPoint3.$errors)
-              "
-              label="おすすめポイント3"
+          </v-card-text>
+        </v-card>
+
+        <!-- 営業時間・場所セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiMapMarker"
+              size="24"
+              class="mr-3 text-primary"
             />
+            <span class="text-h6 font-weight-medium">営業時間・場所</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <div class="mb-4">
+              <p class="text-subtitle-2 mb-3 text-grey-darken-1">
+                営業時間
+              </p>
+              <v-row>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="formDataValidate.businessOpenTime.$model"
+                    type="time"
+                    label="開始時間"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                </v-col>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="formDataValidate.businessCloseTime.$model"
+                    type="time"
+                    label="終了時間"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                </v-col>
+              </v-row>
+            </div>
+
             <molecules-address-form
               v-model:postal-code="formDataValue.hostPostalCode"
               v-model:prefecture="formDataValue.hostPrefectureCode"
@@ -377,177 +553,361 @@ const onSubmit = async (): Promise<void> => {
               @click:search="onClickSearchAddress"
             />
           </v-card-text>
-          <v-card-title>価格設定</v-card-title>
-          <v-card-text>
-            <v-text-field
-              v-model.number="formDataValidate.priceAdult.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.priceAdult.$errors)
-              "
-              label="大人(高校生以上）(〜64歳)"
-              type="number"
-              min="0"
-              suffix="円"
+        </v-card>
+
+        <!-- 価格設定セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiCurrencyJpy"
+              size="24"
+              class="mr-3 text-primary"
             />
-            <v-text-field
-              v-model.number="formDataValidate.priceJuniorHighSchool.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.priceJuniorHighSchool.$errors)
-              "
-              label="中学生"
-              type="number"
-              min="0"
-              suffix="円"
+            <span class="text-h6 font-weight-medium">価格設定</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <v-row>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.priceAdult.$model"
+                  :error-messages="
+                    getErrorMessage(formDataValidate.priceAdult.$errors)
+                  "
+                  label="大人(高校生以上）"
+                  type="number"
+                  min="0"
+                  suffix="円"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.priceSenior.$model"
+                  :error-messages="
+                    getErrorMessage(formDataValidate.priceSenior.$errors)
+                  "
+                  label="シニア (65歳〜）"
+                  type="number"
+                  min="0"
+                  suffix="円"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.priceJuniorHighSchool.$model"
+                  :error-messages="
+                    getErrorMessage(formDataValidate.priceJuniorHighSchool.$errors)
+                  "
+                  label="中学生"
+                  type="number"
+                  min="0"
+                  suffix="円"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.priceElementarySchool.$model"
+                  :error-messages="
+                    getErrorMessage(formDataValidate.priceElementarySchool.$errors)
+                  "
+                  label="小学生"
+                  type="number"
+                  min="0"
+                  suffix="円"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <v-text-field
+                  v-model.number="formDataValidate.pricePreschool.$model"
+                  :error-messages="
+                    getErrorMessage(formDataValidate.pricePreschool.$errors)
+                  "
+                  label="未就学児 (3歳〜）"
+                  type="number"
+                  min="0"
+                  suffix="円"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <v-col
+        cols="12"
+        lg="4"
+      >
+        <!-- 販売設定セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiClock"
+              size="24"
+              class="mr-3 text-primary"
             />
-            <v-text-field
-              v-model.number="formDataValidate.priceElementarySchool.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.priceElementarySchool.$errors)
-              "
-              label="小学生"
-              type="number"
-              min="0"
-              suffix="円"
+            <span class="text-h6 font-weight-medium">販売設定</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <v-select
+              v-model="formDataValue._public"
+              label="公開状況 *"
+              :items="publicStatus"
+              item-title="title"
+              item-value="value"
+              variant="outlined"
+              density="comfortable"
+              class="mb-4"
             />
-            <v-text-field
-              v-model.number="formDataValidate.pricePreschool.$model"
-              :error-messages="
-                getErrorMessage(formDataValidate.pricePreschool.$errors)
-              "
-              label="未就学児 (3歳〜）"
-              type="number"
-              min="0"
-              suffix="円"
+            <v-select
+              v-model="formDataValue.soldOut"
+              label="販売状況 *"
+              :items="soldStatus"
+              item-title="title"
+              item-value="value"
+              variant="outlined"
+              density="comfortable"
+              class="mb-4"
             />
-            <v-text-field
-              v-model.number="formDataValidate.priceSenior.$model"
+
+            <div class="date-time-section">
+              <p class="text-subtitle-2 mb-3 text-grey-darken-1">
+                販売開始日時 *
+              </p>
+              <v-row>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="startTimeDataValidate.date.$model"
+                    :error-messages="
+                      getErrorMessage(startTimeDataValidate.date.$errors)
+                    "
+                    label="日付"
+                    type="date"
+                    variant="outlined"
+                    density="comfortable"
+                    @update:model-value="onChangeStartAt"
+                  />
+                </v-col>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="startTimeDataValidate.time.$model"
+                    :error-messages="
+                      getErrorMessage(startTimeDataValidate.time.$errors)
+                    "
+                    label="時刻"
+                    type="time"
+                    variant="outlined"
+                    density="comfortable"
+                    @update:model-value="onChangeStartAt"
+                  />
+                </v-col>
+              </v-row>
+
+              <p class="text-subtitle-2 mb-3 mt-4 text-grey-darken-1">
+                販売終了日時 *
+              </p>
+              <v-row>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="endTimeDataValidate.date.$model"
+                    :error-messages="
+                      getErrorMessage(endTimeDataValidate.date.$errors)
+                    "
+                    label="日付"
+                    type="date"
+                    variant="outlined"
+                    density="comfortable"
+                    @update:model-value="onChangeEndAt"
+                  />
+                </v-col>
+                <v-col
+                  cols="12"
+                  sm="6"
+                >
+                  <v-text-field
+                    v-model="endTimeDataValidate.time.$model"
+                    :error-messages="
+                      getErrorMessage(notSameTimeValidate.endAt.$errors)
+                    "
+                    label="時刻"
+                    type="time"
+                    variant="outlined"
+                    density="comfortable"
+                    @update:model-value="onChangeEndAt"
+                  />
+                </v-col>
+              </v-row>
+            </div>
+          </v-card-text>
+        </v-card>
+
+        <!-- 詳細分類セクション -->
+        <v-card
+          class="form-section-card mb-6"
+          elevation="2"
+        >
+          <v-card-title class="d-flex align-center section-header">
+            <v-icon
+              :icon="mdiTagMultiple"
+              size="24"
+              class="mr-3 text-primary"
+            />
+            <span class="text-h6 font-weight-medium">詳細分類</span>
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <v-select
+              v-model="formDataValidate.experienceTypeId.$model"
               :error-messages="
-                getErrorMessage(formDataValidate.priceSenior.$errors)
+                getErrorMessage(formDataValidate.experienceTypeId.$errors)
               "
-              label="シニア (65歳〜）"
-              type="number"
-              min="0"
-              suffix="円"
+              label="カテゴリ *"
+              :items="experienceTypes"
+              item-title="name"
+              item-value="id"
+              variant="outlined"
+              density="comfortable"
+              no-data-text="カテゴリを選択してください。"
+              clearable
             />
           </v-card-text>
         </v-card>
-      </div>
-    </v-col>
-    <v-col
-      sm="12"
-      md="12"
-      lg="4"
-    >
-      <v-card
-        elevation="0"
-        class="mb-4"
-      >
-        <v-card-title>販売設定</v-card-title>
-        <v-card-text>
-          <v-select
-            v-model="formDataValue._public"
-            label="販売状況"
-            :items="publicStatus"
-            item-title="title"
-            item-value="value"
-          />
-          <v-select
-            v-model="formDataValue.soldOut"
-            label="公開状況"
-            :items="soldStatus"
-            item-title="title"
-            item-value="value"
-          />
-          <p class="text-subtitle-2 text-grey py-2">
-            販売開始日時
-          </p>
-          <div class="d-flex flex-column flex-md-row justify-center">
-            <v-text-field
-              v-model="startTimeDataValidate.date.$model"
-              :error-messages="
-                getErrorMessage(startTimeDataValidate.date.$errors)
-              "
-              type="date"
-              variant="outlined"
-              density="compact"
-              class="mr-md-2"
-              @update:model-value="onChangeStartAt"
-            />
-            <v-text-field
-              v-model="startTimeDataValidate.time.$model"
-              :error-messages="
-                getErrorMessage(startTimeDataValidate.time.$errors)
-              "
-              type="time"
-              variant="outlined"
-              density="compact"
-              @update:model-value="onChangeStartAt"
-            />
-          </div>
-          <p class="text-subtitle-2 text-grey py-2">
-            販売終了日時
-          </p>
-          <div class="d-flex flex-column flex-md-row justify-center">
-            <v-text-field
-              v-model="endTimeDataValidate.date.$model"
-              :error-messages="
-                getErrorMessage(endTimeDataValidate.date.$errors)
-              "
-              type="date"
-              variant="outlined"
-              density="compact"
-              class="mr-md-2"
-              @update:model-value="onChangeEndAt"
-            />
-            <v-text-field
-              v-model="endTimeDataValidate.time.$model"
-              :error-messages="
-                getErrorMessage(notSameTimeValidate.endAt.$errors)
-              "
-              type="time"
-              variant="outlined"
-              density="compact"
-              @update:model-value="onChangeEndAt"
-            />
-          </div>
-        </v-card-text>
-        <v-card-title>詳細情報</v-card-title>
-        <v-card-text>
-          <v-select
-            v-model="formDataValidate.experienceTypeId.$model"
-            :error-messages="
-              getErrorMessage(formDataValidate.experienceTypeId.$errors)
-            "
-            label="カテゴリ"
-            :items="experienceTypes"
-            item-title="name"
-            item-value="id"
-            no-data-text="カテゴリを選択してください。"
-            clearable
-          />
-        </v-card-text>
-      </v-card>
-    </v-col>
-  </v-row>
+      </v-col>
+    </v-row>
 
-  <v-btn
-    :loading="loading"
-    block
-    variant="outlined"
-    @click="onSubmit"
-  >
-    <v-icon
-      start
-      :icon="mdiPlus"
-    />
-    登録
-  </v-btn>
+    <!-- 送信ボタン -->
+    <div class="d-flex justify-end gap-3 mt-6">
+      <v-btn
+        variant="text"
+        size="large"
+        @click="$router.back()"
+      >
+        キャンセル
+      </v-btn>
+      <v-btn
+        :loading="loading"
+        color="primary"
+        variant="elevated"
+        size="large"
+        @click="onSubmit"
+      >
+        <v-icon
+          :icon="mdiPlus"
+          start
+        />
+        体験を登録
+      </v-btn>
+    </div>
+  </v-container>
 </template>
 
-<style lang="scss">
-.thumbnail-border {
-  border: 2px;
-  border-style: solid;
-  border-color: rgb(var(--v-theme-secondary));
+<style scoped>
+.form-section-card {
+  border-radius: 12px;
+  max-width: none;
+}
+
+.section-header {
+  background: linear-gradient(90deg, rgb(33 150 243 / 5%) 0%, rgb(33 150 243 / 0%) 100%);
+  border-bottom: 1px solid rgb(0 0 0 / 5%);
+  padding: 20px 24px;
+}
+
+.image-gallery {
+  margin-top: 16px;
+}
+
+.image-card {
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 2px solid transparent;
+}
+
+.image-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgb(0 0 0 / 10%);
+}
+
+.thumbnail-selected {
+  border-color: rgb(33 150 243);
+  background: rgb(33 150 243 / 5%);
+}
+
+.image-preview {
+  position: relative;
+}
+
+.image-overlay {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  gap: 4px;
+}
+
+.thumbnail-radio {
+  background: rgb(255 255 255 / 90%);
+  border-radius: 50%;
+}
+
+.delete-btn {
+  background: rgb(255 255 255 / 90%) !important;
+}
+
+.date-time-section {
+  border-top: 1px solid rgb(0 0 0 / 10%);
+  padding-top: 16px;
+}
+
+@media (width <= 600px) {
+  .form-section-card {
+    border-radius: 8px;
+  }
+
+  .section-header {
+    padding: 16px 20px;
+  }
+
+  .image-card {
+    margin-bottom: 16px;
+  }
 }
 </style>

--- a/web/admin/src/pages/experiences/[id]/index.vue
+++ b/web/admin/src/pages/experiences/[id]/index.vue
@@ -21,6 +21,7 @@ const { producers } = storeToRefs(producerStore)
 const { experienceTypes } = storeToRefs(experienceTypeStore)
 
 const isLoading = ref<boolean>(false)
+const producerSearchKeyword = ref<string>('')
 
 const formData = ref<UpdateExperienceRequest>({
   title: '',
@@ -151,7 +152,7 @@ const convertToTimeFormat = (time: string): string => {
 
 onMounted(async () => {
   isLoading.value = true
-  producerStore.fetchProducers()
+  producerStore.fetchProducers(100, 0)
   experienceTypeStore.fetchExperienceTypes()
   const result = await experienceStore.fetchExperience(experienceId.value)
   formData.value = {
@@ -166,18 +167,28 @@ onMounted(async () => {
   )
   isLoading.value = false
 })
+
+const filteredProducers = computed(() => {
+  if (!producerSearchKeyword.value) {
+    return producers.value
+  }
+  return producers.value.filter(producer =>
+    producer.username.toLowerCase().includes(producerSearchKeyword.value.toLowerCase()),
+  )
+})
 </script>
 
 <template>
   <templates-experience-new
     v-model:form-data="formData"
+    v-model:producer-search-keyword="producerSearchKeyword"
     :loading="isLoading"
     :search-loading="searchAddress.loading.value"
     :search-error-message="searchAddress.errorMessage.value"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"
-    :producers="producers"
+    :producers="filteredProducers"
     :experience-types="experienceTypes"
     :video-uploading="videoUploading"
     @click:search-address="handleSearchAddress"

--- a/web/admin/src/pages/experiences/index.vue
+++ b/web/admin/src/pages/experiences/index.vue
@@ -18,7 +18,7 @@ const pagination = usePagination()
 const { alertType, isShow, alertText, show } = useAlert('error')
 
 const { adminType } = storeToRefs(authStore)
-const { experiencesResponse, totalItems } = storeToRefs(experienceStore)
+const { experiences, totalItems } = storeToRefs(experienceStore)
 const { experienceTypes } = storeToRefs(experienceTypeStore)
 const { producers } = storeToRefs(producerStore)
 
@@ -27,28 +27,12 @@ const deleteDialog = ref<boolean>(false)
 const selectedItemId = ref<string>('')
 
 const fetchState = useAsyncData(async (): Promise<void> => {
-  await Promise.all([
-    fetchExperiences(),
-    fetchExperienceTypes(),
-    fetchProducers(),
-  ])
+  await fetchExperiences()
 })
 
 watch(pagination.itemsPerPage, (): void => {
   fetchState.refresh()
 })
-
-const fetchProducers = async (): Promise<void> => {
-  try {
-    await producerStore.fetchProducers(pagination.itemsPerPage.value, pagination.offset.value)
-  }
-  catch (err) {
-    if (err instanceof Error) {
-      show(err.message)
-    }
-    console.log(err)
-  }
-}
 
 const fetchExperiences = async (): Promise<void> => {
   try {
@@ -56,18 +40,6 @@ const fetchExperiences = async (): Promise<void> => {
       pagination.itemsPerPage.value,
       pagination.offset.value,
     )
-  }
-  catch (err) {
-    if (err instanceof Error) {
-      show(err.message)
-    }
-    console.log(err)
-  }
-}
-
-const fetchExperienceTypes = async (): Promise<void> => {
-  try {
-    await experienceTypeStore.fetchExperienceTypes()
   }
   catch (err) {
     if (err instanceof Error) {
@@ -92,6 +64,12 @@ const handleClickShow = (experienceId: string): void => {
 
 const handleClickNew = (): void => {
   router.push('/experiences/new')
+}
+
+const handleClickCopyItem = (): void => {
+  if (selectedItemId.value !== '') {
+    router.push(`/experiences/new?from=${selectedItemId.value}`)
+  }
 }
 
 const handleClickDelete = async (experienceId: string): Promise<void> => {
@@ -128,9 +106,9 @@ catch (err) {
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"
-    :producers="producers"
-    :experiences-response="experiencesResponse"
+    :experiences="experiences"
     :experience-types="experienceTypes"
+    :producers="producers"
     :table-items-per-page="pagination.itemsPerPage.value"
     :table-items-total="totalItems"
     @click:show="handleClickShow"
@@ -138,5 +116,6 @@ catch (err) {
     @click:delete="handleClickDelete"
     @click:update-page="handleUpdatePage"
     @click:update-items-per-page="pagination.handleUpdateItemsPerPage"
+    @click:copy-item="handleClickCopyItem"
   />
 </template>

--- a/web/admin/src/pages/experiences/new.vue
+++ b/web/admin/src/pages/experiences/new.vue
@@ -26,6 +26,7 @@ const { producers } = storeToRefs(producerStore)
 const { experienceTypes } = storeToRefs(experienceTypeStore)
 
 const loading = ref<boolean>(false)
+const producerSearchKeyword = ref<string>('')
 const formData = ref<CreateExperienceRequest>({
   title: '',
   description: '',
@@ -58,8 +59,17 @@ const formData = ref<CreateExperienceRequest>({
 })
 
 onMounted(() => {
-  producerStore.fetchProducers(20, 0, '')
+  producerStore.fetchProducers(100, 0, '')
   fetchExperienceTypes()
+})
+
+const filteredProducers = computed(() => {
+  if (!producerSearchKeyword.value) {
+    return producers.value
+  }
+  return producers.value.filter(producer =>
+    producer.username.toLowerCase().includes(producerSearchKeyword.value.toLowerCase()),
+  )
 })
 
 const fetchExperienceTypes = async (): Promise<void> => {
@@ -180,20 +190,21 @@ const handleSearchAddress = async (): Promise<void> => {
 }
 
 const isLoading = (): boolean => {
-  return false
+  return loading.value || videoUploading.value
 }
 </script>
 
 <template>
   <templates-experience-new
     v-model:form-data="formData"
+    v-model:producer-search-keyword="producerSearchKeyword"
     :loading="isLoading()"
     :search-loading="searchAddress.loading.value"
     :search-error-message="searchAddress.errorMessage.value"
     :is-alert="isShow"
     :alert-type="alertType"
     :alert-text="alertText"
-    :producers="producers"
+    :producers="filteredProducers"
     :experience-types="experienceTypes"
     :video-uploading="videoUploading"
     @click:search-address="handleSearchAddress"


### PR DESCRIPTION
## 概要
体験管理ページのUI/UXを商品管理ページと統一し、モダンなデザインに改善しました。

## 変更内容
- ✨ 体験一覧ページを商品管理ページと同じ構造に統一
- 🎨 体験新規作成/編集ページのデザインをモダンに刷新
- 🔧 v-card-titleのデザインを商品管理ページと統一

## 背景・目的
体験管理ページのUIが商品管理ページと異なっており、管理画面全体の一貫性が損なわれていました。
ユーザビリティ向上のため、商品管理ページで採用したモダンなデザインを体験管理ページにも適用しました。

## 主な改善点

### 📋 一覧ページ
- データ取得処理のシンプル化（不要なフィルタリング機能を削除）
- コピー機能の追加（選択した体験を複製）
- ヘッダーレイアウトの統一（アイコン付きタイトル、サブタイトル）
- 削除ダイアログのデザイン改善

### ✏️ 新規作成/編集ページ
- **レイアウト改善**
  - 2カラムレイアウトの採用（左側8列：主要情報、右側4列：設定項目）
  - セクション別カードデザインの実装
  - グラデーション背景とアイコン付きセクションヘッダー
  
- **UI要素の改善**
  - 画像ギャラリーのUI改善（ホバーエフェクト、サムネイル選択）
  - フォーム要素のスタイル統一（`variant="outlined"`, `density="comfortable"`）
  - 紹介動画セクションの独立化
  - レスポンシブ対応の強化

## テスト
- [x] フロントエンド: yarn typecheck ✅
- [x] フロントエンド: yarn lint ✅
- [x] フロントエンド: yarn format ✅
- [ ] 手動テスト（体験一覧表示）
- [ ] 手動テスト（体験新規作成）
- [ ] 手動テスト（体験編集）
- [ ] 手動テスト（体験削除）

## スクリーンショット
※必要に応じて画面キャプチャを追加予定

## レビューポイント
- 商品管理ページとの統一感が保たれているか
- フォーム要素のアクセシビリティ
- レスポンシブデザインの適切性
- コードの保守性（重複コードがないか）

## 関連情報
- 関連PR: #3048, #3047（商品管理ページUI改善）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 体験のコピー機能を追加
  - プロデューサー検索のキーワード入力・絞り込みに対応（双方向バインド）
  - 体験画像ギャラリー（サムネイル指定・削除）と動画プレビュー/アップロードを追加
  - 価格設定・販売期間などの入力セクションを追加しフローを整理

- 改善
  - 一覧・新規作成画面をカード型レイアウトに刷新しアイコンを追加
  - 削除確認ダイアログの視認性と文脈情報を強化
  - プロデューサー取得件数を拡大し検索と連動

- 変更
  - 一覧でコピー操作イベントを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->