### PR TITLE
fix(web): Firebase Messaging の未サポートブラウザ対応

### DIFF
--- a/web/admin/src/plugins/firebase.ts
+++ b/web/admin/src/plugins/firebase.ts
@@ -1,13 +1,13 @@
 import { initializeApp } from 'firebase/app'
 import type { FirebaseApp, FirebaseOptions } from 'firebase/app'
-import { getMessaging } from 'firebase/messaging'
+import { getMessaging, isSupported } from 'firebase/messaging'
 import type { Messaging } from 'firebase/messaging'
 
 /* eslint-disable import/no-mutable-exports */
 let app: FirebaseApp
-let messaging: Messaging
+let messaging: Messaging | null = null
 
-export default defineNuxtPlugin(() => {
+export default defineNuxtPlugin(async () => {
   const runtimeConfig = useRuntimeConfig()
 
   const config: FirebaseOptions = {
@@ -21,7 +21,20 @@ export default defineNuxtPlugin(() => {
   }
 
   app = initializeApp(config)
-  messaging = getMessaging(app)
+
+  // Firebase Messaging のサポートチェック
+  try {
+    const supported = await isSupported()
+    if (supported) {
+      messaging = getMessaging(app)
+    }
+    else {
+      console.log('Firebase Messaging is not supported in this browser')
+    }
+  }
+  catch (error) {
+    console.log('Firebase Messaging initialization failed:', error)
+  }
 
   return {
     provide: {

--- a/web/admin/src/store/auth.ts
+++ b/web/admin/src/store/auth.ts
@@ -274,6 +274,12 @@ export const useAuthStore = defineStore('auth', {
         return '' // Push通知未対応ブラウザ
       }
 
+      // messaging が null の場合は空文字を返す
+      if (!messaging) {
+        console.log('Firebase Messaging is not initialized')
+        return ''
+      }
+
       return await getToken(messaging, {
         vapidKey: runtimeConfig.public.FIREBASE_VAPID_KEY,
       })


### PR DESCRIPTION
## 概要
Firebase Messaging がサポートされていないブラウザ（LINE WebView等）でエラーが発生する問題を修正

## 変更内容
- Firebase Messaging 初期化前に `isSupported()` チェックを追加
- 未サポートブラウザでは messaging を null に設定
- auth store で messaging が null の場合の処理を追加

## 背景・目的
LINE アプリの WebView など、Firebase Messaging をサポートしていないブラウザで
管理画面を開くと「Messaging: This browser doesn't support the API's required to use the Firebase SDK」
エラーが発生していた。プッシュ通知が使えないブラウザでも他の機能は正常に使えるようにする。

## テスト
- [x] フロントエンド: yarn build 成功
- [ ] 手動テスト: LINE WebView での動作確認
- [ ] 手動テスト: 通常ブラウザでのプッシュ通知動作確認

## レビューポイント
- Firebase Messaging の初期化処理の変更箇所
- 未サポートブラウザでの処理のスキップが適切か

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - プッシュ通知未対応のブラウザで初期化エラーが発生していた問題を解消。不要なトークン取得を回避し、安定性を向上。
  - 対応環境では従来どおり通知を取得し、未対応環境では処理を静かにスキップ。

- リファクタ
  - 初期化処理を非同期化し、サポート状況に応じて必要機能のみを起動。
  - エラーログ／情報ログを強化し、トラブルシューティングを容易に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->