### PR TITLE
Release for v7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v7.1.1](https://github.com/and-period/furumaru/compare/v7.1.0...v7.1.1) - 2025-09-18
+- chore(deps): Pin dependencies by @renovate[bot] in https://github.com/and-period/furumaru/pull/3062
+- chore(deps): Pin dependencies by @renovate[bot] in https://github.com/and-period/furumaru/pull/3061
+- fix(web): 管理画面の一覧ページのレスポンシブ対応 by @taba2424 in https://github.com/and-period/furumaru/pull/3063
+
 ## [v7.1.0](https://github.com/and-period/furumaru/compare/v7.0.0...v7.1.0) - 2025-09-17
 - feat(web): 動画編集画面にタブ機能と分析情報を追加 by @taba2424 in https://github.com/and-period/furumaru/pull/3034
 - feat(web): 管理画面ダッシュボードの情報充実化 by @taba2424 in https://github.com/and-period/furumaru/pull/3036


### PR DESCRIPTION
This pull request is for the next release as v7.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v7.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v7.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): Pin dependencies by @renovate[bot] in https://github.com/and-period/furumaru/pull/3062
* chore(deps): Pin dependencies by @renovate[bot] in https://github.com/and-period/furumaru/pull/3061
* fix(web): 管理画面の一覧ページのレスポンシブ対応 by @taba2424 in https://github.com/and-period/furumaru/pull/3063


**Full Changelog**: https://github.com/and-period/furumaru/compare/v7.1.0...tagpr-from-v7.1.0