### PR TITLE
fix(web): 管理画面の一覧ページのレスポンシブ対応

### DIFF
--- a/web/admin/src/components/templates/ExperienceList.vue
+++ b/web/admin/src/components/templates/ExperienceList.vue
@@ -277,28 +277,29 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiCalendarCheck"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             体験管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             体験の登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex flex-column flex-sm-row ga-2 ga-sm-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="outlined"
           color="secondary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           :disabled="selectedItemId === ''"
           @click="onClickCopyItem"
         >
@@ -319,7 +320,8 @@ const getPrefecture = (hostPrefectureCode: Prefecture): string => {
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickNew"
         >
           <v-icon

--- a/web/admin/src/components/templates/HomeTop.vue
+++ b/web/admin/src/components/templates/HomeTop.vue
@@ -15,6 +15,7 @@ import { TopOrderPeriodType } from '~/types'
 import { PaymentMethodType } from '~/types/api/v1'
 import type { TopOrderSalesTrend, TopOrdersResponse } from '~/types/api/v1'
 import type { DateTimeInput } from '~/types/props'
+import { mdiAccountMultipleOutline, mdiCartOutline, mdiCashMultiple, mdiChartLine, mdiCreditCardOutline, mdiCurrencyJpy, mdiTable } from '@mdi/js'
 
 use([
   GridComponent,
@@ -409,9 +410,8 @@ const onChangeEndAt = (): void => {
                 color="primary"
                 size="small"
                 class="mr-2"
-              >
-                mdi-currency-jpy
-              </v-icon>
+                :icon="mdiCurrencyJpy"
+              />
               <span class="text-caption text-grey-darken-1">売上総額</span>
             </div>
             <div class="text-h5 font-weight-bold mb-1">
@@ -448,9 +448,8 @@ const onChangeEndAt = (): void => {
                 color="info"
                 size="small"
                 class="mr-2"
-              >
-                mdi-cart-outline
-              </v-icon>
+                :icon="mdiCartOutline"
+              />
               <span class="text-caption text-grey-darken-1">注文件数</span>
             </div>
             <div class="text-h5 font-weight-bold mb-1">
@@ -488,9 +487,8 @@ const onChangeEndAt = (): void => {
                 color="success"
                 size="small"
                 class="mr-2"
-              >
-                mdi-account-multiple-outline
-              </v-icon>
+                :icon="mdiAccountMultipleOutline"
+              />
               <span class="text-caption text-grey-darken-1">購入者数</span>
             </div>
             <div class="text-h5 font-weight-bold mb-1">
@@ -528,9 +526,8 @@ const onChangeEndAt = (): void => {
                 color="warning"
                 size="small"
                 class="mr-2"
-              >
-                mdi-cash-multiple
-              </v-icon>
+                :icon="mdiCashMultiple"
+              />
               <span class="text-caption text-grey-darken-1">平均単価</span>
             </div>
             <div class="text-h5 font-weight-bold mb-1">
@@ -558,9 +555,8 @@ const onChangeEndAt = (): void => {
             <v-icon
               color="primary"
               class="mr-2"
-            >
-              mdi-chart-line
-            </v-icon>
+              :icon="mdiChartLine"
+            />
             売上額推移
           </v-card-title>
           <v-card-text>
@@ -585,9 +581,8 @@ const onChangeEndAt = (): void => {
             <v-icon
               color="info"
               class="mr-2"
-            >
-              mdi-credit-card-outline
-            </v-icon>
+              :icon="mdiCreditCardOutline"
+            />
             支払い方法別
           </v-card-title>
           <v-card-text>
@@ -612,10 +607,8 @@ const onChangeEndAt = (): void => {
             <v-icon
               color="secondary"
               class="mr-2"
-            >
-              mdi-table
-            </v-icon>
-            支払い方法別詳細
+              :icon="mdiTable"
+            />
           </v-card-title>
           <v-card-text>
             <v-data-table

--- a/web/admin/src/components/templates/NotificationList.vue
+++ b/web/admin/src/components/templates/NotificationList.vue
@@ -269,28 +269,29 @@ const onClickDelete = (): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiBellOutline"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             お知らせ管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             お知らせの登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex ga-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickAdd"
         >
           <v-icon

--- a/web/admin/src/components/templates/OrderList.vue
+++ b/web/admin/src/components/templates/OrderList.vue
@@ -375,27 +375,28 @@ const onSubmitExport = (): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiFileDocumentOutline"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             注文管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             注文の確認・管理・エクスポートを行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex ga-3 w-100 w-sm-auto">
         <v-btn
           variant="outlined"
           color="info"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="toggleExportDialog"
         >
           <v-icon

--- a/web/admin/src/components/templates/ProducerList.vue
+++ b/web/admin/src/components/templates/ProducerList.vue
@@ -224,28 +224,29 @@ const onClickDelete = (): void => {
       elevation="0"
       rounded="lg"
     >
-      <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-        <div class="d-flex align-center">
+      <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+        <div class="d-flex align-center mb-3 mb-sm-0">
           <v-icon
             :icon="mdiAccountGroup"
             size="28"
             class="mr-3 text-primary"
           />
           <div>
-            <h1 class="text-h5 font-weight-bold text-primary">
+            <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
               生産者管理
             </h1>
-            <p class="text-body-2 text-medium-emphasis ma-0">
+            <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
               生産者の登録・編集・削除を行います
             </p>
           </div>
         </div>
-        <div class="d-flex ga-3">
+        <div class="d-flex ga-3 w-100 w-sm-auto">
           <v-btn
             v-show="isRegisterable()"
             variant="elevated"
             color="primary"
-            size="large"
+            :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+            class="w-100 w-sm-auto"
             @click="onClickAdd"
           >
             <v-icon

--- a/web/admin/src/components/templates/ProductList.vue
+++ b/web/admin/src/components/templates/ProductList.vue
@@ -299,28 +299,29 @@ const onClickCopyItem = (): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiPackageVariant"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             商品管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             商品の登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex flex-column flex-sm-row ga-2 ga-sm-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="outlined"
           color="secondary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           :disabled="selectedItemId === ''"
           @click="onClickCopyItem"
         >
@@ -341,7 +342,8 @@ const onClickCopyItem = (): void => {
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickNew"
         >
           <v-icon

--- a/web/admin/src/components/templates/PromotionList.vue
+++ b/web/admin/src/components/templates/PromotionList.vue
@@ -290,28 +290,29 @@ const onClickDelete = (): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiTagOutline"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             セール情報管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             セール・キャンペーン情報の登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex ga-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickAdd"
         >
           <v-icon

--- a/web/admin/src/components/templates/ScheduleList.vue
+++ b/web/admin/src/components/templates/ScheduleList.vue
@@ -257,28 +257,29 @@ const onClickPublished = (scheduleId: string): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiCalendarToday"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             ライブ配信管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             ライブ配信の登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex ga-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickAdd"
         >
           <v-icon

--- a/web/admin/src/components/templates/VideoList.vue
+++ b/web/admin/src/components/templates/VideoList.vue
@@ -204,28 +204,29 @@ const onClickDelete = (): void => {
     elevation="0"
     rounded="lg"
   >
-    <v-card-title class="d-flex align-center justify-space-between pa-6 pb-4">
-      <div class="d-flex align-center">
+    <v-card-title class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between pa-4 pa-sm-6 pb-4">
+      <div class="d-flex align-center mb-3 mb-sm-0">
         <v-icon
           :icon="mdiPlayCircle"
           size="28"
           class="mr-3 text-primary"
         />
         <div>
-          <h1 class="text-h5 font-weight-bold text-primary">
+          <h1 class="text-h6 text-sm-h5 font-weight-bold text-primary">
             動画管理
           </h1>
-          <p class="text-body-2 text-medium-emphasis ma-0">
+          <p class="text-caption text-sm-body-2 text-medium-emphasis ma-0">
             動画コンテンツの登録・編集・削除を行います
           </p>
         </div>
       </div>
-      <div class="d-flex ga-3">
+      <div class="d-flex ga-3 w-100 w-sm-auto">
         <v-btn
           v-show="isRegisterable()"
           variant="elevated"
           color="primary"
-          size="large"
+          :size="$vuetify.display.smAndDown ? 'default' : 'large'"
+          class="w-100 w-sm-auto"
           @click="onClickAdd"
         >
           <v-icon


### PR DESCRIPTION
## 概要
管理画面の各一覧表示ページでスマートフォン表示時に横スクロールが発生し、画面右上のボタンがクリックできない問題を修正しました。

## 変更内容
- カードヘッダーのレイアウトをレスポンシブ対応（フレックスボックス）
- モバイル/デスクトップでボタンサイズを自動調整
- テキストサイズをデバイスに応じて最適化
- モバイルでのボタンを全幅表示に変更

## 対象画面
- 体験管理 (ExperienceList.vue)
- お知らせ管理 (NotificationList.vue)
- 注文管理 (OrderList.vue)
- 生産者管理 (ProducerList.vue)
- 商品管理 (ProductList.vue)
- セール情報管理 (PromotionList.vue)
- ライブ配信管理 (ScheduleList.vue)
- 動画管理 (VideoList.vue)
- ダッシュボード (HomeTop.vue)

## 背景・目的
管理者がスマートフォンで管理画面を操作する際のユーザビリティ向上

## テスト
- [x] フロントエンド: yarn format
- [ ] フロントエンド: yarn typecheck
- [ ] フロントエンド: yarn lint
- [ ] 手動テスト（スマートフォン表示）
- [ ] 手動テスト（デスクトップ表示）

## レビューポイント
- Vuetifyのブレークポイント（`$vuetify.display.smAndDown`）の使用方法
- フレックスボックスのレスポンシブ切り替え（`flex-column flex-sm-row`）
- ボタンの幅調整（`w-100 w-sm-auto`）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - 各一覧カードのヘッダーをレスポンシブ化（体験/お知らせ/注文/生産者/商品/プロモーション/スケジュール/動画）し、モバイルで縦積み・大画面で横並びに最適化。
  - タイトル/サブタイトルのフォントサイズと余白を調整し、可読性を向上。
  - アクションボタンのサイズと幅を画面幅に応じて自動調整（小画面で全幅表示、大画面で自動幅）。
  - ボタン間の間隔を最適化し、操作性を改善。
  - ホームのダッシュボードでアイコン表示を最適化し、描画の一貫性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->