### PR TITLE
Release for v7.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v7.3.2](https://github.com/and-period/furumaru/compare/v7.3.1...v7.3.2) - 2025-10-08
+- コーディネーターページを修正 by @hamachans in https://github.com/and-period/furumaru/pull/3113
+
 ## [v7.3.1](https://github.com/and-period/furumaru/compare/v7.3.0...v7.3.1) - 2025-10-08
 - build(deps): bump github.com/go-playground/validator/v10 from 10.27.0 to 10.28.0 in /api by @dependabot[bot] in https://github.com/and-period/furumaru/pull/3115
 - build(deps): bump google.golang.org/api from 0.251.0 to 0.252.0 in /api by @dependabot[bot] in https://github.com/and-period/furumaru/pull/3117


### PR DESCRIPTION
This pull request is for the next release as v7.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v7.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v7.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* コーディネーターページを修正 by @hamachans in https://github.com/and-period/furumaru/pull/3113


**Full Changelog**: https://github.com/and-period/furumaru/compare/v7.3.1...tagpr-from-v7.3.1