### PR TITLE
feat:チェックイン登録が必須の場合はチェックイン登録画面から遷移できないように変更

### DIFF
--- a/web/liff/src/middleware/auth.global.ts
+++ b/web/liff/src/middleware/auth.global.ts
@@ -38,6 +38,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   if (authStore.isAuthenticated && !authStore.isTokenExpired) {
+    if (authStore.checkInRequired) {
+      const path = `/${facilityId}/checkin/new`;
+      return navigateTo(path);
+    }
     return;
   }
 
@@ -51,10 +55,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
     const accessToken = authStore.token!.accessToken;
     await userStore.fetchMe(facilityId, accessToken);
     await shoppingCartStore.getCart(facilityId);
+    authStore.setCheckInRequired(false);
   }
   catch (err) {
     if (err instanceof ResponseError) {
       if (err.response.status === 404) {
+        authStore.setCheckInRequired(true);
         const path = `/${facilityId}/checkin/new`;
         return navigateTo(path);
       }

--- a/web/liff/src/stores/auth.ts
+++ b/web/liff/src/stores/auth.ts
@@ -8,6 +8,8 @@ interface AuthState {
   token: Pick<AuthResponse, 'accessToken' | 'refreshToken' | 'expiresIn' | 'tokenType' | 'userId'> | null;
   // アクセストークンの有効期限（UNIXエポックミリ秒）
   expiresAt: number | null;
+  // チェックインの登録が必要かどうかのフラグ
+  checkInRequired: boolean;
 }
 
 /**
@@ -21,6 +23,7 @@ export const useAuthStore = defineStore('auth', {
     isAuthenticated: false,
     token: null,
     expiresAt: null,
+    checkInRequired: true,
   }),
 
   getters: {
@@ -99,6 +102,10 @@ export const useAuthStore = defineStore('auth', {
       finally {
         this.isLoading = false;
       }
+    },
+
+    setCheckInRequired(required: boolean) {
+      this.checkInRequired = required;
     },
   },
 });


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで (○○の実装, ○○の修正) -->

## スクリーンショット

<!--
フロントエンド実装の場合、実装した場面のスクリーンショットを貼る
(スマホとPCでデザインが違う場合はそれぞれあると)
-->

## リファレンス

<!--
Issue,仕様書,デザイン設計など参考になるものがあれば
(Figma, KibelaのURL貼っておいてもらえると)
-->

## 残タスク

<!--
次のプルリクにまわす実装内容を書く
* [x] DDLの適用
* [ ] ○○の実装
-->

## 備考

<!-- マージ後に必要な操作,破壊的変更あるかなどはここに -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - チェックイン必須フラグを追加し、認証済みかつ必要時は施設のチェックイン作成画面へ自動リダイレクト。
  - サインイン完了後（ユーザー情報・カート取得後）はフラグを解除し、通常の画面遷移に復帰。

- バグ修正
  - 起動時の取得で対象が見つからない（404）場合に、チェックイン画面へ確実にフォールバックする挙動を追加・安定化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->