### PR TITLE
Release for v7.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v7.1.3](https://github.com/and-period/furumaru/compare/v7.1.2...v7.1.3) - 2025-09-22
+- fix(web): Firebase Messaging の未サポートブラウザ対応 by @taba2424 in https://github.com/and-period/furumaru/pull/3073
+
 ## [v7.1.2](https://github.com/and-period/furumaru/compare/v7.1.1...v7.1.2) - 2025-09-20
 - build(deps): bump the dependencies group across 1 directory with 21 updates by @dependabot[bot] in https://github.com/and-period/furumaru/pull/3065
 - [web/liff] 注文一覧画面、注文詳細画面の実装 by @Copilot in https://github.com/and-period/furumaru/pull/3067


### PR DESCRIPTION
This pull request is for the next release as v7.1.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v7.1.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v7.1.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix(web): Firebase Messaging の未サポートブラウザ対応 by @taba2424 in https://github.com/and-period/furumaru/pull/3073


**Full Changelog**: https://github.com/and-period/furumaru/compare/v7.1.2...tagpr-from-v7.1.2