### PR TITLE
fix: 未認証時にチェックイン登録画面に遷移する処理を追加

### DIFF
--- a/web/liff/src/pages/[facilityId]/index.vue
+++ b/web/liff/src/pages/[facilityId]/index.vue
@@ -7,7 +7,11 @@ import { useShoppingCartStore } from '~/stores/shopping';
 import { useLiffInit } from '~/composables/useLiffInit';
 
 const route = useRoute();
+const router = useRouter();
 const runtimeConfig = useRuntimeConfig();
+
+const authStore = useAuthStore();
+const { isAuthenticated } = storeToRefs(authStore);
 
 const facilityId = computed<string>(() => String(route.params.facilityId || ''));
 const { init: initLiff } = useLiffInit();
@@ -17,6 +21,13 @@ const productStore = useProductStore();
 const { products, isLoading, error } = storeToRefs(productStore);
 onMounted(async () => {
   await initLiff(runtimeConfig.public.LIFF_ID);
+
+  // 未認証ならチェックインページへリダイレクト
+  if (!isAuthenticated.value) {
+    router.push(`/${facilityId.value}/checkin/new`);
+    return;
+  }
+
   productStore.fetchProducts();
 });
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 施設ページでユーザーの認証状態を判定し、未認証の場合は自動的に「/［施設ID］/checkin/new」へリダイレクトされます。これにより、未認証ユーザーはスムーズにチェックインへ移行できます。
  - 認証済みユーザーは従来どおり商品情報の取得に進み、既存の閲覧体験に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->