### PR TITLE
fix(auth): 管理者アカウントの外部連携処理を修正

### DIFF
--- a/api/pkg/cognito/client.go
+++ b/api/pkg/cognito/client.go
@@ -33,6 +33,8 @@ type Client interface {
 	GenerateAuthURL(ctx context.Context, params *GenerateAuthURLParams) (string, error)
 	// OAuth2.0認証 (コード検証)
 	GetAccessToken(ctx context.Context, params *GetAccessTokenParams) (*AuthResult, error)
+	// OAuth2.0認証の紐づけ
+	LinkProvider(ctx context.Context, params *LinkProviderParams) error
 
 	// #############################################
 	// ユーザー関連


### PR DESCRIPTION
## 概要
管理者アカウントのGoogle/LINE連携処理において、CognitoのLinkProvider APIを使用した正しい連携フローに修正しました。

## 変更内容
- `AdminVerifyEmail`の呼び出しを削除（不要な処理）
- 既存の外部アカウントを`DeleteUser`で削除してから連携
- `LinkProvider`を使用してCognitoアカウントと外部プロバイダーを連携
- 対応するテストケースの修正

## 背景・目的
Cognitoの仕様上、すでにサインイン済みの外部アカウントは連携できないため、一度削除してから連携する必要があります。
参照: https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/cognito-user-pools-identity-federation-consolidate-users.html

## テスト
- [x] API: make test (Go) - 関連テストすべてパス
- [ ] API: make lint-fix
- [ ] 手動テスト完了

## レビューポイント
- 外部アカウントの削除→連携のフローが適切か
- テストケースが新しいフローを正しくカバーしているか

## 関連情報
- AWS Cognito ドキュメント: [ユーザープールでの外部 IdP ユーザーの統合](https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/cognito-user-pools-identity-federation-consolidate-users.html)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* バグ修正
  * 外部認証プロバイダ変更時に管理者アカウントの連携やメール確認が失敗する問題を修正。
  * 既存の外部アカウントが残存してログインできないケースを解消し、サインインの安定性を向上。

* リファクタ
  * 管理者認証の連携フローを見直し、不要なアカウントの整理と確実なプロバイダ連携によりエラー処理と信頼性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->