### PR TITLE
fix: ラベル名を宿泊日時を変更

### DIFF
--- a/web/liff/src/pages/[facilityId]/checkin/new.vue
+++ b/web/liff/src/pages/[facilityId]/checkin/new.vue
@@ -215,7 +215,7 @@ async function onSubmit() {
           <FmTextInput
             id="stay_date"
             v-model="stayDate"
-            label="宿泊日"
+            label="宿泊日時"
             name="stay_date"
             required
             class="w-full px-2"

--- a/web/liff/src/stores/user.ts
+++ b/web/liff/src/stores/user.ts
@@ -31,7 +31,13 @@ export const useUserStore = defineStore('user', {
           return '—';
         }
         const datetime = new Date(state.profile.lastCheckInAt * 1000);
-        return datetime.toLocaleDateString('ja-JP');
+        return datetime.toLocaleString('ja-JP', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
       }
       return '—';
     },


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * チェックイン新規画面のラベルを「宿泊日」から「宿泊日時」に変更し、日時入力であることを明確化しました。表示のみの変更で操作や既存データに影響ありません。
* **Bug Fixes**
  * ユーザーの最終チェックイン表示を日付のみから「年/月/日 時:分」の日時表示に改善し、より詳細な時刻情報を確認できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->